### PR TITLE
Bug 565011 rebuild the core of condition expression evaluation

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
@@ -36,7 +36,10 @@ import org.eclipse.passage.lic.internal.api.diagnostic.FailureDiagnostic;
  * at all ({@code Emission.failed()}) and then request either permissions or
  * failure details.
  * </p>
- * 
+ * <p>
+ * Any implementation must follow the contract defined in
+ * {@code EmissionContractTest}
+ * </p>
  */
 public interface Emission {
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionEvaluationService.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionEvaluationService.java
@@ -14,6 +14,10 @@ package org.eclipse.passage.lic.internal.api.conditions.evaluation;
 
 import org.eclipse.passage.lic.internal.api.registry.Service;
 
+/**
+ * Any implementation must follow the contract defined in
+ * {@code ExpressionEvaluationServiceContractTest}
+ */
 public interface ExpressionEvaluationService extends Service<ExpressionProtocol> {
 
 	/**

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionParsingService.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionParsingService.java
@@ -14,6 +14,10 @@ package org.eclipse.passage.lic.internal.api.conditions.evaluation;
 
 import org.eclipse.passage.lic.internal.api.registry.Service;
 
+/**
+ * An implementation must follow the contract defined in
+ * {@code ExpressionParsingServiceContractTest}
+ */
 public interface ExpressionParsingService extends Service<ExpressionProtocol> {
 
 	ParsedExpression parsed(String expression) throws ExpressionParsingException;

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpression.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpression.java
@@ -21,12 +21,12 @@ import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionProt
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
 
 @SuppressWarnings("restriction")
-final class SimpleMapExpression implements ParsedExpression {
+public final class SimpleMapExpression implements ParsedExpression {
 
 	private final Map<String, String> checks;
 	private final ExpressionProtocol format;
 
-	SimpleMapExpression(ExpressionProtocol format, Map<String, String> checks) {
+	public SimpleMapExpression(ExpressionProtocol format, Map<String, String> checks) {
 		Objects.requireNonNull(format);
 		Objects.requireNonNull(checks);
 		this.format = format;

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.conditions.evaluation;
 
+import java.util.Objects;
+
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationException;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationService;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionProtocol;
@@ -32,6 +34,9 @@ public final class SimpleMapExpressionEvaluationService implements ExpressionEva
 	@Override
 	public void evaluate(ParsedExpression expression, ExpressionTokenAssessmentService assessor)
 			throws ExpressionEvaluationException {
+		Objects.requireNonNull(expression);
+		Objects.requireNonNull(assessor);
+		verifyProtocol(expression);
 		SimpleMapExpression map = map(expression);
 		for (String key : map.keys()) {
 			boolean passed = equal(key, map.expected(key), assessor);
@@ -56,16 +61,25 @@ public final class SimpleMapExpressionEvaluationService implements ExpressionEva
 
 	private SimpleMapExpression map(ParsedExpression expression) throws ExpressionEvaluationException {
 		if (!SimpleMapExpression.class.isInstance(expression)) {
-			new ExpressionEvaluationException(String.format(ConditionsEvaluationMessages.getString(//
+			throw new ExpressionEvaluationException(String.format(ConditionsEvaluationMessages.getString(//
 					"SimpleMapExpressionEvaluationService.foreign_expression"), // //$NON-NLS-1$
 					expression.protocol()));
 		}
 		SimpleMapExpression map = (SimpleMapExpression) expression;
 		if (map.keys().isEmpty()) {
-			new ExpressionEvaluationException(ConditionsEvaluationMessages.getString(//
+			throw new ExpressionEvaluationException(ConditionsEvaluationMessages.getString(//
 					"SimpleMapExpressionEvaluationService.no_checks")); //$NON-NLS-1$
 		}
 		return map;
+	}
+
+	private void verifyProtocol(ParsedExpression expression) throws ExpressionEvaluationException {
+		if (!id().equals(expression.protocol())) {
+			throw new ExpressionEvaluationException(String.format(
+					ConditionsEvaluationMessages
+							.getString("SimpleMapExpressionEvaluationService.unexpected_expression_protocol"), //$NON-NLS-1$
+					expression.protocol(), id()));
+		}
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
@@ -15,6 +15,7 @@ SimpleMapExpressionEvaluationService.foreign_expression=Expression protocol [%s]
 SimpleMapExpressionEvaluationService.no_checks=Expression is invalid: it contains no checks
 SimpleMapExpressionEvaluationService.segment_fails_evaluation=Expression fails evaluation (type %s) on segment [%s = %s]
 SimpleMapExpressionEvaluationService.evaluation_fails=Expression segment [%s = %s] %s assessment failed with error
+SimpleMapExpressionEvaluationService.unexpected_expression_protocol=Unexpected expression protocol [%s] (should be [%s])
 AndsProtocolExpressionParseService.invalid_format=Segment [%s] is corrupted. Expected to have key=value structure.
 AndsProtocolExpressionParseService.no_checks=Expression [%s] contains no checks. Expected to be of [key=value;...key=value] structure.
 BasePermissionEmittingService.failed=Failed to assess expression [%s] 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/EmissionImplsContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/EmissionImplsContractTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.conditions.evaluation;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermission;
+import org.eclipse.passage.lic.api.tests.fakes.diagnostic.FakeFailureDiagnostic;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Emission;
+
+@SuppressWarnings("restriction")
+public class EmissionImplsContractTest extends EmissionContractTest {
+
+	@Override
+	protected Emission failed() {
+		return new Emission.Failed(new FakeFailureDiagnostic());
+	}
+
+	@Override
+	protected Emission successful() {
+		return new Emission.Successful(new FakePermission());
+	}
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionEvaluationServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionEvaluationServiceContractTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.conditions.evaluation;
+
+import static org.junit.Assert.fail;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionTokenAssessmentService;
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeParsedExpression;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationException;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationService;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionTokenAssessmentService;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public abstract class ExpressionEvaluationServiceContractTest {
+
+	@Test(expected = NullPointerException.class)
+	public final void prohibitsNullExpression() {
+		prohibitsNullArgument(null, new FakeExpressionTokenAssessmentService());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void prohibitsNullAssessor() {
+		prohibitsNullArgument(new FakeParsedExpression(), null);
+	}
+
+	@Test(expected = ExpressionEvaluationException.class)
+	public final void canOnlyEvaluateExpressionOfSameProtocl() throws ExpressionEvaluationException {
+		evaluator().evaluate(new FakeParsedExpression("fake"), //$NON-NLS-1$
+				new FakeExpressionTokenAssessmentService());
+	}
+
+	private void prohibitsNullArgument(ParsedExpression expression, ExpressionTokenAssessmentService assessor) {
+		try {
+			evaluator().evaluate(expression, assessor);
+		} catch (ExpressionEvaluationException e) {
+			fail("No evaluation activity is expected to be started for invalid incoming data"); //$NON-NLS-1$
+		}
+	}
+
+	protected abstract ExpressionEvaluationService evaluator();
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionParsingServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionParsingServiceContractTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.conditions.evaluation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingException;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingService;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public abstract class ExpressionParsingServiceContractTest {
+
+	@Test(expected = ExpressionParsingException.class)
+	public final void blankExpressionCausesFailure() throws ExpressionParsingException {
+		parser().parsed("\t"); //$NON-NLS-1$
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void prohibitsNullExpression() throws ExpressionParsingException {
+		parser().parsed(null);
+	}
+
+	@Test
+	public final void producesSameProtocolResult() {
+		ExpressionParsingService parser = parser();
+		try {
+			assertEquals(parser.id(), parser.parsed(validExpression()).protocol());
+		} catch (ExpressionParsingException e) {
+			fail("Is not expected to fail on valid data"); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	public final void producesResultOfExpectedType() throws ExpressionParsingException {
+		assertTrue(resultType().isInstance(parser().parsed(validExpression())));
+	}
+
+	protected abstract ExpressionParsingService parser();
+
+	protected abstract String validExpression();
+
+	protected abstract Class<? extends ParsedExpression> resultType();
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakeParsedExpression.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakeParsedExpression.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation;
+
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionProtocol;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
+
+@SuppressWarnings("restriction")
+public final class FakeParsedExpression implements ParsedExpression {
+
+	private final ExpressionProtocol protocol;
+
+	public FakeParsedExpression(ExpressionProtocol protocol) {
+		this.protocol = protocol;
+	}
+
+	public FakeParsedExpression(String protocol) {
+		this(new ExpressionProtocol.Of(protocol));
+	}
+
+	public FakeParsedExpression() {
+		this(new ExpressionProtocol.Default());
+	}
+
+	@Override
+	public ExpressionProtocol protocol() {
+		return protocol;
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/AndsProtocolExpressionParseServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/AndsProtocolExpressionParseServiceTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.conditions.evaluation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.eclipse.passage.lic.api.tests.conditions.evaluation.ExpressionParsingServiceContractTest;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingException;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingService;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.AndsProtocolExpressionParseService;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpression;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class AndsProtocolExpressionParseServiceTest extends ExpressionParsingServiceContractTest {
+
+	@Test
+	public void parsesValidData() {
+		try {
+			parser().parsed("a=b"); //$NON-NLS-1$
+		} catch (ExpressionParsingException e) {
+			fail("Is not expected to fial on valid data"); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	public void pasingIsAccurate() throws ExpressionParsingException {
+		SimpleMapExpression parsed = (SimpleMapExpression) parser().parsed("k1=v1;k2=*;"); //$NON-NLS-1$
+		assertEquals("v1", parsed.expected("k1")); //$NON-NLS-1$//$NON-NLS-2$
+		assertEquals("*", parsed.expected("k2")); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	@Test(expected = ExpressionParsingException.class)
+	public void evenSingleCorruptedSegmentFailsParsing() throws ExpressionParsingException {
+		parser().parsed("k1=v1;k2;k3=v3"); //$NON-NLS-1$
+	}
+
+	@Test(expected = ExpressionParsingException.class)
+	public void valueOnlySegmentIsCorrupted() throws ExpressionParsingException {
+		parser().parsed("k1=v1;=v2;k3=v3"); //$NON-NLS-1$
+	}
+
+	@Test(expected = ExpressionParsingException.class)
+	public void mediatorOnlySegmentIsCorrupted() throws ExpressionParsingException {
+		parser().parsed("k1=v1;=;k3=v3"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void allowsWhiteSpaces() throws ExpressionParsingException {
+		SimpleMapExpression parsed = (SimpleMapExpression) parser().parsed("k 1=v 1"); //$NON-NLS-1$
+		assertEquals("v 1", parsed.expected("k 1")); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	@Test
+	public void keysAndValuesAreTrimmed() throws ExpressionParsingException {
+		SimpleMapExpression parsed = (SimpleMapExpression) parser().parsed(" k\n= v\t"); //$NON-NLS-1$
+		assertEquals("v", parsed.expected("k")); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	@Override
+	protected ExpressionParsingService parser() {
+		return new AndsProtocolExpressionParseService();
+	}
+
+	@Override
+	protected String validExpression() {
+		return "a=b;c=*;d=1 2"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected Class<? extends ParsedExpression> resultType() {
+		return SimpleMapExpression.class;
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.conditions.evaluation;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.FakeCondition;
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.base.BaseLicensedProduct;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.BasePermission;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class BasePermissionTest {
+
+	@Test(expected = NullPointerException.class)
+	public void productIsMandatory() {
+		new BasePermission(null, condition(), ZonedDateTime.now(), ZonedDateTime.now().plusDays(1));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void conditionIsMandatory() {
+		new BasePermission(product(), null, ZonedDateTime.now(), ZonedDateTime.now().plusDays(1));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void leaseDateIsMandatory() {
+		new BasePermission(product(), condition(), null, ZonedDateTime.now());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void expirationDateIsMandatory() {
+		new BasePermission(product(), condition(), ZonedDateTime.now(), null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void expiredAfterLeasing() {
+		new BasePermission(product(), condition(), ZonedDateTime.now().plusDays(1), ZonedDateTime.now());
+	}
+
+	private LicensedProduct product() {
+		return new BaseLicensedProduct("t", "v"); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	private Condition condition() {
+		return new FakeCondition();
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SimpleMapExpressionEvaluationServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SimpleMapExpressionEvaluationServiceTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.conditions.evaluation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.api.tests.conditions.evaluation.ExpressionEvaluationServiceContractTest;
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionTokenAssessmentService;
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeParsedExpression;
+import org.eclipse.passage.lic.internal.api.conditions.EvaluationType;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationException;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationService;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionProtocol;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionTokenAssessmentService;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpression;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpressionEvaluationService;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class SimpleMapExpressionEvaluationServiceTest extends ExpressionEvaluationServiceContractTest {
+
+	@Override
+	protected ExpressionEvaluationService evaluator() {
+		return new SimpleMapExpressionEvaluationService();
+	}
+
+	@Test(expected = ExpressionEvaluationException.class)
+	public void failureOnUnexpectedExpression() throws ExpressionEvaluationException {
+		evaluator().evaluate(new FakeParsedExpression(), new FakeExpressionTokenAssessmentService());
+
+	}
+
+	@Test(expected = ExpressionEvaluationException.class)
+	public void segmantFailureIsContagious() throws ExpressionEvaluationException {
+		Biased assessor = new Biased()//
+				.withAnswer("ok", true) //$NON-NLS-1$
+				.withAnswer("nok", false); //$NON-NLS-1$
+		try {
+
+			evaluator().evaluate(//
+					expression(//
+							new String[] { "ok", "!1" }, //$NON-NLS-1$//$NON-NLS-2$
+							new String[] { "nok", "?!" }), //$NON-NLS-1$//$NON-NLS-2$
+					assessor);
+		} catch (ExpressionEvaluationException e) {
+			assertTrue(assessor.asked.size() >= 1);
+			throw e;
+		}
+	}
+
+	@Test(expected = ExpressionEvaluationException.class)
+	public void failOnEmptyExpression() throws ExpressionEvaluationException {
+		evaluator().evaluate(expression(), new FakeExpressionTokenAssessmentService());
+	}
+
+	@Test
+	public void canSucceed() {
+		Biased assessor = new Biased()//
+				.withAnswer("ok1", true) //$NON-NLS-1$
+				.withAnswer("ok2", true); //$NON-NLS-1$
+		try {
+			evaluator().evaluate(//
+					expression(//
+							new String[] { "ok1", ":)" }, //$NON-NLS-1$//$NON-NLS-2$
+							new String[] { "ok2", ":)" }), //$NON-NLS-1$//$NON-NLS-2$
+					assessor);
+		} catch (ExpressionEvaluationException e) {
+			fail("Intended to succeed"); //$NON-NLS-1$
+		}
+		assertEquals(2, assessor.asked.size()); // each key is asked
+	}
+
+	private SimpleMapExpression expression(String[]... pairs) {
+		return new SimpleMapExpression(//
+				new ExpressionProtocol.Ands(), // $NON-NLS-1$
+				Arrays.stream(pairs) //
+						.collect(Collectors.<String[], String, String>toMap(pair -> pair[0], pair -> pair[1])));
+	}
+
+	private static final class Biased implements ExpressionTokenAssessmentService {
+		private final Map<String, Boolean> answers = new HashMap<>();
+		private final Set<String> asked = new HashSet<>();
+
+		Biased withAnswer(String key, boolean answer) {
+			answers.put(key, answer);
+			return this;
+		}
+
+		@Override
+		public EvaluationType id() {
+			return new EvaluationType.Of("biased"); //$NON-NLS-1$
+		}
+
+		@Override
+		public boolean equal(String key, String value) throws ExpressionEvaluationException {
+			asked.add(key);
+			return answers.containsKey(key) ? answers.get(key) : false;
+		}
+
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SumOfEmissionsTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SumOfEmissionsTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.conditions.evaluation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermission;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Emission;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Emission.Failed;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Emission.Successful;
+import org.eclipse.passage.lic.internal.api.diagnostic.TroubleCode;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.SumOfEmissions;
+import org.eclipse.passage.lic.internal.base.diagnostic.BaseFailureDiagnostic;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class SumOfEmissionsTest {
+
+	@Test
+	public void sumOfSuccessesIsSuccess() {
+		assertFalse(new SumOfEmissions().apply(success(), success()).failed());
+	}
+
+	@Test
+	public void sumOfSuccessesAndFailureIsFailure() {
+		assertTrue(new SumOfEmissions().apply(success(), failure()).failed());
+	}
+
+	@Test
+	public void sumOfFailureAndSuccessIsFailure() {
+		assertTrue(new SumOfEmissions().apply(failure(), success()).failed());
+	}
+
+	@Test
+	public void sumOfFailuresIsFailure() {
+		assertTrue(new SumOfEmissions().apply(failure(), failure()).failed());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void prohibitsNullFirstOperand() {
+		new SumOfEmissions().apply(null, success());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void prohibitsNullSecondOperand() {
+		new SumOfEmissions().apply(success(), null);
+	}
+
+	@Test
+	public void sumsPermissions() {
+		assertEquals(2, //
+				new SumOfEmissions().apply(//
+						new Emission.Successful(new FakePermission()), //
+						new Emission.Successful(new FakePermission()))//
+						.permissions().size());
+	}
+
+	@Test
+	public void sumsDiagnostics() {
+		assertEquals(2, new SumOfEmissions().apply(failure(), failure()).failureDiagnostic().troubles().size());
+	}
+
+	private Successful success() {
+		return new Emission.Successful(Collections.emptyList());
+	}
+
+	private Failed failure() {
+		return new Emission.Failed(new BaseFailureDiagnostic(new TroubleCode.Of(0, "0"), "")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+}


### PR DESCRIPTION
 Start covering `conditions.evaluation` with tests.

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>