### PR TITLE
Bug 558616 - [Passage] put .setup and .target in order

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -120,9 +120,11 @@
         <requirement
             name="org.bouncycastle.bcprov"/>
         <requirement
-            name="org.eclipse.emf.ecp.sdk.feature.feature.group"/>
+            name="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group"/>
         <requirement
             name="org.eclipse.emf.sdk.feature.group"/>
+        <requirement
+            name="org.eclipse.emfforms.setup.base"/>
         <requirement
             name="org.eclipse.passage.lbc.execute.feature.feature.group"/>
         <requirement
@@ -146,9 +148,11 @@
         <repositoryList
             name="Passage Latest Released">
           <repository
-              url="https://download.eclipse.org/releases/2020-06/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.15/"/>
           <repository
-              url="https://download.eclipse.org/tools/orbit/downloads/2020-06"/>
+              url="https://download.eclipse.org/ecp/releases/releases_124/1240/"/>
+          <repository
+              url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.21/"/>
           <repository
               url="https://download.eclipse.org/passage/updates/release/0.9.0/lic/"/>
           <repository
@@ -157,6 +161,8 @@
               url="https://download.eclipse.org/passage/updates/release/0.9.0/lbc/"/>
           <repository
               url="https://download.eclipse.org/passage/updates/release/0.9.0/ldc/"/>
+          <repository
+              url="https://download.eclipse.org/tools/orbit/downloads/2020-06"/>
         </repositoryList>
       </targlet>
     </setupTask>
@@ -219,9 +225,11 @@
         <requirement
             name="org.bouncycastle.bcprov"/>
         <requirement
-            name="org.eclipse.emf.ecp.sdk.feature.feature.group"/>
+            name="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group"/>
         <requirement
             name="org.eclipse.emf.sdk.feature.group"/>
+        <requirement
+            name="org.eclipse.emfforms.setup.base"/>
         <requirement
             name="org.eclipse.pde.feature.group"/>
         <requirement
@@ -242,7 +250,11 @@
           <repository
               url="https://download.eclipse.org/cbi/updates/license/"/>
           <repository
-              url="https://download.eclipse.org/releases/2020-06/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540/"/>
+          <repository
+              url="https://download.eclipse.org/ecp/releases/releases_124/1240/"/>
+          <repository
+              url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.22/"/>
           <repository
               url="https://download.eclipse.org/tools/orbit/downloads/2020-06"/>
         </repositoryList>
@@ -260,34 +272,34 @@
           <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
           <repository
-              url="https://download.eclipse.org/tools/orbit/downloads/2019-12"/>
-          <repository
               url="https://download.eclipse.org/releases/2019-12/"/>
+          <repository
+              url="https://download.eclipse.org/tools/orbit/downloads/2019-12"/>
         </repositoryList>
         <repositoryList
             name="2019-09">
           <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
           <repository
-              url="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
-          <repository
               url="https://download.eclipse.org/releases/2019-09/"/>
+          <repository
+              url="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
         </repositoryList>
         <repositoryList
             name="2019-06">
           <repository
-              url="https://download.eclipse.org/releases/2019-06/"/>
-          <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
+          <repository
+              url="https://download.eclipse.org/releases/2019-06/"/>
           <repository
               url="https://download.eclipse.org/tools/orbit/downloads/2019-06"/>
         </repositoryList>
         <repositoryList
             name="2019-03">
           <repository
-              url="https://download.eclipse.org/releases/2019-03"/>
-          <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
+          <repository
+              url="https://download.eclipse.org/releases/2019-03"/>
           <repository
               url="https://download.eclipse.org/tools/orbit/downloads/2019-03"/>
         </repositoryList>

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
@@ -12,11 +12,26 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.baseline" sequenceNumber="86">
+<target name="org.eclipse.passage.baseline" sequenceNumber="87">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.15/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emfforms.setup.base" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/ecp/releases/releases_124/1240/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>https://download.eclipse.org/ecp/releases/releases_124/
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.21/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.passage.lbc.execute.feature.feature.group" version="0.0.0"/>
@@ -33,14 +48,6 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.passage.loc.operator.feature.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/passage/updates/release/0.9.0/loc/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.ecp.sdk.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-06/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -12,19 +12,26 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.target" sequenceNumber="86">
+<target name="org.eclipse.passage.target" sequenceNumber="87">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.ecp.sdk.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-06/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emfforms.setup.base" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/ecp/releases/releases_124/1240/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>https://download.eclipse.org/ecp/releases/releases_124/
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.22/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>


### PR DESCRIPTION
Use precise p2 repos instead of SimRel composite. Needs update to setup
for 2020-09.

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>