### PR TITLE
Bug 565656 API revision | restriction execution

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
@@ -44,6 +44,10 @@ public final class BaseServiceInvocationResult<T> implements ServiceInvocationRe
 		this(new BaseDiagnostic(), data);
 	}
 
+	public BaseServiceInvocationResult(Diagnostic diagnostic) {
+		this(diagnostic, Optional.empty());
+	}
+
 	public BaseServiceInvocationResult(Diagnostic diagnostic, T data) {
 		this(diagnostic, Optional.of(data));
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Allow.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Allow.java
@@ -24,12 +24,12 @@ final class Allow extends Cycle<Boolean> {
 	}
 
 	@Override
-	protected Boolean stop(Diagnostic diagnostic) {
+	protected Boolean stopOnError(Diagnostic diagnostic) {
 		return new NoSevereErrors().test(diagnostic);
 	}
 
 	@Override
-	protected Boolean stop(ExaminationCertificate certificate, Diagnostic diagnostic) {
+	protected Boolean stopOnCertificate(ExaminationCertificate certificate, Diagnostic diagnostic) {
 		return new NoSevereErrors().test(diagnostic) && //
 				new NoSevereRestrictions().test(certificate);
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/CanProceed.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/CanProceed.java
@@ -12,27 +12,18 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.access;
 
-import org.eclipse.passage.lic.internal.api.Framework;
+import java.util.function.Predicate;
+
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 
-/**
- * Top-level access cycle
- */
-public final class Access {
+public final class CanProceed implements Predicate<ServiceInvocationResult<ExaminationCertificate>> {
 
-	private final Framework framework;
-
-	public Access(Framework framework) {
-		this.framework = framework;
-	}
-
-	public boolean canUse(String feature) {
-		return new Allow(framework, feature).apply();
-	}
-
-	public ServiceInvocationResult<ExaminationCertificate> check(String feature) {
-		return new Expose(framework, feature).apply();
+	@Override
+	public boolean test(ServiceInvocationResult<ExaminationCertificate> result) {
+		return new NoSevereErrors().test(result.diagnostic()) && //
+				result.data().map(certificate -> new NoSevereRestrictions().test(certificate))//
+						.orElse(true);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Expose.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Expose.java
@@ -13,33 +13,32 @@
 package org.eclipse.passage.lic.internal.base.access;
 
 import org.eclipse.passage.lic.internal.api.Framework;
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.diagnostic.Diagnostic;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
 
 @SuppressWarnings("restriction")
-final class Expose extends Cycle<Boolean> {
+final class Expose extends Cycle<ServiceInvocationResult<ExaminationCertificate>> {
 
 	Expose(Framework framework, String feature) {
 		super(framework, feature);
 	}
 
 	@Override
-	protected Boolean stop(Diagnostic diagnostic) {
-		// FIXME: build prohibitions out of severe troubles and appeal to executors
-		return new NoSevereErrors().test(diagnostic);
+	protected ServiceInvocationResult<ExaminationCertificate> stopOnError(Diagnostic diagnostic) {
+		return new BaseServiceInvocationResult<ExaminationCertificate>(diagnostic);
 	}
 
 	@Override
-	protected Boolean stop(ExaminationCertificate certificate, Diagnostic diagnostic) {
-		// FIXME: build out both of severe troubles and restrictions, if any, and call
-		// executors
-		return new NoSevereErrors().test(diagnostic) && //
-				new NoSevereRestrictions().test(certificate);
+	protected ServiceInvocationResult<ExaminationCertificate> stopOnCertificate(ExaminationCertificate certificate,
+			Diagnostic diagnostic) {
+		return new BaseServiceInvocationResult<ExaminationCertificate>(diagnostic, certificate);
 	}
 
 	@Override
-	protected Boolean freeWayOut() {
-		return true;
+	protected ServiceInvocationResult<ExaminationCertificate> freeWayOut() {
+		return new BaseServiceInvocationResult<ExaminationCertificate>();
 	}
 
 }

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/requirements/FakeRequirement.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/requirements/FakeRequirement.java
@@ -27,10 +27,6 @@ public final class FakeRequirement implements Requirement {
 		this.level = level;
 	}
 
-	public FakeRequirement(String feature, String level) {
-		this(new FakeFeature(feature), new RestrictionLevel.Of(level));
-	}
-
 	public FakeRequirement(String feature) {
 		this(new FakeFeature(feature), new RestrictionLevel.Error());
 	}


### PR DESCRIPTION
As restriction executors are re-thought to stay out of access cycle and only provide auxiliary facilities for the end user, the access cycle in it's heaviest face returns the full feathered `ServiceInvocationResult<ExaminationCertificate>` coupled with decision simplifying facilities like `CanProceed`.

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>