### PR TITLE
566816 - "diagnostic" from licensing status dialog should not fail

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BasePermissionEmittingService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BasePermissionEmittingService.java
@@ -138,7 +138,11 @@ public final class BasePermissionEmittingService implements PermissionEmittingSe
 		} catch (Exception e) {
 			return new BaseServiceInvocationResult<>(//
 					new BaseDiagnostic(Collections.singletonList(new Trouble(new ServiceFailedOnMorsel(),
-							ConditionsEvaluationMessages.getString("BasePermissionEmittingService.e_create_for"), e)))); //$NON-NLS-1$
+							String.format(
+									ConditionsEvaluationMessages
+											.getString("BasePermissionEmittingService.e_create_for"), //$NON-NLS-1$
+									condition.feature(), condition.identifier()),
+							e))));
 		}
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
@@ -10,7 +10,7 @@
 # Contributors:
 #      ArSysOp - initial API and implementation
 ###############################################################################
-BasePermissionEmittingService.e_create_for=Invalid condition %s
+BasePermissionEmittingService.e_create_for=Invalid condition for %s (%s)
 BasePermissionEmittingService.evaluation_failed=Failed to evaluate expression [%s] 
 SimpleMapExpressionEvaluationService.foreign_expression=Expression protocol [%s] does not fit the expected [ands]
 SimpleMapExpressionEvaluationService.no_checks=Expression is invalid: it contains no checks

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
@@ -40,7 +40,7 @@ public final class DiagnosticDialog extends NotificationDialog {
 		super.configureShell(shell);
 		shell.setText(DiagnosticDialogMessages.DiagnosticDialog_title);
 		shell.setImage(getDefaultImage());
-		shell.setSize(850, 300);
+		shell.setSize(850, 600);
 	}
 
 	@Override


### PR DESCRIPTION
Show feature identifier and condition identifier
Do not use modern status contructors
Increase initial dialog size

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>