### PR TITLE
Bug 565318 - [Passage] pack200:normalize cannot be called for signed jar

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.ldc.pde.ui.templates;singleton:=true
-Bundle-Version: 0.5.200.qualifier
+Bundle-Version: 0.5.300.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.passage.ldc.internal.pde.ui.templates;x-internal:=true,
  org.eclipse.passage.ldc.internal.pde.ui.templates.i18n;x-internal:=true

--- a/bundles/org.eclipse.passage.ldc/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.ldc
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.ldc;singleton:=true
-Bundle-Version: 0.5.300.qualifier
+Bundle-Version: 0.5.400.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.features.e4.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.features.e4.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.passage.lic.features.e4.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.lic.features.e4.ui;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.passage.lic.licenses.e4.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.licenses.e4.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.passage.lic.licenses.e4.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.lic.licenses.e4.ui;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.passage.lic.products.e4.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.products.e4.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.passage.lic.products.e4.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.lic.products.e4.ui;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.passage.lic.users.e4.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.users.e4.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.passage.lic.users.e4.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.lic.users.e4.ui;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 0.5.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
Bumped version for the bunldes to remove this unpredictable distortion
* org.eclipse.passage.lic.features.e4.ui
* org.eclipse.passage.lic.products.e4.ui
* org.eclipse.passage.lic.users.e4.ui
* org.eclipse.passage.lic.licenses.e4.ui
* org.eclipse.passage.ldc.pde.ui.templates
* org.eclipse.passage.ldc

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>