### PR TITLE
Bug 566215 - [Passage] Condition should have a persistent identifier

### DIFF
--- a/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/api/LicenseGrant.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/api/LicenseGrant.java
@@ -65,6 +65,7 @@ public interface LicenseGrant extends EObject, LicenseGrantDescriptor {
 	 * @param value the new value of the '<em>Identifier</em>' attribute.
 	 * @see #getIdentifier()
 	 * @generated
+	 * @since 1.0
 	 */
 	void setIdentifier(String value);
 


### PR DESCRIPTION
added @since 1.0 for LicenseGrant#setIdentifier(String);

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>