### PR TITLE
564419 API revision | conditions | Path condition miner

### DIFF
--- a/bundles/org.eclipse.passage.lbc.equinox/src/org/eclipse/passage/lbc/internal/equinox/conditions/ServerConditionsMiner.java
+++ b/bundles/org.eclipse.passage.lbc.equinox/src/org/eclipse/passage/lbc/internal/equinox/conditions/ServerConditionsMiner.java
@@ -24,11 +24,16 @@ import org.eclipse.passage.lic.api.io.KeyKeeperRegistry;
 import org.eclipse.passage.lic.api.io.StreamCodecRegistry;
 import org.eclipse.passage.lic.base.conditions.PathConditionMiner;
 import org.eclipse.passage.lic.base.io.LicensingPaths;
+import org.eclipse.passage.lic.internal.base.conditions.mining.UserHomeResidentConditions;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;;
 
+/**
+ * @deprecated use {@link UserHomeResidentConditions} instead
+ */
+@Deprecated
 @Component(service = ConditionMiner.class)
 public class ServerConditionsMiner extends PathConditionMiner {
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/PathConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/PathConditionMiner.java
@@ -29,8 +29,13 @@ import org.eclipse.passage.lic.base.LicensingResults;
 import org.eclipse.passage.lic.base.io.LicensingPaths;
 import org.eclipse.passage.lic.base.io.NullKeyKeeper;
 import org.eclipse.passage.lic.base.io.NullStreamCodec;
+import org.eclipse.passage.lic.internal.base.conditions.mining.LocalConditions;
 import org.eclipse.passage.lic.internal.base.i18n.BaseMessages;
 
+/**
+ * @deprecated use {@link LocalConditions}
+ */
+@Deprecated
 public abstract class PathConditionMiner extends BaseConditionMiner {
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/UserHomeResidentConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/UserHomeResidentConditions.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.conditions.mining;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
+import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
+import org.eclipse.passage.lic.internal.base.io.UserHomePath;
+
+/**
+ * Reads all the conditions containing in license files under
+ * {@code user.home}'s {@code .passage} data folder.
+ */
+public final class UserHomeResidentConditions extends LocalConditions {
+
+	public UserHomeResidentConditions(MiningEquipment equipment, Consumer<LicensingException> handler) {
+		super(new StringServiceId("user-home-conditions"), equipment, handler); //$NON-NLS-1$
+	}
+
+	@Override
+	protected Path base() {
+		return new LicensingFolder(new UserHomePath()).get();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/ConfigurationResidentConditions.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/ConfigurationResidentConditions.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.conditions;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
+import org.eclipse.passage.lic.internal.base.conditions.mining.LocalConditions;
+import org.eclipse.passage.lic.internal.base.conditions.mining.MiningEquipment;
+import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
+import org.eclipse.passage.lic.internal.equinox.io.ConfigurationPath;
+
+/**
+ * Reads all the conditions containing in license files under {@code .passage}
+ * settings folder located under the product {@code configuration} directory
+ * (supplied by the eclipse platform).
+ */
+@SuppressWarnings("restriction")
+public final class ConfigurationResidentConditions extends LocalConditions {
+
+	public ConfigurationResidentConditions(MiningEquipment equipment, Consumer<LicensingException> handler) {
+		super(new StringServiceId("installation-conditions"), equipment, handler); //$NON-NLS-1$
+	}
+
+	@Override
+	protected Path base() {
+		return new LicensingFolder(new ConfigurationPath()).get();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionMinerRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionMinerRegistry.java
@@ -17,10 +17,16 @@ import java.util.Map;
 import org.eclipse.passage.lic.api.conditions.ConditionMiner;
 import org.eclipse.passage.lic.api.conditions.ConditionMinerRegistry;
 import org.eclipse.passage.lic.base.conditions.BaseConditionMinerRegistry;
+import org.eclipse.passage.lic.internal.api.Framework;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
+/**
+ * @deprecated use {@link Framework}-supplied miners registry
+ */
+@SuppressWarnings("restriction")
+@Deprecated
 @Component(service = ConditionMinerRegistry.class)
 public class EquinoxConditionMinerRegistry extends BaseConditionMinerRegistry {
 

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionTransportRegistry.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/EquinoxConditionTransportRegistry.java
@@ -17,10 +17,16 @@ import java.util.Map;
 import org.eclipse.passage.lic.api.conditions.ConditionTransport;
 import org.eclipse.passage.lic.api.conditions.ConditionTransportRegistry;
 import org.eclipse.passage.lic.base.conditions.BaseConditionTransportRegistry;
+import org.eclipse.passage.lic.internal.api.Framework;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
+/**
+ * @deprecated use {@link Framework}-supplied transport registry
+ */
+@SuppressWarnings("restriction")
+@Deprecated
 @Component
 public class EquinoxConditionTransportRegistry extends BaseConditionTransportRegistry
 		implements ConditionTransportRegistry {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallLocationConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallLocationConditionMiner.java
@@ -26,6 +26,10 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
+/**
+ * @deprecated use {@link InstallationResidentConditions}
+ */
+@Deprecated
 @Component(service = ConditionMiner.class)
 public class InstallLocationConditionMiner extends PathConditionMiner {
 

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallationResidentConditions.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/InstallationResidentConditions.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.conditions;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
+import org.eclipse.passage.lic.internal.base.conditions.mining.LocalConditions;
+import org.eclipse.passage.lic.internal.base.conditions.mining.MiningEquipment;
+import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
+import org.eclipse.passage.lic.internal.equinox.io.InstallationPath;
+
+/**
+ * Reads all the conditions containing in license files under {@code .passage}
+ * settings folder located under the product installation directory (supplied by
+ * the eclipse platform).
+ */
+@SuppressWarnings("restriction")
+public final class InstallationResidentConditions extends LocalConditions {
+
+	public InstallationResidentConditions(MiningEquipment equipment, Consumer<LicensingException> handler) {
+		super(new StringServiceId("installation-conditions"), equipment, handler); //$NON-NLS-1$
+	}
+
+	@Override
+	protected Path base() {
+		return new LicensingFolder(new InstallationPath()).get();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/UserHomeConditionMiner.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/conditions/UserHomeConditionMiner.java
@@ -24,12 +24,17 @@ import org.eclipse.passage.lic.api.io.KeyKeeperRegistry;
 import org.eclipse.passage.lic.api.io.StreamCodecRegistry;
 import org.eclipse.passage.lic.base.conditions.PathConditionMiner;
 import org.eclipse.passage.lic.base.io.LicensingPaths;
+import org.eclipse.passage.lic.internal.base.conditions.mining.UserHomeResidentConditions;
 import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
 import org.eclipse.passage.lic.internal.base.io.UserHomePath;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
+/**
+ * @deprecated use {@link UserHomeResidentConditions}
+ */
+@Deprecated
 @SuppressWarnings("restriction")
 @Component(service = ConditionMiner.class)
 public class UserHomeConditionMiner extends PathConditionMiner {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
@@ -17,12 +17,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 
+import org.eclipse.passage.lic.api.tests.fakes.FakeConditionTransport;
 import org.eclipse.passage.lic.api.tests.fakes.FakeKeyKeeper;
 import org.eclipse.passage.lic.api.tests.fakes.FakeMinedConditions;
 import org.eclipse.passage.lic.api.tests.fakes.FakeResolvedRequirements;
 import org.eclipse.passage.lic.api.tests.fakes.FakeStreamCodec;
 import org.eclipse.passage.lic.internal.api.AccessCycleConfiguration;
 import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
 import org.eclipse.passage.lic.internal.api.registry.Registry;
 import org.eclipse.passage.lic.internal.api.registry.Service;
 import org.eclipse.passage.lic.internal.api.registry.ServiceId;
@@ -103,7 +105,7 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void keepsPublicKeyForProduct() {
+	public final void hasKeyKeepers() {
 		assertServiceRegistryIsFunctional(config().keyKeepers().get());
 	}
 
@@ -118,8 +120,28 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void keepsKepForProduct() {
+	public final void keepsKeyForProduct() {
 		assertTrue(config().keyKeepers().get().hasService(framework().get().product()));
+	}
+
+	@Test
+	public final void hasConditionTransports() {
+		assertServiceRegistryIsFunctional(config().transports().get());
+	}
+
+	@Test
+	public final void prohibitsConditionTransportServicesExtension() {
+		assertTrue(readOnly(config().transports().get()));
+	}
+
+	@Test
+	public final void prohibitsInjectionIntoConditionTransportServices() {
+		assertServiceInjectionsIsProhibited(config().transports().get(), new FakeConditionTransport());
+	}
+
+	@Test
+	public final void hasTransportForXml() {
+		assertTrue(config().transports().get().hasService(new ContentType.Xml()));
 	}
 
 	private <I extends ServiceId, S extends Service<I>> void assertServiceRegistryIsFunctional(

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/FakeConditionTransport.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/FakeConditionTransport.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.fakes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ConditionTransport;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
+
+@SuppressWarnings("restriction")
+public final class FakeConditionTransport implements ConditionTransport {
+
+	@Override
+	public ContentType id() {
+		return new ContentType.Of("application/test"); //$NON-NLS-1$
+	}
+
+	@Override
+	public Collection<Condition> read(InputStream input) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void write(Collection<Condition> conditions, OutputStream output) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/DemoFrameworkContractTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/DemoFrameworkContractTest.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
 /**
  * integration test: required OSGi running
- * @author user
  */
 @SuppressWarnings("restriction")
 public final class DemoFrameworkContractTest extends FrameworkContractTest {


### PR DESCRIPTION
 - reimplement existing local conditions miners (`UserHomeResident`, `InstallationResident` and `ConfigurationResident`)
 - add 'em all to the sealed access cycle configuration
 - deprecate more code covered by 1.0 alternatives
 - more to framework contract test

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>