### PR TITLE
561555 API revision: use BundleRequirements in FullFeather project template

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
@@ -93,6 +93,7 @@
       <plugin id="org.eclipse.passage.lic.equinox"/>
       <plugin id="org.eclipse.passage.lic.jface"/>
       <plugin id="org.eclipse.passage.lic.e4.ui"/>
+       <plugin id="org.slf4j.api"/>
    </plugins>
 
    <configurations>

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/LicensingNamespaces.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/LicensingNamespaces.java
@@ -18,11 +18,7 @@ public final class LicensingNamespaces {
 
 	public static final String CAPABILITY_LICENSING_CONFIGURATION = "licensing.configuration"; //$NON-NLS-1$
 	/**
-	 * @deprecated use
-	 *             {@link org.eclipse.passage.lic.internal.equinox.requirements.CapabilityLicFeatureId}
-	 *             for capability property or
-	 *             {@link org.eclipse.passage.lic.internal.equinox.requirements.LicensingFeaturesFromBundle}
-	 *             for the whole capabilities space
+	 * @deprecated use RequirementToCapability, RequirementsToBundle
 	 */
 	@Deprecated
 	public static final String CAPABILITY_LICENSING_FEATURE = "licensing.feature"; //$NON-NLS-1$

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/NamedData.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/NamedData.java
@@ -38,7 +38,16 @@ public interface NamedData<T> extends Supplier<Optional<T>> {
 		return String.valueOf(value);
 	}
 
-	class Writable<T> {
+	default String keyValueSeparator() {
+		return "="; //$NON-NLS-1$
+	}
+
+	default String entrySeparator() {
+		return ""; //$NON-NLS-1$
+	}
+
+	public class Writable<T> {
+
 		private final NamedData<T> data;
 
 		public Writable(NamedData<T> data) {
@@ -50,11 +59,20 @@ public interface NamedData<T> extends Supplier<Optional<T>> {
 		}
 
 		public void write(StringBuilder target) {
+			write(target, data.keyValueSeparator(), data.entrySeparator());
+		}
+
+		public void write(StringBuilder target, String mediator, String separator) {
 			data.get().ifPresent(//
-					value -> target //
-							.append(data.key()) //
-							.append("=") //$NON-NLS-1$
-							.append(data.printed(value)));
+					value -> {
+						if (target.length() > 0) {
+							target.append(separator);
+						}
+						target //
+								.append(data.key()) //
+								.append(mediator) //
+								.append(data.printed(value));
+					});
 		}
 
 	}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleRequirements.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleRequirements.java
@@ -89,6 +89,8 @@ public final class BundleRequirements implements ResolvedRequirements {
 		return Arrays.stream(context.get().getBundles())//
 				.map(RequirementsFromBundle::new)//
 				.map(RequirementsFromBundle::get) //
+				.filter(Optional::isPresent)//
+				.map(Optional::get)//
 				.flatMap(List::stream) //
 				.collect(Collectors.toList());
 	}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureInfo.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureInfo.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.Map;
+
+import org.eclipse.passage.lic.internal.base.NamedData;
+import org.eclipse.passage.lic.internal.base.StringNamedData;
+
+/**
+ * <p>
+ * Hiding actual name of an attribute for a feature under licensing, instead of
+ * sharing it
+ * </p>
+ * <ul>
+ * <li>facilitates reading it's value from a {@code Capability}'s attributes,
+ * and</li>
+ * <li>provides writing <i>name-value</i> pair to a selected target</li>
+ * </ul>
+ * 
+ * @see NamedData
+ * @see NamedData.Writable
+ */
+@SuppressWarnings("restriction")
+abstract class CapabilityLicFeatureInfo extends StringNamedData {
+
+	public CapabilityLicFeatureInfo(String value) {
+		super(value);
+	}
+
+	public CapabilityLicFeatureInfo(Map<String, Object> container) {
+		super(container);
+	}
+
+	@Override
+	public String printed(String value) {
+		return "\"" + value + "\""; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	public String key() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String keyValueSeparator() {
+		return "="; //$NON-NLS-1$
+	}
+
+	@Override
+	public String entrySeparator() {
+		return ";"; //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureLevel.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureLevel.java
@@ -14,8 +14,8 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.Map;
 
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.base.NamedData;
-import org.eclipse.passage.lic.internal.base.StringNamedData;
 
 /**
  * Encapsulate reading of a {@code restriction level} of a feature under
@@ -24,10 +24,10 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * @see NamedData
  */
 @SuppressWarnings("restriction")
-public final class CapabilityLicFeatureLevel extends StringNamedData {
+public final class CapabilityLicFeatureLevel extends CapabilityLicFeatureInfo {
 
-	public CapabilityLicFeatureLevel(String version) {
-		super(version);
+	public CapabilityLicFeatureLevel(Requirement requirement) {
+		super(requirement.restrictionLevel().identifier());
 	}
 
 	public CapabilityLicFeatureLevel(Map<String, Object> container) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureName.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureName.java
@@ -14,8 +14,8 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.Map;
 
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.base.NamedData;
-import org.eclipse.passage.lic.internal.base.StringNamedData;
 
 /**
  * Encapsulate reading of a {@code name} of a feature under licensing from a
@@ -24,10 +24,10 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * @see NamedData
  */
 @SuppressWarnings("restriction")
-public final class CapabilityLicFeatureName extends StringNamedData {
+public final class CapabilityLicFeatureName extends CapabilityLicFeatureInfo {
 
-	public CapabilityLicFeatureName(String version) {
-		super(version);
+	public CapabilityLicFeatureName(Requirement requirement) {
+		super(requirement.feature().name());
 	}
 
 	public CapabilityLicFeatureName(Map<String, Object> container) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureProvider.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureProvider.java
@@ -14,8 +14,8 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.Map;
 
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.base.NamedData;
-import org.eclipse.passage.lic.internal.base.StringNamedData;
 
 /**
  * Encapsulate reading of a {@code provider} information for a feature under
@@ -24,10 +24,10 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * @see NamedData
  */
 @SuppressWarnings("restriction")
-public final class CapabilityLicFeatureProvider extends StringNamedData {
+public final class CapabilityLicFeatureProvider extends CapabilityLicFeatureInfo {
 
-	public CapabilityLicFeatureProvider(String provider) {
-		super(provider);
+	public CapabilityLicFeatureProvider(Requirement requirement) {
+		super(requirement.feature().provider());
 	}
 
 	public CapabilityLicFeatureProvider(Map<String, Object> container) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureVersion.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureVersion.java
@@ -14,8 +14,8 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.Map;
 
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.base.NamedData;
-import org.eclipse.passage.lic.internal.base.StringNamedData;
 
 /**
  * Encapsulate reading of a raw string {@code version} value of a feature under
@@ -24,10 +24,10 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * @see NamedData
  */
 @SuppressWarnings("restriction")
-public final class CapabilityLicFeatureVersion extends StringNamedData {
+public final class CapabilityLicFeatureVersion extends CapabilityLicFeatureInfo {
 
-	public CapabilityLicFeatureVersion(String version) {
-		super(version);
+	public CapabilityLicFeatureVersion(Requirement requirement) {
+		super(requirement.feature().version());
 	}
 
 	public CapabilityLicFeatureVersion(Map<String, Object> container) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityNamespace.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityNamespace.java
@@ -12,30 +12,12 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.equinox.requirements;
 
-import java.util.Map;
+import java.util.function.Supplier;
 
-import org.eclipse.passage.lic.internal.api.requirements.Requirement;
-import org.eclipse.passage.lic.internal.base.NamedData;
-
-/**
- * Encapsulate reading of a {@code feature identifier} from a
- * {@code Capability}'s attributes.
- * 
- * @see NamedData
- */
-@SuppressWarnings("restriction")
-public final class CapabilityLicFeatureId extends CapabilityLicFeatureInfo {
-
-	public CapabilityLicFeatureId(Requirement requirement) {
-		super(requirement.feature().identifier());
-	}
-
-	public CapabilityLicFeatureId(Map<String, Object> container) {
-		super(container);
-	}
+final class LicCapabilityNamespace implements Supplier<String> {
 
 	@Override
-	public String key() {
+	public String get() {
 		return "licensing.feature"; //$NON-NLS-1$
 	}
 

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementToCapability.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementToCapability.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.NamedData;
+import org.eclipse.passage.lic.internal.base.StringNamedData;
+
+/**
+ * <p>
+ * Represent a {@linkplain Requirement} as named piece of textual information to
+ * be kept in a bundle manifest under {@code Provide-Capability} header.
+ * </p>
+ * <p>
+ * To turn your {@linkplain Requirement} to a proper string, use
+ * </p>
+ * <span> new NamedData.Writable&lt;Requirement&gt;(new
+ * RequirementToCapability(requirement)).write(target); </span>
+ * 
+ * @see NamedData.Writable
+ */
+@SuppressWarnings("restriction")
+public final class RequirementToCapability implements NamedData<Requirement> {
+
+	private final Requirement requirement;
+
+	public RequirementToCapability(Requirement requirement) {
+		Objects.requireNonNull(requirement);
+		this.requirement = requirement;
+	}
+
+	@Override
+	public Optional<Requirement> get() {
+		return Optional.of(requirement);
+	}
+
+	@Override
+	public String key() {
+		return new LicCapabilityNamespace().get();
+	}
+
+	@Override
+	public String printed(Requirement value) {
+		StringBuilder out = new StringBuilder();
+		attributes().stream() //
+				.map(NamedData.Writable<String>::new)//
+				.forEach(w -> w.write(out));
+		return out.toString();
+	}
+
+	@Override
+	public String keyValueSeparator() {
+		return ";"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String entrySeparator() {
+		return ","; //$NON-NLS-1$
+	}
+
+	private List<StringNamedData> attributes() {
+		return Arrays.asList(//
+				new CapabilityLicFeatureId(requirement), //
+				new CapabilityLicFeatureName(requirement), //
+				new CapabilityLicFeatureVersion(requirement), //
+				new CapabilityLicFeatureProvider(requirement), //
+				new CapabilityLicFeatureLevel(requirement) //
+		);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsToBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsToBundle.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.NamedData;
+
+/**
+ * <p>
+ * Turns a list of {@linkplain Requirement}s to string for writing into a bundle
+ * manifest under {@code Provide-Capability} header.
+ * </p>
+ * <p>
+ * Typical usage:
+ * </p>
+ * <span> new NamedData.Writable&lt;List&lt;Requirement&gt;&gt;(new
+ * RequirementsToBundle(requirements)).write(target); </span>
+ * 
+ * Á
+ * 
+ * @see NamedData.Writable
+ */
+@SuppressWarnings("restriction")
+public final class RequirementsToBundle implements NamedData<List<Requirement>> {
+
+	private final List<Requirement> requirements;
+
+	public RequirementsToBundle(List<Requirement> requirements) {
+		this.requirements = requirements;
+	}
+
+	public RequirementsToBundle() {
+		this(Collections.emptyList());
+	}
+
+	@Override
+	public Optional<List<Requirement>> get() {
+		return Optional.of(requirements);
+	}
+
+	@Override
+	public String key() {
+		return "Provide-Capability"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String printed(List<Requirement> values) {
+		StringBuilder out = new StringBuilder();
+		values.stream()//
+				.map(RequirementToCapability::new) //
+				.map(NamedData.Writable<Requirement>::new)//
+				.forEach(w -> w.write(out));
+		return out.toString();
+	}
+
+	@Override
+	public String keyValueSeparator() {
+		return ": "; //$NON-NLS-1$
+	}
+
+	@Override
+	public String entrySeparator() {
+		return ""; //$NON-NLS-1$
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/LicensingFeatureCapabilitiesFromBundleTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/LicensingFeatureCapabilitiesFromBundleTest.java
@@ -38,7 +38,7 @@ public final class LicensingFeatureCapabilitiesFromBundleTest {
 	}
 
 	private void assertExpectedContent(Optional<List<BundleCapability>> capabilities) {
-		String key = new CapabilityLicFeatureId("").key(); //$NON-NLS-1$
+		String key = new CapabilityLicFeatureId(new DataBundle().e()).key();
 		assertEquals(//
 				new HashSet<String>(Arrays.asList(//
 						"Incomplete", //$NON-NLS-1$

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/WriteLicCapablitiesTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/WriteLicCapablitiesTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.NamedData;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class WriteLicCapablitiesTest {
+	private final String expectation = "Provide-Capability: " //$NON-NLS-1$
+			+ "licensing.feature;licensing.feature=\"E\";name=\"Euler number\";version=\"2.71.82\";provider=\"Euler\";level=\"info\"," //$NON-NLS-1$
+			+ "licensing.feature;licensing.feature=\"PI\";name=\"PI of version PI\";version=\"3.14.15\";provider=\"Eclipse Passage\";level=\"error\"," //$NON-NLS-1$
+			+ "licensing.feature;licensing.feature=\"Incomplete\";name=\"Incomplete\";version=\"0.0.0\";provider=\"Eclipse Passage\";level=\"warn\""; //$NON-NLS-1$
+
+	@Test
+	public void writeProvideCapabilityHeader() {
+		DataBundle data = new DataBundle();
+		StringBuilder target = new StringBuilder();
+		new NamedData.Writable<List<Requirement>>(//
+				new RequirementsToBundle(Arrays.asList(//
+						data.e(), //
+						data.pi(), //
+						data.incomplete())))//
+								.write(target); //
+		assertEquals(expectation, target.toString());
+
+	}
+}


### PR DESCRIPTION
Preliminary work:
  - fix `slf4j` dependency issue in the minimal e4 passage templated
projects as well
  - provide `Requirement`s to-string  writing on the basis of `NamedData` idea
  - and thus eliminate one more LicensingNamespaces public constant
usage

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>