### PR TITLE
565660 API revision | restriction execution | workbench restriction executor

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/LicensingException.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/LicensingException.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.api;
 
+import java.time.ZonedDateTime;
+
 /**
  * As licensing runtime is a complicated and infrastructure-dependent, wide
  * variety of things can occasionally go south. This general purpose exception
@@ -24,12 +26,20 @@ public final class LicensingException extends Exception {
 	 */
 	private static final long serialVersionUID = 7746884069745071894L;
 
+	private final ZonedDateTime stamp;
+
 	public LicensingException(String message, Throwable cause) {
 		super(message, cause);
+		stamp = ZonedDateTime.now();
 	}
 
 	public LicensingException(String message) {
 		super(message);
+		stamp = ZonedDateTime.now();
+	}
+
+	public ZonedDateTime stamp() {
+		return stamp;
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/ExaminationCertificate.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/restrictions/ExaminationCertificate.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.api.restrictions;
 
+import java.time.ZonedDateTime;
 import java.util.Collection;
 
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
@@ -46,5 +47,7 @@ public interface ExaminationCertificate {
 	Collection<Restriction> restrictions();
 
 	Collection<Permission> participants();
+
+	ZonedDateTime stamp();
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/RestrictionVerdicts.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/RestrictionVerdicts.java
@@ -38,7 +38,9 @@ public class RestrictionVerdicts {
 
 	/**
 	 * @since 0.6
+	 * @deprecated use diagnostic codes (TroubleCode)
 	 */
+	@Deprecated
 	public static RestrictionVerdict createConfigurationError(LicensingConfiguration configuration, String featureId) {
 		LicensingRequirement requirement = LicensingRequirements.createConfigurationError(featureId, configuration);
 		int code = CODE_CONFIGURATION_ERROR;
@@ -59,19 +61,29 @@ public class RestrictionVerdicts {
 
 	/**
 	 * @since 0.6
+	 * @deprecated use diagnostic codes (TroubleCode)
 	 */
+	@Deprecated
 	public static RestrictionVerdict createError(LicensingConfiguration configuration, LicensingRequirement requirement,
 			int code) {
 		String policy = LICENSING_RESTRICTION_LEVEL_ERROR;
 		return new BaseRestrictionVerdict(configuration, requirement, policy, code);
 	}
 
+	/**
+	 * @deprecated use diagnostic codes (TroubleCode)
+	 */
+	@Deprecated
 	public static Iterable<RestrictionVerdict> createConfigurationError(LicensingConfiguration configuration,
 			LicensingRequirement requirement) {
 		int code = CODE_CONFIGURATION_ERROR;
 		return Collections.singletonList(createError(configuration, requirement, code));
 	}
 
+	/**
+	 * @deprecated use WorstRestrictionsPerFeature
+	 */
+	@Deprecated
 	public static RestrictionVerdict resolveLastVerdict(Iterable<RestrictionVerdict> verdicts) {
 		if (verdicts == null) {
 			return null;
@@ -86,6 +98,10 @@ public class RestrictionVerdicts {
 		return last;
 	}
 
+	/**
+	 * @deprecated use WorstRestrictionsPerFeature
+	 */
+	@Deprecated
 	public static RestrictionVerdict resolveLastVerdict(Iterable<RestrictionVerdict> verdicts, String featureId) {
 		if (featureId == null) {
 			return resolveLastVerdict(verdicts);
@@ -106,6 +122,10 @@ public class RestrictionVerdicts {
 		return resolveLastVerdict(candidates);
 	}
 
+	/**
+	 * @deprecated use RestrictionMustPauseExecution predicate
+	 */
+	@Deprecated
 	public static boolean shouldPauseExecution(RestrictionVerdict verdict) {
 		if (verdict == null) {
 			return false;
@@ -115,6 +135,10 @@ public class RestrictionVerdicts {
 				|| LICENSING_RESTRICTION_LEVEL_FATAL.equals(level);
 	}
 
+	/**
+	 * @deprecated use RestrictionMustStopExecution predicate
+	 */
+	@Deprecated
 	public static boolean shouldInterruptExecution(RestrictionVerdict verdict) {
 		if (verdict == null) {
 			return false;

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
@@ -1,3 +1,15 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#      ArSysOp - initial API and implementation
+###############################################################################
 Conditions.no_miners=No condition mining services are available, that means there is no one to read a license\!
 Conditions.servive_type=comdition mining
 Restrictions.no_services=There is no examination service available. Looks suspicious.

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionMiningMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionMiningMessages.properties
@@ -1,1 +1,13 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#      ArSysOp - initial API and implementation
+###############################################################################
 LocalConditions.failed=Condition mining across local file system failed

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ExaminationExplanedMessages.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ExaminationExplanedMessages.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.i18n;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+public class ExaminationExplanedMessages {
+	private static final String BUNDLE_NAME = "org.eclipse.passage.lic.internal.base.i18n.ExaminationExplanedMessages"; //$NON-NLS-1$
+
+	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+	private ExaminationExplanedMessages() {
+	}
+
+	public static String getString(String key) {
+		try {
+			return RESOURCE_BUNDLE.getString(key);
+		} catch (MissingResourceException e) {
+			return '!' + key + '!';
+		}
+	}
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ExaminationExplanedMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ExaminationExplanedMessages.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#      ArSysOp - initial API and implementation
+###############################################################################
+ExaminationExplained.feature_format=%s version %s
+ExaminationExplained.prelude=Licensing status of features %d assessed at %s - %d restriction leased:

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BaseExaminationCertificate.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BaseExaminationCertificate.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.restrictions;
 
+import java.time.ZonedDateTime;
 import java.util.Collection;
 
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.Permission;
@@ -23,10 +24,12 @@ public final class BaseExaminationCertificate implements ExaminationCertificate 
 
 	private final Collection<Permission> participants;
 	private final Collection<Restriction> restrictions;
+	private final ZonedDateTime stamp;
 
 	public BaseExaminationCertificate(Collection<Permission> participants, Collection<Restriction> restrictions) {
 		this.participants = participants;
 		this.restrictions = restrictions;
+		this.stamp = ZonedDateTime.now();
 	}
 
 	@Override
@@ -42,6 +45,11 @@ public final class BaseExaminationCertificate implements ExaminationCertificate 
 	@Override
 	public Collection<Permission> participants() {
 		return participants;
+	}
+
+	@Override
+	public ZonedDateTime stamp() {
+		return stamp;
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/ExaminationExplained.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/ExaminationExplained.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.restrictions;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.internal.base.i18n.ExaminationExplanedMessages;
+
+//FIXME: work for CachingSupplier
+@SuppressWarnings("restriction")
+public final class ExaminationExplained implements Supplier<String> {
+
+	private final ExaminationCertificate certificate;
+
+	public ExaminationExplained(ExaminationCertificate certificate) {
+		Objects.requireNonNull(certificate, "ExaminationExplained::certificate"); //$NON-NLS-1$
+		this.certificate = certificate;
+	}
+
+	@Override
+	public String get() {
+		StringBuilder out = new StringBuilder();
+		List<String> features = features();
+		out.append(String.format(//
+				ExaminationExplanedMessages.getString("ExaminationExplained.prelude"), //$NON-NLS-1$
+				features.size(), //
+				date(), //
+				certificate.restrictions().size()));
+
+		return out.toString();
+	}
+
+	private List<String> features() {
+		return certificate.participants().stream()//
+				.map(p -> String.format(ExaminationExplanedMessages.getString("ExaminationExplained.feature_format"), //$NON-NLS-1$
+						p.condition().feature(), p //
+								.condition().versionMatch().version()))//
+				.distinct() //
+				.collect(Collectors.toList());
+	}
+
+	private String date() {
+		return DateTimeFormatter.RFC_1123_DATE_TIME.format(certificate.stamp());
+	}
+}


### PR DESCRIPTION
Start reimplementing restriction execution to a set of developer's tools for handling access cycle execution result. 
Here is mostly side works:
 - time stamps are appended to critical diagnostic units:  `LicensingException` and `ExaminstionCertificate`
- missing license headers are added to *.properties files
- generic `ExaminationCertificate` wordy explanation tool is placed to the basic restrictions implementation package
- bits of proper deprecation
