### PR TITLE
Bug 564420 move HC condition miner to new interfaces

### DIFF
--- a/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.json
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.json
-Bundle-Version: 0.5.200.qualifier
+Bundle-Version: 0.6.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -15,6 +15,7 @@ Require-Bundle: org.apache.httpcomponents.httpcore;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.net;bundle-version="0.0.0"
-Export-Package: org.eclipse.passage.lic.internal.json;x-internal:=true
+Export-Package: org.eclipse.passage.lic.internal.json;x-internal:=true,
+ org.eclipse.passage.lic.internal.json.tobemoved
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.json
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.json
-Bundle-Version: 0.5.200.qualifier
+Bundle-Version: 0.5.300.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.json/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.json
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.json
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -16,6 +16,6 @@ Require-Bundle: org.apache.httpcomponents.httpcore;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.net;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.internal.json;x-internal:=true,
- org.eclipse.passage.lic.internal.json.tobemoved
+ org.eclipse.passage.lic.internal.json.tobemoved;x-internal:=true
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonConditionTransport.java
@@ -27,6 +27,10 @@ import org.osgi.service.component.annotations.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * @deprecated use revised version (package revision)
+ */
+@Deprecated
 @Component(property = { LICENSING_CONTENT_TYPE + '=' + LICENSING_CONTENT_TYPE_JSON })
 public class JsonConditionTransport implements ConditionTransport {
 

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonConditionTransport.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * @deprecated use revised version (package revision)
+ * @deprecated use revised version (tobemoved package)
  */
 @Deprecated
 @Component(property = { LICENSING_CONTENT_TYPE + '=' + LICENSING_CONTENT_TYPE_JSON })

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonTransport.java
@@ -26,8 +26,9 @@ public class JsonTransport {
 	public static ObjectMapper createObjectMapper() {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
-				.withFieldVisibility(JsonAutoDetect.Visibility.ANY).withGetterVisibility(JsonAutoDetect.Visibility.NONE)
-				.withSetterVisibility(JsonAutoDetect.Visibility.ANY)
+				.withFieldVisibility(JsonAutoDetect.Visibility.ANY)//
+				.withGetterVisibility(JsonAutoDetect.Visibility.NONE)//
+				.withSetterVisibility(JsonAutoDetect.Visibility.ANY)//
 				.withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
 		mapper.enable(SerializationFeature.INDENT_OUTPUT);
 		mapper.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/JsonTransport.java
@@ -17,6 +17,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+/**
+ * @deprecated use revised version of transport (tobemoved package)
+ */
+@Deprecated
 public class JsonTransport {
 
 	private JsonTransport() {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionAggregator.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionAggregator.java
@@ -17,6 +17,10 @@ import java.util.List;
 
 import org.eclipse.passage.lic.api.conditions.LicensingCondition;
 
+/**
+ * @deprecated use revised version of transport (package revision)
+ */
+@Deprecated
 public class LicensingConditionAggregator {
 
 	private final List<LicensingConditionMixIn> licensingConditions = new ArrayList<>();

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionAggregator.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionAggregator.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.eclipse.passage.lic.api.conditions.LicensingCondition;
 
 /**
- * @deprecated use revised version of transport (package revision)
+ * @deprecated use revised version of transport (tobemoved package)
  */
 @Deprecated
 public class LicensingConditionAggregator {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionMixIn.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionMixIn.java
@@ -19,6 +19,10 @@ import org.eclipse.passage.lic.api.conditions.LicensingCondition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated use revised version of transport (package revision)
+ */
+@Deprecated
 final class LicensingConditionMixIn implements LicensingCondition {
 
 	static LicensingConditionMixIn create(LicensingCondition d) {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionMixIn.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConditionMixIn.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @deprecated use revised version of transport (package revision)
+ * @deprecated use revised version of transport (tobemoved package)
  */
 @Deprecated
 final class LicensingConditionMixIn implements LicensingCondition {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConfigurationMixIn.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConfigurationMixIn.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @deprecated use revised version of transport (package revision)
+ * @deprecated use revised version of transport (tobemoved package)
  */
 @Deprecated
 final class LicensingConfigurationMixIn implements LicensingConfiguration {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConfigurationMixIn.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/LicensingConfigurationMixIn.java
@@ -17,6 +17,10 @@ import org.eclipse.passage.lic.api.LicensingConfiguration;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated use revised version of transport (package revision)
+ */
+@Deprecated
 final class LicensingConfigurationMixIn implements LicensingConfiguration {
 
 	static LicensingConfigurationMixIn create(LicensingConfiguration d) {

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionDeserializer.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionDeserializer.java
@@ -44,6 +44,7 @@ final class ConditionDeserializer extends StdDeserializer<Condition> {
 	@Override
 	public Condition deserialize(JsonParser parser, DeserializationContext context)
 			throws IOException, JsonProcessingException {
+		// FIXME: redesign innards basing on {@code NamedData}
 		JsonNode node = parser.getCodec().readTree(parser);
 		return new BaseCondition(node.get("feature").textValue(), //$NON-NLS-1$ ,
 				new BaseVersionMatch( //

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionDeserializer.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionDeserializer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.conditions.EvaluationType;
+import org.eclipse.passage.lic.internal.base.conditions.BaseCondition;
+import org.eclipse.passage.lic.internal.base.conditions.BaseEvaluationInstructions;
+import org.eclipse.passage.lic.internal.base.conditions.BaseValidityPeriodClosed;
+import org.eclipse.passage.lic.internal.base.conditions.BaseVersionMatch;
+import org.eclipse.passage.lic.internal.base.conditions.MatchingRuleForIdentifier;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+@SuppressWarnings("restriction")
+final class ConditionDeserializer extends StdDeserializer<Condition> {
+
+	/**
+	 * generated
+	 */
+	private static final long serialVersionUID = 4583912455528712124L;
+
+	ConditionDeserializer(Class<Condition> type) {
+		super(type);
+	}
+
+	@Override
+	public Condition deserialize(JsonParser parser, DeserializationContext context)
+			throws IOException, JsonProcessingException {
+		JsonNode node = parser.getCodec().readTree(parser);
+		return new BaseCondition(node.get("feature").textValue(), //$NON-NLS-1$ ,
+				new BaseVersionMatch( //
+						node.get("version").textValue(), //$NON-NLS-1$
+						new MatchingRuleForIdentifier(node.get("rule").textValue()).get()), //$NON-NLS-1$
+				new BaseValidityPeriodClosed(//
+						new Date(node.get("period").get("from").longValue()), //$NON-NLS-1$ //$NON-NLS-2$
+						new Date(node.get("period").get("to").longValue())), //$NON-NLS-1$ //$NON-NLS-2$
+				new BaseEvaluationInstructions(//
+						new EvaluationType.Of(node.get("type").textValue()), // //$NON-NLS-1$
+						node.get("expression").textValue())); //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionPack.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionPack.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.util.Collection;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+
+/**
+ * Cover connection of typed elements as our persistence library requires.
+ * Intentionally ugly.
+ */
+@SuppressWarnings("restriction")
+final class ConditionPack {
+
+	Collection<Condition> conditions;
+
+	ConditionPack(Collection<Condition> conditions) {
+		this.conditions = conditions;
+	}
+
+	ConditionPack() {
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionSerializer.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionSerializer.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.io.IOException;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+@SuppressWarnings("restriction")
+final class ConditionSerializer extends StdSerializer<Condition> {
+
+	ConditionSerializer(Class<Condition> type) {
+		super(type);
+	}
+
+	/**
+	 * generated
+	 */
+	private static final long serialVersionUID = -8694881423638827104L;
+
+	@Override
+	public void serialize(Condition condition, JsonGenerator gen, SerializerProvider provider) throws IOException {
+		gen.writeStartObject();
+		gen.writeStringField("feature", condition.feature()); //$NON-NLS-1$
+		gen.writeStringField("version", condition.versionMatch().version()); //$NON-NLS-1$
+		gen.writeStringField("rule", condition.versionMatch().rule().identifier()); //$NON-NLS-1$
+		gen.writeObjectField("period", condition.validityPeriod()); //$NON-NLS-1$
+		gen.writeStringField("type", condition.evaluationInstructions().type().identifier()); //$NON-NLS-1$
+		gen.writeStringField("expression", condition.evaluationInstructions().expression()); //$NON-NLS-1$
+		gen.writeEndObject();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionSerializer.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ConditionSerializer.java
@@ -34,6 +34,7 @@ final class ConditionSerializer extends StdSerializer<Condition> {
 
 	@Override
 	public void serialize(Condition condition, JsonGenerator gen, SerializerProvider provider) throws IOException {
+		// FIXME: redesign innards basing on {@code NamedData}
 		gen.writeStartObject();
 		gen.writeStringField("feature", condition.feature()); //$NON-NLS-1$
 		gen.writeStringField("version", condition.versionMatch().version()); //$NON-NLS-1$

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonConditionTransport.java
@@ -22,9 +22,6 @@ import org.eclipse.passage.lic.internal.api.conditions.Condition;
 import org.eclipse.passage.lic.internal.api.conditions.mining.ConditionTransport;
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
 
-/**
- * @since 0.6
- */
 @SuppressWarnings("restriction")
 public final class JsonConditionTransport implements ConditionTransport {
 

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonConditionTransport.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Objects;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ConditionTransport;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
+
+/**
+ * @since 0.6
+ */
+@SuppressWarnings("restriction")
+public final class JsonConditionTransport implements ConditionTransport {
+
+	private final ContentType type = new ContentType("application/json"); //$NON-NLS-1$
+
+	@Override
+	public ContentType id() {
+		return type;
+	}
+
+	@Override
+	public Collection<Condition> read(InputStream input) throws IOException {
+		return new JsonObjectMapper().get().readValue(input, ConditionPack.class).conditions;
+	}
+
+	@Override
+	public void write(Collection<Condition> conditions, OutputStream output) throws IOException {
+		Objects.requireNonNull(conditions, "JsonConditionTransport::write::conditions"); //$NON-NLS-1$
+		output.write(new JsonObjectMapper().get().writeValueAsBytes(new ConditionPack(conditions)));
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonObjectMapper.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/JsonObjectMapper.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.conditions.ValidityPeriodClosed;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+@SuppressWarnings("restriction")
+class JsonObjectMapper implements Supplier<ObjectMapper> {
+
+	@Override
+	public ObjectMapper get() {
+		return ((Function<ObjectMapper, ObjectMapper>) this::withVisibility)//
+				.andThen(this::withFeatures) //
+				.andThen(this::withMixIns) //
+				.andThen(this::withSerializers) //
+				.apply(new ObjectMapper());
+	}
+
+	private ObjectMapper withVisibility(ObjectMapper mapper) {
+		return mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+				.withFieldVisibility(JsonAutoDetect.Visibility.ANY)//
+				.withGetterVisibility(JsonAutoDetect.Visibility.NONE)//
+				.withSetterVisibility(JsonAutoDetect.Visibility.ANY)//
+				.withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
+	}
+
+	private ObjectMapper withFeatures(ObjectMapper mapper) {
+		return mapper//
+				.enable(SerializationFeature.INDENT_OUTPUT) //
+				.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
+	}
+
+	private ObjectMapper withMixIns(ObjectMapper mapper) {
+		return mapper.addMixIn(ValidityPeriodClosed.class, ValidityPeriodClosedMixIn.class);
+	}
+
+	private ObjectMapper withSerializers(ObjectMapper mapper) {
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(new ConditionSerializer(Condition.class));
+		module.addDeserializer(Condition.class, new ConditionDeserializer(Condition.class));
+		mapper.registerModule(module);
+		return mapper;
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ValidityPeriodClosedMixIn.java
+++ b/bundles/org.eclipse.passage.lic.json/src/org/eclipse/passage/lic/internal/json/tobemoved/ValidityPeriodClosedMixIn.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.json.tobemoved;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("unused")
+abstract class ValidityPeriodClosedMixIn {
+
+	@JsonCreator
+	ValidityPeriodClosedMixIn(//
+			@JsonProperty Date from, //
+			@JsonProperty Date to) {
+	}
+
+}


### PR DESCRIPTION
 - implement `ConditionTransport` service for `application/json` content
type
 - deprecate corresponding units relying on the previous version of
interfaces

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>