### PR TITLE
Bug 565153 API revision | permission | observatory

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
@@ -54,8 +54,8 @@ public abstract class Emission {
 	}
 
 	/**
-	 * Must be asked before any information ( permission or failure details) is
-	 * asked for.
+	 * Must be asked before any information permission or failure details) is asked
+	 * for.
 	 */
 	public final boolean successful() {
 		return success;

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/Emission.java
@@ -54,7 +54,7 @@ public abstract class Emission {
 	}
 
 	/**
-	 * Must be asked before any information permission or failure details) is asked
+	 * Must be asked before any information (permission or failure details) is asked
 	 * for.
 	 */
 	public final boolean successful() {

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/ExaminationCertificate.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/ExaminationCertificate.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api.restrictions;
+
+import java.util.Collection;
+
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+
+/**
+ * <p>
+ * {@linkplain Permission}s-against-{@linkplain Requirement}s examination boils
+ * down to the instance of this certificate.
+ * </p>
+ * <p>
+ * During the examinations some of the given {@code requirements} are satisfied,
+ * and some can stay unsatisfied.
+ * </p>
+ * <p>
+ * For the satisfied {@code requirements} here we keep all the
+ * {@code permissions} that participated in this satisfaction. Use
+ * {@code participants()} to get'em.
+ * </p>
+ * <p>
+ * For each unsatisfied {@code requirement} a {@linkplain Restriction} is
+ * produced. Here is {@code restrictions()} method to access these ones.
+ * </p>
+ * <p>
+ * If the examination produced no {@linkplain Restriction}s, then it is treated
+ * as successful ({@code examinationPassed()})
+ */
+public interface ExaminationCertificate {
+
+	boolean examinationPassed();
+
+	Collection<Restriction> restrictions();
+
+	Collection<Permission> participants();
+
+}

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/PermissionsExaminationService.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/PermissionsExaminationService.java
@@ -32,7 +32,7 @@ import org.eclipse.passage.lic.internal.api.requirements.Requirement;
  */
 public interface PermissionsExaminationService extends Service<StringServiceId> {
 
-	Collection<Restriction> examine(Collection<Requirement> requirements, Collection<Permission> permissions,
+	ExaminationCertificate examine(Collection<Requirement> requirements, Collection<Permission> permissions,
 			LicensedProduct product);
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Access.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Access.java
@@ -20,6 +20,7 @@ import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.lic.internal.api.conditions.ConditionPack;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
 import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
 import org.eclipse.passage.lic.internal.api.restrictions.RestrictionLevel;
 
@@ -44,18 +45,15 @@ public final class Access {
 		if (!mining.successful()) {
 			return false;
 		}
-		if (mining.data().isEmpty()) {
+		Collection<Permission> permissions = permissions(mining.data());
+		if (permissions.isEmpty()) {
 			return false;
 		}
-		Collection<Permission> emission = permissions(mining.data());
-		if (emission.isEmpty()) {
-			return false;
-		}
-		ServiceInvocationResult<Collection<Restriction>> examination = restrictions(emission, requirements);
+		ServiceInvocationResult<ExaminationCertificate> examination = restrictions(permissions, requirements);
 		if (!examination.successful()) {
 			return false;
 		}
-		return noSevereRestrictions(examination.data());
+		return noSevereRestrictions(examination.data().restrictions());
 	}
 
 	private Collection<Requirement> requirements(String feature) {
@@ -78,7 +76,7 @@ public final class Access {
 				framework.product()).get();
 	}
 
-	private ServiceInvocationResult<Collection<Restriction>> restrictions(Collection<Permission> permissions,
+	private ServiceInvocationResult<ExaminationCertificate> restrictions(Collection<Permission> permissions,
 			Collection<Requirement> requirements) {
 		return new Restrictions(//
 				framework.accessCycleConfiguration().examinators().get(), //

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Restrictions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Restrictions.java
@@ -14,18 +14,17 @@ package org.eclipse.passage.lic.internal.base.access;
 
 import java.util.Collection;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
 import org.eclipse.passage.lic.internal.api.registry.Registry;
 import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
 import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
-import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
 
 @SuppressWarnings("restriction")
-public final class Restrictions implements Supplier<ServiceInvocationResult<Collection<Restriction>>> {
+public final class Restrictions implements Supplier<ServiceInvocationResult<ExaminationCertificate>> {
 
 	private final Registry<StringServiceId, PermissionsExaminationService> registry;
 	private final Collection<Requirement> requirements;
@@ -41,15 +40,16 @@ public final class Restrictions implements Supplier<ServiceInvocationResult<Coll
 	}
 
 	@Override
-	public ServiceInvocationResult<Collection<Restriction>> get() {
+	public ServiceInvocationResult<ExaminationCertificate> get() {
 		if (registry.services().isEmpty()) {
 			return new ServiceInvocationResult.Error<>();
 		}
 		return new ServiceInvocationResult.Success<>(//
 				registry.services().stream()//
-						.map(service -> service.examine(requirements, permissions, product))//
-						.flatMap(Collection::stream) //
-						.collect(Collectors.toSet()));
+						.map(service -> service.examine(requirements, permissions, product)) //
+						.reduce(new SumOfCertificates()) //
+						.get() // always exists
+		);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/ServiceInvocationResult.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/ServiceInvocationResult.java
@@ -14,7 +14,7 @@ package org.eclipse.passage.lic.internal.base.access;
 
 import java.util.function.BinaryOperator;
 
-public abstract class ServiceInvocationResult<T> {
+abstract class ServiceInvocationResult<T> {
 
 	private final boolean success;
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/SumOfCertificates.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/SumOfCertificates.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.access;
+
+import java.util.function.BinaryOperator;
+
+import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
+import org.eclipse.passage.lic.internal.base.restrictions.BaseExaminationCertificate;
+
+@SuppressWarnings("restriction")
+public final class SumOfCertificates implements BinaryOperator<ExaminationCertificate> {
+
+	@Override
+	public ExaminationCertificate apply(ExaminationCertificate first, ExaminationCertificate second) {
+
+		return new BaseExaminationCertificate(//
+				new SumOfCollections<Permission>().apply(first.participants(), second.participants()), //
+				new SumOfCollections<Restriction>().apply(first.restrictions(), second.restrictions())//
+		);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BaseExaminationCertificate.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BaseExaminationCertificate.java
@@ -10,29 +10,38 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.api.tests.fakes.restrictions;
+package org.eclipse.passage.lic.internal.base.restrictions;
 
 import java.util.Collection;
 
-import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
-import org.eclipse.passage.lic.internal.api.registry.StringServiceId;
-import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
-import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
+import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
 
 @SuppressWarnings("restriction")
-public final class FakePermissionsExaminationService implements PermissionsExaminationService {
+public final class BaseExaminationCertificate implements ExaminationCertificate {
 
-	@Override
-	public StringServiceId id() {
-		throw new UnsupportedOperationException();
+	private final Collection<Permission> participants;
+	private final Collection<Restriction> restrictions;
+
+	public BaseExaminationCertificate(Collection<Permission> participants, Collection<Restriction> restrictions) {
+		this.participants = participants;
+		this.restrictions = restrictions;
 	}
 
 	@Override
-	public ExaminationCertificate examine(Collection<Requirement> requirements, Collection<Permission> permissions,
-			LicensedProduct product) {
-		throw new UnsupportedOperationException();
+	public boolean examinationPassed() {
+		return restrictions.isEmpty();
+	}
+
+	@Override
+	public Collection<Restriction> restrictions() {
+		return restrictions;
+	}
+
+	@Override
+	public Collection<Permission> participants() {
+		return participants;
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxPassage.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxPassage.java
@@ -49,7 +49,7 @@ public final class EquinoxPassage implements Passage {
 		throw new UnsupportedOperationException();
 	}
 
-	Optional<FrameworkSupplier> frameworkSupplier() {
+	private Optional<FrameworkSupplier> frameworkSupplier() {
 		BundleContext context = FrameworkUtil.getBundle(getClass()).getBundleContext();
 		try {
 			return context.getServiceReferences(FrameworkSupplier.class, null).stream() //


### PR DESCRIPTION
 In  order to facilitate permission observatory with all the required data alter permission examination service interface to supply rich information about all the examination results: restrictions and active permissions.

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>