### PR TITLE
Bug 565248 OSHI hw inspector fails on Linux-based virtual machines

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/tobemoved/HardwareEnvironment.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/tobemoved/HardwareEnvironment.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.oshi.tobemoved;
 
+import java.util.Objects;
+
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.conditions.EvaluationType;
 import org.eclipse.passage.lic.internal.api.inspection.EnvironmentProperty;
@@ -40,6 +42,8 @@ public final class HardwareEnvironment implements RuntimeEnvironment {
 
 	@Override
 	public boolean isAssuptionTrue(EnvironmentProperty property, String assumption) throws LicensingException {
+		Objects.requireNonNull(property, "HardwareEnvironment::isAssuptionTrue::property"); //$NON-NLS-1$
+		Objects.requireNonNull(assumption, "HardwareEnvironment::isAssuptionTrue::assumption"); //$NON-NLS-1$
 		return freshState().hasValue(property, assumption);
 	}
 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
@@ -44,7 +44,7 @@ public abstract class RuntimeEnvironmentContractTest {
 		try {
 			assertFalse(environment().isAssuptionTrue(property(), invalidPropertyValue()));
 		} catch (LicensingException e) {
-			// possible due to severe environment denials
+			assumeNoException(e); // skip the test in the case of environment denial
 		}
 	}
 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNoException;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +44,7 @@ public abstract class RuntimeEnvironmentContractTest {
 		try {
 			assertFalse(environment().isAssuptionTrue(property(), invalidPropertyValue()));
 		} catch (LicensingException e) {
-			fail("Is not supposed to fail on valid data"); //$NON-NLS-1$
+			// possible due to severe environment denials
 		}
 	}
 
@@ -70,7 +71,7 @@ public abstract class RuntimeEnvironmentContractTest {
 		try {
 			assertTrue(environment().isAssuptionTrue(property(), "*"));//$NON-NLS-1$
 		} catch (LicensingException e) {
-			fail("Is not supposed to fail on valid data"); //$NON-NLS-1$
+			assumeNoException(e); // skip the test in the case of environment denial
 		}
 	}
 
@@ -81,7 +82,7 @@ public abstract class RuntimeEnvironmentContractTest {
 			assertNotNull(state);
 			assertFalse(state.trim().isEmpty());
 		} catch (LicensingException e) {
-			fail("In not intended to fail"); //$NON-NLS-1$
+			assumeNoException(e); // skip the test in the case of environment denial
 		}
 	}
 
@@ -104,7 +105,7 @@ public abstract class RuntimeEnvironmentContractTest {
 			readySteadyGo.countDown(); // and now trigger'em all to ddos the env
 			done.await(); // and just wait until each of'em finish
 		} catch (InterruptedException e) {
-			fail("Test has been interrupted"); //$NON-NLS-1$
+			assumeNoException(e); // skip the test then: further checks will fail
 		}
 
 		// then: all of'em succeed


### PR DESCRIPTION
 - skip positive tests on environment denials
 - fix null-protective tests

 Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>