### PR TITLE
564818 API revision | conditions | key keepers review

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeper.java
@@ -19,9 +19,11 @@ import org.eclipse.passage.lic.api.LicensingConfiguration;
 
 /**
  * Provides the key required for given configuration
- *
+ * 
  * @since 0.4.0
+ * @deprecated use internal (1.0) KeyKeeper
  */
+@Deprecated
 public interface KeyKeeper {
 
 	/**

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeperRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeperRegistry.java
@@ -12,15 +12,17 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.api.io;
 
-import org.eclipse.passage.lic.api.LicensingConfiguration;
-
 import java.util.Map;
+
+import org.eclipse.passage.lic.api.LicensingConfiguration;
 
 /**
  * Registry for {@link KeyKeeper} instances available at runtime.
  *
  * @since 0.4.0
+ * @deprecated use internal (1.0) KeyKeeperregistry
  */
+@Deprecated
 public interface KeyKeeperRegistry {
 
 	/**
@@ -36,17 +38,18 @@ public interface KeyKeeperRegistry {
 	 * created from the given {@code properties}.
 	 *
 	 * @param keyKeeper  instance to be registered
-	 * @param properties source information for {@code LicensingConfiguration} creation
+	 * @param properties source information for {@code LicensingConfiguration}
+	 *                   creation
 	 * @see LicensingConfiguration
 	 * @since 0.4.0
 	 */
 	void registerKeyKeeper(KeyKeeper keyKeeper, Map<String, Object> properties);
 
 	/**
-	 * Unregister the given {@code keyKeeper}. The {@code keyKeeper} will no longer available on
-	 * {@link #getKeyKeeper(LicensingConfiguration)} invocation
+	 * Unregister the given {@code keyKeeper}. The {@code keyKeeper} will no longer
+	 * available on {@link #getKeyKeeper(LicensingConfiguration)} invocation
 	 *
-	 * @param keyKeeper  instance to be unregistered
+	 * @param keyKeeper instance to be unregistered
 	 * @see LicensingConfiguration
 	 * @since 0.4.0
 	 */

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeperRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/KeyKeeperRegistry.java
@@ -20,7 +20,7 @@ import org.eclipse.passage.lic.api.LicensingConfiguration;
  * Registry for {@link KeyKeeper} instances available at runtime.
  *
  * @since 0.4.0
- * @deprecated use internal (1.0) KeyKeeperregistry
+ * @deprecated use internal (1.0) KeyKeeperRegistry
  */
 @Deprecated
 public interface KeyKeeperRegistry {

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/StreamCodecRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/io/StreamCodecRegistry.java
@@ -20,7 +20,9 @@ import org.eclipse.passage.lic.api.LicensingConfiguration;
  * Registry for {@link StreamCodec}s available at runtime
  *
  * @since 0.4.0
+ * @deprecated use internal (1.0) StreamCodecRegistry
  */
+@Deprecated
 public interface StreamCodecRegistry {
 
 	/**
@@ -35,18 +37,20 @@ public interface StreamCodecRegistry {
 	 * Register the given {@code streamCodec} for a {@code LicensingConfiguration},
 	 * created from the given {@code properties}.
 	 *
-	 * @param streamCodec  instance to be registered
-	 * @param properties source information for {@code LicensingConfiguration} creation
+	 * @param streamCodec instance to be registered
+	 * @param properties  source information for {@code LicensingConfiguration}
+	 *                    creation
 	 * @see LicensingConfiguration
 	 * @since 0.4.0
 	 */
 	void registerStreamCodec(StreamCodec streamCodec, Map<String, Object> properties);
 
 	/**
-	 * Unregister the given {@code streamCodec}. The {@code streamCodec} will no longer available on
-	 * {@link #getStreamCodec(LicensingConfiguration)} invocation
+	 * Unregister the given {@code streamCodec}. The {@code streamCodec} will no
+	 * longer available on {@link #getStreamCodec(LicensingConfiguration)}
+	 * invocation
 	 *
-	 * @param streamCodec  instance to be unregistered
+	 * @param streamCodec instance to be unregistered
 	 * @see LicensingConfiguration
 	 * @since 0.4.0
 	 */

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeper.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api.io;
+
+import java.io.InputStream;
+
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.registry.Service;
+
+/**
+ * <p>
+ * For license issuing for a product, pair of cryptographic keys must be
+ * generated and managed for the appropriate {@link LicensedProduct}.
+ * </p>
+ * <p>
+ * This interface covers the service that supplies access to the product's
+ * public key content.
+ * </p>
+ */
+public interface KeyKeeper extends Service<LicensedProduct> {
+	/**
+	 * <p>
+	 * Constructs new input stream for the given {@code product}'s public key
+	 * reading.
+	 * </p>
+	 * <p>
+	 * Ones get the stream, a burden of closing it lies on one's shoulders as well.
+	 * </p>
+	 * 
+	 * @param product owner of the public key to be read
+	 * @return never {@code null}, fresh and ready to be used input stream from
+	 *         content of the public key file
+	 * @throws LicensingException in case of any infrastructure misbehavior or
+	 *                            detected content discrepancy.
+	 */
+	InputStream productPublicKey(LicensedProduct product) throws LicensingException;
+
+}

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeper.java
@@ -31,19 +31,18 @@ import org.eclipse.passage.lic.internal.api.registry.Service;
 public interface KeyKeeper extends Service<LicensedProduct> {
 	/**
 	 * <p>
-	 * Constructs new input stream for the given {@code product}'s public key
-	 * reading.
+	 * Constructs new input stream to read the public key of a {@code product}
+	 * configured for the keeper.
 	 * </p>
 	 * <p>
 	 * Ones get the stream, a burden of closing it lies on one's shoulders as well.
 	 * </p>
 	 * 
-	 * @param product owner of the public key to be read
 	 * @return never {@code null}, fresh and ready to be used input stream from
 	 *         content of the public key file
 	 * @throws LicensingException in case of any infrastructure misbehavior or
 	 *                            detected content discrepancy.
 	 */
-	InputStream productPublicKey(LicensedProduct product) throws LicensingException;
+	InputStream productPublicKey() throws LicensingException;
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeperRegistry.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/io/KeyKeeperRegistry.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api.io;
+
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.registry.Registry;
+
+public interface KeyKeeperRegistry extends Supplier<Registry<LicensedProduct, KeyKeeper>> {
+
+}


### PR DESCRIPTION
- new versions of `KeyKeeper` and appropriate registry interfaces are designed in `lic.api` / `internal.api.io`
- previous versions of `api.io` interfaces are deprecated in the favor of ones designed for 1.0 API revision 