### PR TITLE
Bug 562015 - [Passage] 0.9 incorrect default name for license plan file

### DIFF
--- a/bundles/org.eclipse.passage.loc.licenses.ui/fragment.e4xmi
+++ b/bundles/org.eclipse.passage.loc.licenses.ui/fragment.e4xmi
@@ -8,6 +8,9 @@
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_QouDcA86Eemq0ONZAqyi5g" featurename="commands" parentElementId="org.eclipse.passage.loc.workbench.application">
     <elements xsi:type="commands:Command" xmi:id="_S15ssA86Eemq0ONZAqyi5g" elementId="org.eclipse.passage.loc.licenses.ui.command.licenseplan.create" commandName="License Plan" description="New License Plan"/>
   </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_vSgxIA6TEemZZbTGyctv6w" featurename="handlers" parentElementId="org.eclipse.passage.loc.workbench.application">
+    <elements xsi:type="commands:Handler" xmi:id="_vGV6MA6PEemZZbTGyctv6w" elementId="org.eclipse.passage.loc.licenses.ui.handler.licenseplan.create" contributionURI="bundleclass://org.eclipse.passage.loc.licenses.ui/org.eclipse.passage.loc.internal.licenses.ui.handlers.CreateLicensePlanHandler" command="_S15ssA86Eemq0ONZAqyi5g"/>
+  </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_RRnF0OjiEeirQd2CUcYMjQ" featurename="children" parentElementId="org.eclipse.passage.loc.workbench.perspectivestack.main">
     <elements xsi:type="advanced:Perspective" xmi:id="_VBf38OjiEeirQd2CUcYMjQ" elementId="org.eclipse.passage.loc.licenses.ui.perspective.main" label="Licenses" iconURI="platform:/plugin/org.eclipse.passage.lic.licenses.edit/icons/full/obj16/license.png">
       <children xsi:type="basic:PartSashContainer" xmi:id="_h1z38OjiEeirQd2CUcYMjQ" elementId="org.eclipse.passage.loc.licenses.ui.partsashcontainer.main" selectedElement="_k2D84OjiEeirQd2CUcYMjQ" horizontal="true">
@@ -16,7 +19,6 @@
       </children>
       <handlers xmi:id="_HEOMkPIpEeiO9ZCh0caXIg" elementId="org.eclipse.passage.loc.licenses.ui.handler.license.open" contributionURI="bundleclass://org.eclipse.passage.loc.licenses.ui/org.eclipse.passage.loc.internal.licenses.ui.handlers.OpenLicensePlanHandler" command="_LEzGEPIpEeiO9ZCh0caXIg"/>
       <handlers xmi:id="_uF8WAPJoEeiO9ZCh0caXIg" elementId="org.eclipse.passage.loc.licenses.ui.handler.license.export" contributionURI="bundleclass://org.eclipse.passage.loc.licenses.ui/org.eclipse.passage.loc.internal.licenses.ui.handlers.LicenseExportHandler" command="_B0LYAPJlEeiO9ZCh0caXIg"/>
-      <handlers xmi:id="_qU6lkBQAEemRg8XCpeTHbg" elementId="org.eclipse.passage.loc.licenses.ui.handler.licenseplan.create" contributionURI="bundleclass://org.eclipse.passage.loc.licenses.ui/org.eclipse.passage.loc.internal.licenses.ui.handlers.CreateLicensePlanHandler" command="_S15ssA86Eemq0ONZAqyi5g"/>
     </elements>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_4yf2IOjiEeirQd2CUcYMjQ" featurename="children" parentElementId="org.eclipse.passage.loc.workbench.menu.view">
@@ -25,6 +27,6 @@
     </elements>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_fLDEcA86Eemq0ONZAqyi5g" featurename="children" parentElementId="org.eclipse.passage.loc.workbench.menu.file.new">
-    <elements xsi:type="menu:HandledMenuItem" xmi:id="_h9KmwA86Eemq0ONZAqyi5g" elementId="org.eclipse.passage.loc.licenses.ui.handledmenuitem.licensepack" label="License Plan" iconURI="platform:/plugin/org.eclipse.passage.lic.licenses.edit/icons/full/obj16/license.png" tooltip="New License Plan" command="_S15ssA86Eemq0ONZAqyi5g"/>
+    <elements xsi:type="menu:HandledMenuItem" xmi:id="_h9KmwA86Eemq0ONZAqyi5g" elementId="org.eclipse.passage.loc.licenses.ui.handledmenuitem.licenseplan" label="License Plan" iconURI="platform:/plugin/org.eclipse.passage.lic.licenses.edit/icons/full/obj16/license.png" tooltip="New License Plan" command="_S15ssA86Eemq0ONZAqyi5g"/>
   </fragments>
 </fragment:ModelFragments>


### PR DESCRIPTION
Was actually fixed by another commit, here is the handler contribution fix.
