### PR TITLE
565113 include org.eclipse.passage.demo.feature into the product

### DIFF
--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ConditionMiningServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ConditionMiningServicesRegitryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.mining.FakeMinedConditions;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.mining.MinedConditions;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of condition mining service.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class ConditionMiningServicesRegitryTest extends ReadOnlyCollectionTest<MinedConditions> {
+
+	@Override
+	protected final Supplier<Collection<MinedConditions>> collection() {
+		return () -> framework().get().accessCycleConfiguration().conditionMiners().get().services();
+	}
+
+	@Override
+	protected final MinedConditions single() {
+		return new FakeMinedConditions();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ConditionTransportServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ConditionTransportServicesRegitryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.io.FakeConditionTransport;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ConditionTransport;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of condition transport services.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class ConditionTransportServicesRegitryTest extends ReadOnlyCollectionTest<ConditionTransport> {
+
+	@Override
+	protected final Supplier<Collection<ConditionTransport>> collection() {
+		return () -> framework().get().accessCycleConfiguration().transports().get().services();
+	}
+
+	@Override
+	protected final ConditionTransport single() {
+		return new FakeConditionTransport();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionEvaluationServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionEvaluationServicesRegitryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionEvaluationService;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionEvaluationService;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of condition expression evaluation service.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class ExpressionEvaluationServicesRegitryTest
+		extends ReadOnlyCollectionTest<ExpressionEvaluationService> {
+
+	@Override
+	protected final Supplier<Collection<ExpressionEvaluationService>> collection() {
+		return () -> framework().get().accessCycleConfiguration().expressionEvaluators().get().services();
+	}
+
+	@Override
+	protected final ExpressionEvaluationService single() {
+		return new FakeExpressionEvaluationService();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionParsingServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionParsingServicesRegitryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionParsingService;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingService;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of condition expression parsing services.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class ExpressionParsingServicesRegitryTest extends ReadOnlyCollectionTest<ExpressionParsingService> {
+
+	@Override
+	protected final Supplier<Collection<ExpressionParsingService>> collection() {
+		return () -> framework().get().accessCycleConfiguration().expressionParsers().get().services();
+	}
+
+	@Override
+	protected final ExpressionParsingService single() {
+		return new FakeExpressionParsingService();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionTokenAssessmentServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ExpressionTokenAssessmentServicesRegitryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionTokenAssessmentService;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionTokenAssessmentService;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of condition expression token assessment services.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class ExpressionTokenAssessmentServicesRegitryTest
+		extends ReadOnlyCollectionTest<ExpressionTokenAssessmentService> {
+
+	@Override
+	protected final Supplier<Collection<ExpressionTokenAssessmentService>> collection() {
+		return () -> framework().get().accessCycleConfiguration().expressionAssessors().get().services();
+	}
+
+	@Override
+	protected final ExpressionTokenAssessmentService single() {
+		return new FakeExpressionTokenAssessmentService();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
@@ -17,14 +17,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 
-import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionEvaluationService;
-import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeConditionExpressionParser;
-import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionTokenAssessmentService;
-import org.eclipse.passage.lic.api.tests.fakes.conditions.mining.FakeMinedConditions;
-import org.eclipse.passage.lic.api.tests.fakes.io.FakeConditionTransport;
-import org.eclipse.passage.lic.api.tests.fakes.io.FakeKeyKeeper;
-import org.eclipse.passage.lic.api.tests.fakes.io.FakeStreamCodec;
-import org.eclipse.passage.lic.api.tests.fakes.requirements.FakeResolvedRequirements;
 import org.eclipse.passage.lic.internal.api.AccessCycleConfiguration;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionProtocol;
@@ -70,11 +62,6 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void prohibitsInjectionIntoRequirementResolutionServices() {
-		assertServiceInjectionsIsProhibited(config().requirementResolvers().get(), new FakeResolvedRequirements());
-	}
-
-	@Test
 	public final void canMineConditions() {
 		assertServiceRegistryIsFunctional(config().conditionMiners().get());
 	}
@@ -85,11 +72,6 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void prohibitsInjectionIntoConditionMiningServices() {
-		assertServiceInjectionsIsProhibited(config().conditionMiners().get(), new FakeMinedConditions());
-	}
-
-	@Test
 	public final void canEncodeAndDecodeStreams() {
 		assertServiceRegistryIsFunctional(config().codecs().get());
 	}
@@ -97,11 +79,6 @@ public abstract class FrameworkContractTest {
 	@Test
 	public final void prohibitsStreamCodecServicesExtension() {
 		assertTrue(readOnly(config().codecs().get()));
-	}
-
-	@Test
-	public final void prohibitsInjectionIntoStreamCodecServices() {
-		assertServiceInjectionsIsProhibited(config().codecs().get(), new FakeStreamCodec());
 	}
 
 	@Test
@@ -120,11 +97,6 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void prohibitsInjectionIntoKeyKeeperServices() {
-		assertServiceInjectionsIsProhibited(config().keyKeepers().get(), new FakeKeyKeeper());
-	}
-
-	@Test
 	public final void keepsKeyForProduct() {
 		assertTrue(config().keyKeepers().get().hasService(framework().get().product()));
 	}
@@ -137,11 +109,6 @@ public abstract class FrameworkContractTest {
 	@Test
 	public final void prohibitsConditionTransportServicesExtension() {
 		assertTrue(readOnly(config().transports().get()));
-	}
-
-	@Test
-	public final void prohibitsInjectionIntoConditionTransportServices() {
-		assertServiceInjectionsIsProhibited(config().transports().get(), new FakeConditionTransport());
 	}
 
 	@Test
@@ -160,11 +127,6 @@ public abstract class FrameworkContractTest {
 	}
 
 	@Test
-	public final void prohibitsInjectionIntoExpressionParseServices() {
-		assertServiceInjectionsIsProhibited(config().expressionParsers().get(), new FakeConditionExpressionParser());
-	}
-
-	@Test
 	public final void hasParserForDefaultExpressionFormat() {
 		assertTrue(config().expressionParsers().get().hasService(new ExpressionProtocol.Default()));
 	}
@@ -177,12 +139,6 @@ public abstract class FrameworkContractTest {
 	@Test
 	public final void prohibitsExpressionEvaluationServicesExtension() {
 		assertTrue(readOnly(config().expressionEvaluators().get()));
-	}
-
-	@Test
-	public final void prohibitsInjectionIntoExpressionEvaluationServices() {
-		assertServiceInjectionsIsProhibited(config().expressionEvaluators().get(),
-				new FakeExpressionEvaluationService());
 	}
 
 	@Test
@@ -201,29 +157,11 @@ public abstract class FrameworkContractTest {
 		assertTrue(readOnly(config().expressionAssessors().get()));
 	}
 
-	@Test
-	public final void prohibitsInjectionIntoSegmentAssessmentServices() {
-		assertServiceInjectionsIsProhibited(config().expressionAssessors().get(),
-				new FakeExpressionTokenAssessmentService());
-	}
-
 	private <I extends ServiceId, S extends Service<I>> void assertServiceRegistryIsFunctional(
 			Registry<I, S> registry) {
 		assertNotNull(registry);
 		assertNotNull(registry.services());
 		assertTrue(registry.services().size() > 0);
-	}
-
-	private <I extends ServiceId, S extends Service<I>> void assertServiceInjectionsIsProhibited(
-			Registry<I, S> registry, S intruder) {
-		int before = registry.services().size();
-		try {
-			registry.services().add(intruder);
-		} catch (UnsupportedOperationException unsupported) {
-			// then (hooray! unsupported! no injections!)
-			return;
-		}
-		assertTrue(before == registry.services().size());
 	}
 
 	private AccessCycleConfiguration config() {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/KeyKeepersRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/KeyKeepersRegitryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.io.FakeKeyKeeper;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.io.KeyKeeper;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of public key keepers.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class KeyKeepersRegitryTest extends ReadOnlyCollectionTest<KeyKeeper> {
+
+	@Override
+	protected final Supplier<Collection<KeyKeeper>> collection() {
+		return () -> framework().get().accessCycleConfiguration().keyKeepers().get().services();
+	}
+
+	@Override
+	protected final KeyKeeper single() {
+		return new FakeKeyKeeper();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/PermissionEmittingServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/PermissionEmittingServicesRegitryTest.java
@@ -16,14 +16,14 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lic.api.tests.fakes.requirements.FakeResolvedRequirements;
+import org.eclipse.passage.lic.api.tests.fakes.io.FakeStreamCodec;
 import org.eclipse.passage.lic.internal.api.Framework;
-import org.eclipse.passage.lic.internal.api.requirements.ResolvedRequirements;
+import org.eclipse.passage.lic.internal.api.io.StreamCodec;
 
 /**
  * <p>
  * Check that {@linkplain Framework} instance in use supplies read only
- * collection of requirement resolution services.
+ * collection of sream codecs.
  * </p>
  * <p>
  * Each {@code Framework} implementation must extend this class and satisfy all
@@ -31,16 +31,16 @@ import org.eclipse.passage.lic.internal.api.requirements.ResolvedRequirements;
  * </p>
  */
 @SuppressWarnings("restriction")
-public abstract class FrameworkRequirementResolutionServiceTest extends ReadOnlyCollectionTest<ResolvedRequirements> {
+public abstract class PermissionEmittingServicesRegitryTest extends ReadOnlyCollectionTest<StreamCodec> {
 
 	@Override
-	protected final Supplier<Collection<ResolvedRequirements>> collection() {
-		return () -> framework().get().accessCycleConfiguration().requirementResolvers().get().services();
+	protected final Supplier<Collection<StreamCodec>> collection() {
+		return () -> framework().get().accessCycleConfiguration().codecs().get().services();
 	}
 
 	@Override
-	protected final ResolvedRequirements single() {
-		return new FakeResolvedRequirements();
+	protected final StreamCodec single() {
+		return new FakeStreamCodec();
 	}
 
 	protected abstract Optional<Framework> framework();

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/RequirementResolutionServicesRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/RequirementResolutionServicesRegitryTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermissionEmittingService;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.PermissionEmittingService;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of permission emission services.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class RequirementResolutionServicesRegitryTest
+		extends ReadOnlyCollectionTest<PermissionEmittingService> {
+
+	@Override
+	protected final Supplier<Collection<PermissionEmittingService>> collection() {
+		return () -> framework().get().accessCycleConfiguration().permissionEmitters().get().services();
+	}
+
+	@Override
+	protected final PermissionEmittingService single() {
+		return new FakePermissionEmittingService();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/StreamCodecsRegitryTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/StreamCodecsRegitryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.tests.fakes.io.FakeStreamCodec;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.io.StreamCodec;
+
+/**
+ * <p>
+ * Check that {@linkplain Framework} instance in use supplies read only
+ * collection of sream codecs.
+ * </p>
+ * <p>
+ * Each {@code Framework} implementation must extend this class and satisfy all
+ * the demands.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public abstract class StreamCodecsRegitryTest extends ReadOnlyCollectionTest<StreamCodec> {
+
+	@Override
+	protected final Supplier<Collection<StreamCodec>> collection() {
+		return () -> framework().get().accessCycleConfiguration().codecs().get().services();
+	}
+
+	@Override
+	protected final StreamCodec single() {
+		return new FakeStreamCodec();
+	}
+
+	protected abstract Optional<Framework> framework();
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakeExpressionParsingService.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakeExpressionParsingService.java
@@ -18,7 +18,7 @@ import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionPars
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
 
 @SuppressWarnings("restriction")
-public final class FakeConditionExpressionParser implements ExpressionParsingService {
+public final class FakeExpressionParsingService implements ExpressionParsingService {
 
 	@Override
 	public ExpressionProtocol id() {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakePermissionEmittingService.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/evaluation/FakePermissionEmittingService.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation;
+
+import java.util.Collection;
+
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.conditions.Condition;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Emission;
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.PermissionEmittingService;
+import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
+
+@SuppressWarnings("restriction")
+public final class FakePermissionEmittingService implements PermissionEmittingService {
+
+	@Override
+	public StringServiceId id() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Emission emit(Collection<Condition> conditions, LicensedProduct product) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedCodecsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedCodecsRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.StreamCodecsRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedCodecsRegistryTest extends StreamCodecsRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedConitionMiningServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedConitionMiningServicesRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.RequirementResolutionServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedConitionMiningServicesRegistryTest extends RequirementResolutionServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionEvaluatorsServiceRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionEvaluatorsServiceRegistryTest.java
@@ -10,16 +10,16 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.seal.demo.tests;
+package org.eclipse.passage.seal.demo.tests.registries;
 
 import java.util.Optional;
 
-import org.eclipse.passage.lic.api.tests.FrameworkRequirementResolutionServiceTest;
+import org.eclipse.passage.lic.api.tests.ExpressionParsingServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
 @SuppressWarnings("restriction")
-public final class DemoFrameworkRequirementResolutionServiceTest extends FrameworkRequirementResolutionServiceTest {
+public final class SealedExpressionEvaluatorsServiceRegistryTest extends ExpressionParsingServicesRegitryTest {
 
 	@Override
 	protected Optional<Framework> framework() {

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionParsersRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionParsersRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.ExpressionParsingServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedExpressionParsersRegistryTest extends ExpressionParsingServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedKeyKeepersRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedKeyKeepersRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.KeyKeepersRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedKeyKeepersRegistryTest extends KeyKeepersRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionEmttingServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionEmttingServicesRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.PermissionEmittingServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedPermissionEmttingServicesRegistryTest extends PermissionEmittingServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRequirementsResolutionServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRequirementsResolutionServicesRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.ConditionMiningServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedRequirementsResolutionServicesRegistryTest extends ConditionMiningServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTokenAssessorsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTokenAssessorsRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.ExpressionTokenAssessmentServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedTokenAssessorsRegistryTest extends ExpressionTokenAssessmentServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTransportsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTransportsRegistryTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.demo.tests.registries;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.tests.ConditionTransportServicesRegitryTest;
+import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
+
+@SuppressWarnings("restriction")
+public final class SealedTransportsRegistryTest extends ConditionTransportServicesRegitryTest {
+
+	@Override
+	protected Optional<Framework> framework() {
+		return new DemoFrameworkSupplier().get();
+	}
+
+}


### PR DESCRIPTION
Rework and replenish test set for sealed access cycle configuration

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>