### PR TITLE
Bug 561555  use `BundleRequirements` in FullFeather project template

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedTemplateSection.java
@@ -22,9 +22,6 @@ import java.util.ResourceBundle;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.passage.lic.internal.api.requirements.Requirement;
-import org.eclipse.passage.lic.internal.api.restrictions.RestrictionLevel;
-import org.eclipse.passage.lic.internal.base.requirements.BaseFeature;
-import org.eclipse.passage.lic.internal.base.requirements.BaseRequirement;
 import org.eclipse.passage.lic.internal.equinox.requirements.RequirementsToBundle;
 import org.eclipse.pde.core.plugin.IMatchRules;
 import org.eclipse.pde.core.plugin.IPluginBase;
@@ -123,19 +120,10 @@ public abstract class BaseLicensedTemplateSection extends OptionTemplateSection 
 		((IBundlePluginModelBase) shared).getBundleModel().getBundle()//
 				.setHeader(Constants.PROVIDE_CAPABILITY, //
 						new RequirementsToBundle()//
-								.printed(Arrays.asList(defaultRequirement(identifier))));
+								.printed(requirements(identifier)));
 	}
 
-	private Requirement defaultRequirement(String identifier) {
-		return new BaseRequirement(//
-				new BaseFeature(//
-						identifier, //
-						"1.0.0", //$NON-NLS-1$
-						identifier, //
-						"Eclipse Passage Template"), //$NON-NLS-1$
-				new RestrictionLevel.Warning(), //
-				this);
-	}
+	protected abstract List<Requirement> requirements(String product);
 
 	protected void createApplicationExtension(String identifier, String classValue) throws CoreException {
 		IPluginBase plugin = model.getPluginBase();

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/DefaultProductRequirement.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/DefaultProductRequirement.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.ldc.internal.pde.ui.templates;
+
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.api.restrictions.RestrictionLevel;
+import org.eclipse.passage.lic.internal.base.requirements.BaseFeature;
+import org.eclipse.passage.lic.internal.base.requirements.BaseRequirement;
+
+@SuppressWarnings("restriction")
+final class DefaultProductRequirement implements Supplier<Requirement> {
+	private final String product;
+
+	DefaultProductRequirement(String product) {
+		this.product = product;
+	}
+
+	@Override
+	public Requirement get() {
+		return new BaseRequirement(//
+				new BaseFeature(//
+						product, //
+						"1.0.0", //$NON-NLS-1$
+						product, //
+						"Eclipse Passage Template"), //$NON-NLS-1$
+				new RestrictionLevel.Warning(), //
+				this);
+	}
+
+}

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE3ProductTemplateSection.java
@@ -12,11 +12,15 @@
  *******************************************************************************/
 package org.eclipse.passage.ldc.internal.pde.ui.templates;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.passage.ldc.internal.pde.ui.templates.i18n.PdeUiTemplatesMessages;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginElement;
 import org.eclipse.pde.core.plugin.IPluginExtension;
@@ -24,6 +28,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginReference;
 import org.eclipse.pde.ui.IFieldData;
 
+@SuppressWarnings("restriction")
 public class LicensedE3ProductTemplateSection extends BaseLicensedTemplateSection {
 
 	private static final String LICENSED_E3_PRODUCT = "LicensedE3Product"; //$NON-NLS-1$
@@ -81,6 +86,11 @@ public class LicensedE3ProductTemplateSection extends BaseLicensedTemplateSectio
 		createPerspectiveExtension();
 		createProductExtension();
 		createProcessorExtension(VALUE_PROCESSOR_LICENSING_ID, VALUE_PROCESSOR_LICENSING_CLASS);
+	}
+
+	@Override
+	protected List<Requirement> requirements(String product) {
+		return Arrays.asList(new DefaultProductRequirement(product).get());
 	}
 
 	private void createPerspectiveExtension() throws CoreException {

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4FullFeatherProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4FullFeatherProductTemplateSection.java
@@ -12,11 +12,16 @@
  *******************************************************************************/
 package org.eclipse.passage.ldc.internal.pde.ui.templates;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.passage.ldc.internal.pde.ui.templates.fullfeather.AntimagicShieldFeatureLicRequirement;
 import org.eclipse.passage.ldc.internal.pde.ui.templates.i18n.PdeUiTemplatesMessages;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginElement;
 import org.eclipse.pde.core.plugin.IPluginExtension;
@@ -24,6 +29,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginReference;
 import org.eclipse.pde.ui.IFieldData;
 
+@SuppressWarnings("restriction")
 public final class LicensedE4FullFeatherProductTemplateSection extends BaseLicensedTemplateSection {
 
 	public LicensedE4FullFeatherProductTemplateSection() {
@@ -66,6 +72,13 @@ public final class LicensedE4FullFeatherProductTemplateSection extends BaseLicen
 		String productFqn = model.getPluginBase().getId() + '.' + VALUE_PRODUCT_ID;
 		createLicensingCapability(productFqn);
 		createProductExtension();
+	}
+
+	@Override
+	protected List<Requirement> requirements(String product) {
+		return Arrays.asList(//
+				new DefaultProductRequirement(product).get(), //
+				new AntimagicShieldFeatureLicRequirement().get());
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
@@ -12,11 +12,15 @@
  *******************************************************************************/
 package org.eclipse.passage.ldc.internal.pde.ui.templates;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.passage.ldc.internal.pde.ui.templates.i18n.PdeUiTemplatesMessages;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.pde.core.plugin.IPluginBase;
 import org.eclipse.pde.core.plugin.IPluginElement;
 import org.eclipse.pde.core.plugin.IPluginExtension;
@@ -24,6 +28,7 @@ import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginReference;
 import org.eclipse.pde.ui.IFieldData;
 
+@SuppressWarnings("restriction")
 @Deprecated
 public class LicensedE4ProductTemplateSection extends BaseLicensedTemplateSection {
 
@@ -76,6 +81,11 @@ public class LicensedE4ProductTemplateSection extends BaseLicensedTemplateSectio
 		String productFqn = model.getPluginBase().getId() + '.' + VALUE_PRODUCT_ID;
 		createLicensingCapability(productFqn);
 		createProductExtension();
+	}
+
+	@Override
+	protected List<Requirement> requirements(String product) {
+		return Arrays.asList(new DefaultProductRequirement(product).get());
 	}
 
 	private void createProductExtension() throws CoreException {

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/AntimagicShieldFeatureLicRequirement.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/AntimagicShieldFeatureLicRequirement.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.ldc.internal.pde.ui.templates.fullfeather;
+
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.api.restrictions.RestrictionLevel;
+import org.eclipse.passage.lic.internal.base.requirements.BaseFeature;
+import org.eclipse.passage.lic.internal.base.requirements.BaseRequirement;
+
+@SuppressWarnings("restriction")
+public final class AntimagicShieldFeatureLicRequirement implements Supplier<Requirement> {
+
+	@Override
+	public Requirement get() {
+		return new BaseRequirement(//
+				new BaseFeature(//
+						"antimagic-shield", //$NON-NLS-1$
+						"2.72", //$NON-NLS-1$
+						"Antimagic protection", //$NON-NLS-1$
+						"Passage E4FF Template"), //$NON-NLS-1$
+				new RestrictionLevel.Warning(), //
+				this //
+		);
+	}
+
+}


### PR DESCRIPTION
 - Additional _lic.feature_ capability is defined for E4FF template.
Reserved for consumable tokens utilization.

Going to close [561555](https://bugs.eclipse.org/bugs/show_bug.cgi?id=561555) and the whole [561380](https://bugs.eclipse.org/bugs/show_bug.cgi?id=561380) bunch.