### PR TITLE
562012/avoid illegal memory access

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.oshi
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.oshi
-Bundle-Version: 0.5.201.qualifier
+Bundle-Version: 0.5.202.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.oshi/OSGI-INF/org.eclipse.passage.lic.internal.oshi.OshiPermissionEmitter.xml
+++ b/bundles/org.eclipse.passage.lic.oshi/OSGI-INF/org.eclipse.passage.lic.internal.oshi.OshiPermissionEmitter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.passage.lic.internal.oshi.OshiPermissionEmitter">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.passage.lic.internal.oshi.OshiPermissionEmitter">
    <property name="licensing.condition.type.id" value="hardware"/>
    <property name="licensing.condition.type.name" value="Hardware"/>
    <property name="licensing.condition.type.description" value="Evaluates node-locked conditions using runtime hardware information"/>


### PR DESCRIPTION
@eparovyshnaya I managed to repeat the reported "Invalid memory access" and with this change it is gone. The only idea I have is that we can use hardware query safely(?) outside main thread only.