### PR TITLE
Bug 566790 - [Passage] enforce com.sun.jna bundles to be less than 5.0.0

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.sun.jna;bundle-version="4.5.1",
- com.sun.jna.platform;bundle-version="4.5.1",
+Require-Bundle: com.sun.jna;bundle-version="[4.5.1,5.0.0)",
+ com.sun.jna.platform;bundle-version="[4.5.1,5.0.0)",
  com.github.oshi.oshi-core;bundle-version="0.0.0",
  org.eclipse.osgi;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",


### PR DESCRIPTION
com.sun.jna;bundle-version="[4.5.1,5.0.0)",
com.sun.jna.platform;bundle-version="[4.5.1,5.0.0)",

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>