### PR TITLE
Bug 564420 move HC condition miner to new interfaces

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ConditionTransport.java
@@ -18,11 +18,12 @@ import java.io.OutputStream;
 import java.util.Collection;
 
 import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.registry.Service;
 
 /**
  * Persistence interface for {@link Condition}(s).
  */
-public interface ConditionTransport {
+public interface ConditionTransport extends Service<ContentType> {
 
 	/**
 	 * Reads {@link Condition}(s) from the given {@link InputStream}. Stream remains

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ConditionTransportRegistry.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api.conditions.mining;
+
+import org.eclipse.passage.lic.internal.api.registry.Registry;
+
+public interface ConditionTransportRegistry extends Registry<ContentType, ConditionTransport> {
+
+}

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ContentType.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/mining/ContentType.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api.conditions.mining;
+
+import java.util.Objects;
+
+import org.eclipse.passage.lic.internal.api.registry.ServiceId;
+
+/**
+ * String-valued {@linkplain ServiceId} with mime content type semantics
+ */
+public final class ContentType implements ServiceId {
+
+	private final String type;
+
+	public ContentType(String type) {
+		Objects.requireNonNull(type, "ContentType::type"); //$NON-NLS-1$
+		this.type = type;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (!getClass().isInstance(object)) {
+			return false;
+		}
+		return type.equals(((ContentType) object).contentType());
+	}
+
+	public String contentType() {
+		return type;
+	}
+
+	@Override
+	public int hashCode() {
+		return type.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return type;
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
@@ -11,4 +11,6 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.passage.lic.api;bundle-version="0.7.0"
 Export-Package: org.eclipse.passage.lic.api.tests;x-internal:=true,
  org.eclipse.passage.lic.api.tests.conditions;x-internal:=true,
+ org.eclipse.passage.lic.api.tests.conditions.mining;x-internal:=true,
+ org.eclipse.passage.lic.api.tests.registry;x-internal:=true,
  org.eclipse.passage.lic.api.tests.version;x-internal:=true

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ConditionTransportContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ConditionTransportContractTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.api.tests.conditions.mining;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +30,11 @@ import org.junit.Test;
 
 @SuppressWarnings("restriction")
 public abstract class ConditionTransportContractTest {
+
+	@Test
+	public void identifiedByContentType() {
+		assertNotNull(transport().id());
+	}
 
 	@Test(expected = NullPointerException.class)
 	public void conditionsAreMandatory() throws IOException {
@@ -79,4 +85,5 @@ public abstract class ConditionTransportContractTest {
 	 * Supply as least two test condition for transportation
 	 */
 	protected abstract Collection<Condition> conditions();
+
 }

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ContentTypeTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ContentTypeTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.conditions.mining;
+
+import org.eclipse.passage.lic.api.tests.registry.ServiceIdContractTest;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
+import org.eclipse.passage.lic.internal.api.registry.ServiceId;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class ContentTypeTest extends ServiceIdContractTest {
+
+	@Test(expected = NullPointerException.class)
+	public void typeIsMandatory() {
+		new ContentType(null);
+	}
+
+	@Override
+	protected ServiceId ofSameData() {
+		return new ContentType("same-id-value"); //$NON-NLS-1$
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/ServiceIdContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/ServiceIdContractTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.registry;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.passage.lic.internal.api.registry.ServiceId;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public abstract class ServiceIdContractTest {
+
+	/**
+	 * It is expected that two {@linkplain ServiceId} instances built of the same
+	 * data are `equal` id data-class sense.
+	 */
+	@Test
+	public void isDataDriven() {
+		assertEquals(ofSameData(), ofSameData());
+		assertEquals(ofSameData().hashCode(), ofSameData().hashCode());
+		assertEquals(ofSameData().toString(), ofSameData().toString());
+	}
+
+	/**
+	 * @return new instance each time build of the same data
+	 */
+	protected abstract ServiceId ofSameData();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/StringServiceIdTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/StringServiceIdTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.registry;
+
+import org.eclipse.passage.lic.internal.api.registry.ServiceId;
+import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class StringServiceIdTest extends ServiceIdContractTest {
+
+	@Test(expected = NullPointerException.class)
+	public void idIsMandatory() {
+		new StringServiceId(null);
+	}
+
+	@Override
+	protected ServiceId ofSameData() {
+		return new StringServiceId("same-id-value"); //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
 - make `ConditionTransport` interface a `Service` with a dedicated
registry
 - invite `ContentType` as a `ServiceId`
 - create contract tests for `ServiceId`, test both implementations

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>