### PR TITLE
Bug 565248 OSHI hw inspector fails on Linux-based virtual machines

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/tobemoved/State.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/tobemoved/State.java
@@ -113,7 +113,7 @@ final class State {
 			SystemInfo system = new SystemInfo();
 			readOS(system.getOperatingSystem());
 			readHal(system.getHardware());
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			throw new LicensingException(AssessmentMessages.State_error_reading_hw, e);
 		}
 	}


### PR DESCRIPTION
 - any kind of trouble, including errors, are caught during oshi-library invocation.

 Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>