### PR TITLE
[Passage] fix build failing caused by javax.activation removal

### DIFF
--- a/bundles/org.eclipse.passage.lic.mail/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.mail/META-INF/MANIFEST.MF
@@ -7,9 +7,10 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: javax.mail;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="0.0.0",
+Require-Bundle: javax.activation;bundle-version="0.0.0",
+ javax.mail;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",
+ org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.email;bundle-version="0.0.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.internal.mail;x-internal=true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
added dependency to manifest

Signed-off-by: Nikifor Fedorov <zelenyhleb@gmail.com>