### PR TITLE
Bug 565152 reimplement base permission examiner

### DIFF
--- a/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
@@ -22,4 +22,5 @@ Export-Package: org.eclipse.passage.lic.api.tests;x-internal:=true,
  org.eclipse.passage.lic.api.tests.fakes.requirements;x-internal:=true,
  org.eclipse.passage.lic.api.tests.inspection;x-internal:=true,
  org.eclipse.passage.lic.api.tests.registry;x-internal:=true,
+ org.eclipse.passage.lic.api.tests.resrictions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.version;x-internal:=true

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/resrictions/PermissionsExaminationServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/resrictions/PermissionsExaminationServiceContractTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.resrictions;
+
+import java.util.Collections;
+
+import org.eclipse.passage.lic.api.tests.fakes.conditions.FakeLicensedProduct;
+import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermission;
+import org.eclipse.passage.lic.api.tests.fakes.requirements.FakeRequirement;
+import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public abstract class PermissionsExaminationServiceContractTest {
+
+	@Test(expected = NullPointerException.class)
+	public void prohibitsNullRequirements() {
+		examiner().examine(null, Collections.singleton(new FakePermission()), new FakeLicensedProduct());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void prohibitsNullPermissions() {
+		examiner().examine(Collections.singleton(new FakeRequirement()), null, new FakeLicensedProduct());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void prohibitsNullProduct() {
+		examiner().examine(Collections.singleton(new FakeRequirement()), Collections.singleton(new FakePermission()),
+				null);
+	}
+
+	protected abstract PermissionsExaminationService examiner();
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/requirements/restrictions/BasePermissionsExaminationServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/requirements/restrictions/BasePermissionsExaminationServiceTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.base.tests.requirements.restrictions;
+package org.eclipse.passage.lic.internal.base.tests.restrictions;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.passage.lic.api.tests.fakes.conditions.FakeLicensedProduct;
+import org.eclipse.passage.lic.api.tests.resrictions.PermissionsExaminationServiceContractTest;
 import org.eclipse.passage.lic.internal.api.diagnostic.code.LicenseInvalid;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
 import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
@@ -28,7 +29,7 @@ import org.eclipse.passage.lic.internal.base.restrictions.BasePermissionsExamina
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-public final class BasePermissionsExaminationServiceTest {
+public final class BasePermissionsExaminationServiceTest extends PermissionsExaminationServiceContractTest {
 
 	@Test
 	public void detectsSingleRequirementSatisfaction() {
@@ -103,26 +104,8 @@ public final class BasePermissionsExaminationServiceTest {
 		assertTrue(restrictions.isEmpty());
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void prohibitsNullRequirements() {
-		TestState state = new TestState();
-		examiner().examine(null, Collections.singleton(state.permissionFirst()), state.product());
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void prohibitsNullPermissions() {
-		TestState state = new TestState();
-		examiner().examine(Collections.singleton(state.requirementFirst()), null, state.product());
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void prohibitsNullProduct() {
-		TestState state = new TestState();
-		examiner().examine(Collections.singleton(state.requirementFirst()),
-				Collections.singleton(state.permissionFirst()), null);
-	}
-
-	private PermissionsExaminationService examiner() {
+	@Override
+	protected PermissionsExaminationService examiner() {
 		return new BasePermissionsExaminationService();
 	}
 

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/requirements/restrictions/TestState.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/requirements/restrictions/TestState.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.base.tests.requirements.restrictions;
+package org.eclipse.passage.lic.internal.base.tests.restrictions;
 
 import java.time.ZonedDateTime;
 


### PR DESCRIPTION
 - place tests to proper folder
 - extract part of test expectations as contract demands

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>