### PR TITLE
Bug 562012 license is not recognized when USB disk is plugged

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiHardwareInspector.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiHardwareInspector.java
@@ -42,8 +42,6 @@ import oshi.software.os.OperatingSystemVersion;
 public class OshiHardwareInspector implements HardwareInspector {
 
 	private final Map<String, String> hardwareProperties = new LinkedHashMap<>();
-	private SystemInfo systemInfo;
-
 	private LicensingReporter licensingReporter = SystemReporter.INSTANCE;
 
 	@Activate
@@ -53,7 +51,7 @@ public class OshiHardwareInspector implements HardwareInspector {
 
 	private void initHardwareProperties() {
 		try {
-			systemInfo = new SystemInfo();
+			SystemInfo systemInfo = new SystemInfo();
 			OperatingSystem os = systemInfo.getOperatingSystem();
 			hardwareProperties.put(HardwareInspector.PROPERTY_OS_MANUFACTURER, os.getManufacturer());
 			hardwareProperties.put(HardwareInspector.PROPERTY_OS_FAMILY, os.getFamily());

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiPermissionEmitter.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/OshiPermissionEmitter.java
@@ -16,6 +16,8 @@ import static org.eclipse.passage.lic.base.LicensingProperties.LICENSING_CONDITI
 import static org.eclipse.passage.lic.base.LicensingProperties.LICENSING_CONDITION_TYPE_ID;
 import static org.eclipse.passage.lic.base.LicensingProperties.LICENSING_CONDITION_TYPE_NAME;
 
+import java.util.Arrays;
+
 import org.eclipse.passage.lic.api.access.PermissionEmitter;
 import org.eclipse.passage.lic.api.inspector.HardwareInspector;
 import org.eclipse.passage.lic.base.access.BasePermissionEmitter;
@@ -23,6 +25,8 @@ import org.eclipse.passage.lic.base.conditions.LicensingConditions;
 import org.eclipse.passage.lic.oshi.OshiHal;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import oshi.SystemInfo;
 
 @Component(property = { LICENSING_CONDITION_TYPE_ID + '=' + OshiHal.CONDITION_TYPE_HARDWARE,
 		LICENSING_CONDITION_TYPE_NAME + '=' + "Hardware", LICENSING_CONDITION_TYPE_DESCRIPTION + '='
@@ -47,6 +51,12 @@ public class OshiPermissionEmitter extends BasePermissionEmitter implements Perm
 
 	@Override
 	protected boolean evaluateSegment(String key, String expected) {
+		// FIXME: EP: fast hack for 562012,
+		// to be solved properly with formats alternations in 0.9
+		if (key.equals(HardwareInspector.PROPERTY_HWDISK_SERIAL)) {
+			return Arrays.stream(new SystemInfo().getHardware().getDiskStores()) //
+					.anyMatch(disk -> LicensingConditions.evaluateSegmentValue(expected, disk.getSerial()));
+		}
 		String actual = hardwareInspector.inspectProperty(key);
 		return LicensingConditions.evaluateSegmentValue(expected, actual);
 	}


### PR DESCRIPTION
 - implement a fast inplace fix, yet to be redone in 0.9 with possible
change of license/model formats



Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>