### PR TITLE
Bug 566329 provide a way to summarize total product licensing status

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/PassageLicenseCoverage.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/PassageLicenseCoverage.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.api;
+
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+
+public interface PassageLicenseCoverage {
+
+	ServiceInvocationResult<ExaminationCertificate> assess();
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Access.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Access.java
@@ -32,7 +32,11 @@ public final class Access {
 	}
 
 	public ServiceInvocationResult<ExaminationCertificate> acquire(String feature) {
-		return new Expose(framework, feature).apply();
+		return new Assess(framework, feature).apply();
+	}
+
+	public ServiceInvocationResult<ExaminationCertificate> assess() {
+		return new Assess(framework).apply();
 	}
 
 	public ServiceInvocationResult<Boolean> release(ExaminationCertificate certificate) {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Assess.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Assess.java
@@ -18,10 +18,14 @@ import org.eclipse.passage.lic.internal.api.diagnostic.Diagnostic;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
 
-final class Expose extends Cycle<ServiceInvocationResult<ExaminationCertificate>> {
+final class Assess extends Cycle<ServiceInvocationResult<ExaminationCertificate>> {
 
-	Expose(Framework framework, String feature) {
+	Assess(Framework framework, String feature) {
 		super(framework, feature);
+	}
+
+	Assess(Framework framework) {
+		super(framework);
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Cycle.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Cycle.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.internal.api.Framework;
@@ -33,12 +34,22 @@ import org.eclipse.passage.lic.internal.base.diagnostic.SumOfDiagnostics;
 abstract class Cycle<T> {
 
 	private final Framework framework;
-	private final String feature;
+	private final CycleFilter filter;
 	private final List<Diagnostic> diagnostics;
 
+	Cycle(Framework framework) {
+		this(framework, new CycleFilter());
+	}
+
 	Cycle(Framework framework, String feature) {
+		this(framework, new CycleFilter(feature));
+	}
+
+	private Cycle(Framework framework, CycleFilter filter) {
+		Objects.requireNonNull(framework, "Cycle::framework"); //$NON-NLS-1$
+		Objects.requireNonNull(filter, "Cycle::filter"); //$NON-NLS-1$
 		this.framework = framework;
-		this.feature = feature;
+		this.filter = filter;
 		this.diagnostics = new ArrayList<>();
 	}
 
@@ -112,14 +123,14 @@ abstract class Cycle<T> {
 	private ServiceInvocationResult<Collection<Requirement>> requirements() {
 		return scan(new Requirements(//
 				framework.accessCycleConfiguration().requirementResolvers().get(), //
-				feature).get());
+				filter.requiremental()).get());
 	}
 
 	private ServiceInvocationResult<Collection<ConditionPack>> conditions() {
 		return scan(new Conditions(//
 				framework.accessCycleConfiguration().conditionMiners().get(), //
 				framework.product(), //
-				feature).get());
+				filter.conditional()).get());
 	}
 
 	private ServiceInvocationResult<Collection<Permission>> permissions() {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/CycleFilter.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/CycleFilter.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.access;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.conditions.ConditionPack;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.conditions.ConditionsFeatureFilter;
+import org.eclipse.passage.lic.internal.base.requirements.RequirementsFeatureFilter;
+
+final class CycleFilter {
+
+	private final Function<//
+			ServiceInvocationResult<Collection<Requirement>>, //
+			ServiceInvocationResult<Collection<Requirement>>> requiremental;
+	private final Function<//
+			ServiceInvocationResult<Collection<ConditionPack>>, //
+			ServiceInvocationResult<Collection<ConditionPack>>> conditional;
+
+	CycleFilter() {
+		this(Function.identity(), Function.identity());
+	}
+
+	CycleFilter(String feature) {
+		this(new RequirementsFeatureFilter(feature).get(), new ConditionsFeatureFilter(feature).get());
+	}
+
+	private CycleFilter(
+			Function<ServiceInvocationResult<Collection<Requirement>>, ServiceInvocationResult<Collection<Requirement>>> requiremental,
+			Function<ServiceInvocationResult<Collection<ConditionPack>>, ServiceInvocationResult<Collection<ConditionPack>>> conditional) {
+		this.requiremental = requiremental;
+		this.conditional = conditional;
+	}
+
+	Function<ServiceInvocationResult<Collection<Requirement>>, ServiceInvocationResult<Collection<Requirement>>> requiremental() {
+		return requiremental;
+	}
+
+	Function<ServiceInvocationResult<Collection<ConditionPack>>, ServiceInvocationResult<Collection<ConditionPack>>> conditional() {
+		return conditional;
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Requirements.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Requirements.java
@@ -47,7 +47,7 @@ public final class Requirements implements Supplier<ServiceInvocationResult<Coll
 		this(registry, Function.identity());
 	}
 
-	private Requirements(Registry<StringServiceId, ResolvedRequirements> registry,
+	public Requirements(Registry<StringServiceId, ResolvedRequirements> registry,
 			Function<ServiceInvocationResult<Collection<Requirement>>, ServiceInvocationResult<Collection<Requirement>>> filter) {
 		Objects.requireNonNull(registry, "Requirements::registry"); //$NON-NLS-1$
 		Objects.requireNonNull(filter, "Requirements::filter"); //$NON-NLS-1$

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxPassageLicenseCoverage.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/EquinoxPassageLicenseCoverage.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox;
+
+import org.eclipse.passage.lic.internal.api.PassageLicenseCoverage;
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.internal.base.access.Access;
+
+@SuppressWarnings("restriction")
+public final class EquinoxPassageLicenseCoverage extends FrameworkAware implements PassageLicenseCoverage {
+
+	@Override
+	public ServiceInvocationResult<ExaminationCertificate> assess() {
+		return withFrameworkService(framework -> new Access(framework).assess());
+	}
+
+}


### PR DESCRIPTION
Design new Passage* service for the whole product's license coverage assessment. Implement (equinox) it on the base of access cycle.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>