### PR TITLE
Bump versions for LBC API and LBC Base to 1.0.0

### DIFF
--- a/bundles/org.eclipse.passage.lbc.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lbc.api
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lbc.api;singleton:=true
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lbc.base
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lbc.base
-Bundle-Version: 0.5.100.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright


### PR DESCRIPTION
Actually it should be catched by pipe, but we do not cover LBC by API checks at the moment. I found it with workspace API Baseline checker. 

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>