### PR TITLE
Bug 565987 API revision | implement license importing flow

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/code/InsufficientLicenseCoverage.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/code/InsufficientLicenseCoverage.java
@@ -15,10 +15,10 @@ package org.eclipse.passage.lic.internal.base.diagnostic.code;
 import org.eclipse.passage.lic.internal.api.diagnostic.TroubleCode;
 import org.eclipse.passage.lic.internal.base.i18n.DiagnosticCodeMessages;
 
-public final class LicenseDoesNotMatch extends TroubleCode {
+public final class InsufficientLicenseCoverage extends TroubleCode {
 
-	public LicenseDoesNotMatch() {
-		super(404, DiagnosticCodeMessages.getString("LicenseDoesNotMatch.license_does_not_match")); //$NON-NLS-1$
+	public InsufficientLicenseCoverage() {
+		super(405, DiagnosticCodeMessages.getString("InsufficientLicenseCoverage.not_covered")); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/code/LicenseNotStarted.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/code/LicenseNotStarted.java
@@ -18,7 +18,7 @@ import org.eclipse.passage.lic.internal.base.i18n.DiagnosticCodeMessages;
 public final class LicenseNotStarted extends TroubleCode {
 
 	public LicenseNotStarted() {
-		super(403, DiagnosticCodeMessages.getString("LicenseNotStarted.license_not_started")); //$NON-NLS-1$
+		super(402, DiagnosticCodeMessages.getString("LicenseNotStarted.license_not_started")); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/DiagnosticCodeMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/DiagnosticCodeMessages.properties
@@ -15,6 +15,7 @@ LicenseExpired.license_expired=License expired
 LicenseInvalid.license_invalid=License is not valid
 LicenseNotStarted.license_not_started=License is not started
 LicenseCheckFailed.error=License assessment failed with error
+InsufficientLicenseCoverage.not_covered=Is not covered by a license
 ServiceCannotOperate.explanation=Access cycle service cannot operate
 NoServices.explanation=There is no services of type [{0}] available
 NoFramework.explanation=Passage gains no Framework instance and is completely inoperable. It means either severe lack of configuration or sabotage.

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BasePermissionsExaminationService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/BasePermissionsExaminationService.java
@@ -24,7 +24,7 @@ import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
 import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
-import org.eclipse.passage.lic.internal.base.diagnostic.code.LicenseInvalid;
+import org.eclipse.passage.lic.internal.base.diagnostic.code.InsufficientLicenseCoverage;
 
 @SuppressWarnings("restriction")
 public final class BasePermissionsExaminationService implements PermissionsExaminationService {
@@ -79,7 +79,7 @@ public final class BasePermissionsExaminationService implements PermissionsExami
 	}
 
 	private Restriction restriction(Requirement requirement, LicensedProduct product) {
-		return new BaseRestriction(product, requirement, new LicenseInvalid());
+		return new BaseRestriction(product, requirement, new InsufficientLicenseCoverage());
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
@@ -52,7 +52,7 @@ public final class DiagnosticDialog extends NotificationDialog {
 
 	@Override
 	protected void buildUI(Composite parent) {
-		viewer = new LicensingTable<Trouble>(parent, Trouble.class) //
+		viewer = new HereTable<Trouble>(parent, Trouble.class) //
 				.withColumn("Error", 720, t -> t.details()) //$NON-NLS-1$
 				.withColumn("Code", 50, t -> Integer.toString(t.code().code())) //$NON-NLS-1$
 				.withColumn("Failure", 50, t -> t.exception().isPresent() ? "Oh, yah..." : "Nope!")//$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereTable.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereTable.java
@@ -24,13 +24,13 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
 
-final class LicensingTable<T> {
+final class HereTable<T> {
 
 	private final TableViewer table;
 	private final Class<T> cls;
 	private final Map<Integer, Function<T, String>> texts = new HashMap<>();
 
-	LicensingTable(Composite parent, Class<T> cls) {
+	HereTable(Composite parent, Class<T> cls) {
 		this.table = new TableViewer(parent);
 		this.cls = cls;
 	}
@@ -44,14 +44,14 @@ final class LicensingTable<T> {
 		return table;
 	}
 
-	public LicensingTable<T> withColumn(String name, int width, Function<T, String> text) {
+	public HereTable<T> withColumn(String name, int width, Function<T, String> text) {
 		TableViewerColumn column = new TableViewerColumn(table, SWT.NONE);
 		setupColumn(column.getColumn(), name, width);
 		texts.put(table.getTable().getColumnCount() - 1, text);
 		return this;
 	}
 
-	public LicensingTable<T> withColumn(String name, int width, int index, Function<T, String> text) {
+	public HereTable<T> withColumn(String name, int width, int index, Function<T, String> text) {
 		TableViewerColumn column = new TableViewerColumn(table, SWT.NONE, index);
 		setupColumn(column.getColumn(), name, width);
 		texts.put(index, text);

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
@@ -95,7 +95,7 @@ public final class ImportLicenseDialog extends NotificationDialog {
 	}
 
 	private void buildViewer(Composite parent) {
-		viewer = new LicensingTable<Condition>(parent, Condition.class) //
+		viewer = new HereTable<Condition>(parent, Condition.class) //
 				.withColumn("Feature", 300, this::feature) //$NON-NLS-1$
 				.withColumn("Valid", 300, this::period) //$NON-NLS-1$
 				.withColumn("Evaluation", 220, this::evaluation) //$NON-NLS-1$
@@ -125,7 +125,7 @@ public final class ImportLicenseDialog extends NotificationDialog {
 	}
 
 	private void loadLicense(Event e) {
-
+// FIXME
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/LicenseStatusDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/LicenseStatusDialog.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
 
+import org.eclipse.passage.lic.internal.api.requirements.Feature;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
 import org.eclipse.passage.lic.internal.base.restrictions.ExaminationExplained;
@@ -27,7 +28,6 @@ public final class LicenseStatusDialog extends NotificationDialog {
 	public LicenseStatusDialog(Shell shell, ExaminationCertificate certificate) {
 		super(shell);
 		this.origin = certificate;
-		super.setMessage("Point a license file to see what's inside"); //$NON-NLS-1$
 	}
 
 	public GoodIntention goodIntention() {
@@ -39,14 +39,13 @@ public final class LicenseStatusDialog extends NotificationDialog {
 		super.configureShell(shell);
 		shell.setText("Licensing status"); //$NON-NLS-1$
 		shell.setImage(getDefaultImage());
-		shell.setSize(730, 300);
+		shell.setSize(740, 300);
 	}
 
 	@Override
 	protected void buildUI(Composite parent) {
-		viewer = new LicensingTable<Restriction>(parent, Restriction.class) //
-				.withColumn("Name", 500, r -> r.unsatisfiedRequirement().feature().identifier()) //$NON-NLS-1$
-				.withColumn("Version", 100, r -> r.unsatisfiedRequirement().feature().version()) //$NON-NLS-1$
+		viewer = new HereTable<Restriction>(parent, Restriction.class) //
+				.withColumn("Name", 500, r -> feature(r.unsatisfiedRequirement().feature())) //$NON-NLS-1$
 				.withColumn("Verdict", 200, r -> r.reason().explanation()) //$NON-NLS-1$
 				.viewer();
 	}
@@ -78,10 +77,16 @@ public final class LicenseStatusDialog extends NotificationDialog {
 
 	private void requestLicense() {
 		intention = new GoodIntention.RequestLicense();
+		super.okPressed();
 	}
 
 	private void importLicense() {
 		intention = new GoodIntention.ImportLicense(this::getShell);
+		super.okPressed();
+	}
+
+	private String feature(Feature feature) {
+		return String.format("%s v%s", feature.identifier(), feature.version()); //$NON-NLS-1$
 	}
 
 }

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/BasePermissionsExaminationServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/BasePermissionsExaminationServiceTest.java
@@ -29,7 +29,7 @@ import org.eclipse.passage.lic.internal.api.requirements.Requirement;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
 import org.eclipse.passage.lic.internal.api.restrictions.Restriction;
-import org.eclipse.passage.lic.internal.base.diagnostic.code.LicenseInvalid;
+import org.eclipse.passage.lic.internal.base.diagnostic.code.InsufficientLicenseCoverage;
 import org.eclipse.passage.lic.internal.base.restrictions.BasePermissionsExaminationService;
 import org.eclipse.passage.lic.internal.base.restrictions.CertificateIsRestrictive;
 import org.junit.Test;
@@ -73,7 +73,7 @@ public final class BasePermissionsExaminationServiceTest extends PermissionsExam
 		Restriction restriction = certificate.restrictions().iterator().next();
 		assertEquals(state.requirementFirst(), restriction.unsatisfiedRequirement());
 		assertEquals(state.product(), restriction.product());
-		assertEquals(new LicenseInvalid(), restriction.reason());
+		assertEquals(new InsufficientLicenseCoverage(), restriction.reason());
 		// then: our only permission is counted as active
 		assertEquals(1, certificate.participants().size());
 		assertEquals(state.permissionSecond(), certificate.participants().iterator().next());
@@ -92,7 +92,7 @@ public final class BasePermissionsExaminationServiceTest extends PermissionsExam
 		Restriction restriction = restrictions.iterator().next();
 		assertEquals(state.requirementSecond(), restriction.unsatisfiedRequirement());
 		assertEquals(state.product(), restriction.product());
-		assertEquals(new LicenseInvalid(), restriction.reason());
+		assertEquals(new InsufficientLicenseCoverage(), restriction.reason());
 	}
 
 	@Test


### PR DESCRIPTION
- fix trouble codes for uniqueness
- make examination service report lack of permissions as 'insufficient
license coverage' instead of 'invalid license'
- evolve `LicensingStatusDialog`(ready, letting alone i18n)

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>