### PR TITLE
Bug 566329 provide a way to summarize total product licensing status

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/PassageUI.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/PassageUI.java
@@ -52,4 +52,9 @@ public interface PassageUI {
 	 */
 	ServiceInvocationResult<ExaminationCertificate> acquireLicense(String feature);
 
+	/**
+	 * Assess the whole product licensing coverage.
+	 */
+	ServiceInvocationResult<ExaminationCertificate> assessLicensingStatus();
+
 }

--- a/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/internal/e4/ui/handlers/InspectLicenseHandler.java
+++ b/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/internal/e4/ui/handlers/InspectLicenseHandler.java
@@ -15,9 +15,8 @@ package org.eclipse.passage.lic.internal.e4.ui.handlers;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
-import org.eclipse.passage.lic.internal.equinox.EquinoxPassageLicenseCoverage;
+import org.eclipse.passage.lic.internal.jface.EquinoxPassageUI;
 import org.eclipse.passage.lic.internal.jface.dialogs.licensing.DiagnosticDialog;
-import org.eclipse.passage.lic.internal.jface.dialogs.licensing.LicenseStatusDialog;
 import org.eclipse.swt.widgets.Shell;
 
 @SuppressWarnings("restriction")
@@ -25,10 +24,9 @@ public final class InspectLicenseHandler {
 
 	@Execute
 	public void execute(Shell shell) {
-		ServiceInvocationResult<ExaminationCertificate> result = new EquinoxPassageLicenseCoverage().assess();
-		if (result.data().isPresent()) {
-			new LicenseStatusDialog(shell, result.data().get(), result.diagnostic()).open();
-		} else {
+		ServiceInvocationResult<ExaminationCertificate> result = new EquinoxPassageUI(() -> shell)
+				.assessLicensingStatus();
+		if (!result.data().isPresent()) {
 			new DiagnosticDialog(shell, result.diagnostic()).open();
 		}
 


### PR DESCRIPTION
make InspectLicense handler expose a full-functioning LicnseStatusDialog with all the post-actions like `import license` or `request license`.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>