### PR TITLE
Bug 566852 Design and support 'OR'-based condition expression type

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionProtocol.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/internal/api/conditions/evaluation/ExpressionProtocol.java
@@ -47,10 +47,18 @@ public abstract class ExpressionProtocol implements ServiceId {
 		return identifier;
 	}
 
-	public static final class Ands extends ExpressionProtocol {
+	public static final class Berlin extends ExpressionProtocol {
 
-		public Ands() {
-			super("ands"); //$NON-NLS-1$
+		public Berlin() {
+			super("berlin"); //$NON-NLS-1$
+		}
+
+	}
+
+	public static final class Munich extends ExpressionProtocol {
+
+		public Munich() {
+			super("munich"); //$NON-NLS-1$
 		}
 
 	}
@@ -58,7 +66,7 @@ public abstract class ExpressionProtocol implements ServiceId {
 	public static final class Default extends ExpressionProtocol {
 
 		public Default() {
-			super(new Ands().identifier());
+			super(new Berlin().identifier());
 		}
 
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BerlinProtocolExpressionParseService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BerlinProtocolExpressionParseService.java
@@ -26,9 +26,9 @@ import org.eclipse.passage.lic.internal.base.i18n.ConditionsEvaluationMessages;
  * 
  */
 @SuppressWarnings("restriction")
-public final class AndsProtocolExpressionParseService implements ExpressionParsingService {
+public final class BerlinProtocolExpressionParseService implements ExpressionParsingService {
 
-	private final ExpressionProtocol protocol = new ExpressionProtocol.Ands();
+	private final ExpressionProtocol protocol = new ExpressionProtocol.Berlin();
 	private final String separator = ";"; //$NON-NLS-1$
 	private final String mediator = "="; //$NON-NLS-1$
 
@@ -50,7 +50,7 @@ public final class AndsProtocolExpressionParseService implements ExpressionParsi
 		}
 		if (couples.isEmpty()) {
 			throw new ExpressionParsingException(String.format(//
-					ConditionsEvaluationMessages.getString("AndsProtocolExpressionParseService.no_checks"), //$NON-NLS-1$
+					ConditionsEvaluationMessages.getString("BerlinProtocolExpressionParseService.no_checks"), //$NON-NLS-1$
 					expression));
 		}
 		return new SimpleMapExpression(protocol, couples);
@@ -60,7 +60,8 @@ public final class AndsProtocolExpressionParseService implements ExpressionParsi
 		String[] couple = segment.split(mediator);
 		if (coupleIsInvalid(couple)) {
 			throw new ExpressionParsingException(String.format(//
-					ConditionsEvaluationMessages.getString("AndsProtocolExpressionParseService.invalid_format"), segment)); //$NON-NLS-1$
+					ConditionsEvaluationMessages.getString("BerlinProtocolExpressionParseService.invalid_format"), //$NON-NLS-1$
+					segment));
 		}
 		couples.put(couple[0].trim(), couple[1].trim());
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
@@ -24,7 +24,7 @@ import org.eclipse.passage.lic.internal.base.i18n.ConditionsEvaluationMessages;
 @SuppressWarnings("restriction")
 public final class SimpleMapExpressionEvaluationService implements ExpressionEvaluationService {
 
-	private final ExpressionProtocol format = new ExpressionProtocol.Ands();
+	private final ExpressionProtocol format = new ExpressionProtocol.Berlin();
 
 	@Override
 	public ExpressionProtocol id() {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionsEvaluationMessages.properties
@@ -17,7 +17,7 @@ SimpleMapExpressionEvaluationService.no_checks=Expression is invalid: it contain
 SimpleMapExpressionEvaluationService.segment_fails_evaluation=Expression fails evaluation (type %s) on segment [%s = %s]
 SimpleMapExpressionEvaluationService.evaluation_fails=Expression segment [%s = %s] %s assessment failed with error
 SimpleMapExpressionEvaluationService.unexpected_expression_protocol=Unexpected expression protocol [%s] (should be [%s])
-AndsProtocolExpressionParseService.invalid_format=Segment [%s] is corrupted. Expected to have key=value structure.
-AndsProtocolExpressionParseService.no_checks=Expression [%s] contains no checks. Expected to be of [key=value;...key=value] structure.
+BerlinProtocolExpressionParseService.invalid_format=Segment [%s] is corrupted. Expected to have key=value structure.
+BerlinProtocolExpressionParseService.no_checks=Expression [%s] contains no checks. Expected to be of [key=value;...key=value] structure.
 BasePermissionEmittingService.failed=Failed to assess expression [%s] 
 BasePermissionEmittingService.parse_failed=Failed to parse expression [%s] 

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/SealedAccessCycleConfiguration.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/SealedAccessCycleConfiguration.java
@@ -44,7 +44,7 @@ import org.eclipse.passage.lic.internal.api.requirements.ResolvedRequirements;
 import org.eclipse.passage.lic.internal.api.requirements.ResolvedRequirementsRegistry;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationService;
 import org.eclipse.passage.lic.internal.api.restrictions.PermissionsExaminationServicesRegistry;
-import org.eclipse.passage.lic.internal.base.conditions.evaluation.AndsProtocolExpressionParseService;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.BerlinProtocolExpressionParseService;
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.BasePermissionEmittingService;
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpressionEvaluationService;
 import org.eclipse.passage.lic.internal.base.conditions.mining.MiningEquipment;
@@ -107,7 +107,7 @@ final class SealedAccessCycleConfiguration implements AccessCycleConfiguration {
 						expressionEvaluators())//
 		));
 		expressionParsers = new ReadOnlyRegistry<>(Arrays.asList(//
-				new AndsProtocolExpressionParseService()//
+				new BerlinProtocolExpressionParseService()//
 		));
 		expressionEvaluators = new ReadOnlyRegistry<>(Arrays.asList(//
 				new SimpleMapExpressionEvaluationService()//

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionEmittingServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionEmittingServiceTest.java
@@ -39,7 +39,7 @@ import org.eclipse.passage.lic.internal.base.BaseLicensedProduct;
 import org.eclipse.passage.lic.internal.base.conditions.BaseConditionPack;
 import org.eclipse.passage.lic.internal.base.conditions.BaseEvaluationInstructions;
 import org.eclipse.passage.lic.internal.base.conditions.BaseValidityPeriodClosed;
-import org.eclipse.passage.lic.internal.base.conditions.evaluation.AndsProtocolExpressionParseService;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.BerlinProtocolExpressionParseService;
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.BasePermissionEmittingService;
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpressionEvaluationService;
 import org.eclipse.passage.lic.internal.base.diagnostic.code.LicenseCheckFailed;
@@ -144,7 +144,7 @@ public final class BasePermissionEmittingServiceTest {
 	}
 
 	private ExpressionPasringRegistry parsers() {
-		return () -> new ReadOnlyRegistry<>(Collections.singleton(new AndsProtocolExpressionParseService()));
+		return () -> new ReadOnlyRegistry<>(Collections.singleton(new BerlinProtocolExpressionParseService()));
 	}
 
 	private ExpressionTokenAssessorsRegistry assessors() {

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BerlinProtocolExpressionParseServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BerlinProtocolExpressionParseServiceTest.java
@@ -19,12 +19,12 @@ import org.eclipse.passage.lic.api.tests.conditions.evaluation.ExpressionParsing
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingException;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ExpressionParsingService;
 import org.eclipse.passage.lic.internal.api.conditions.evaluation.ParsedExpression;
-import org.eclipse.passage.lic.internal.base.conditions.evaluation.AndsProtocolExpressionParseService;
+import org.eclipse.passage.lic.internal.base.conditions.evaluation.BerlinProtocolExpressionParseService;
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpression;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-public final class AndsProtocolExpressionParseServiceTest extends ExpressionParsingServiceContractTest {
+public final class BerlinProtocolExpressionParseServiceTest extends ExpressionParsingServiceContractTest {
 
 	@Test
 	public void parsesValidData() {
@@ -71,7 +71,7 @@ public final class AndsProtocolExpressionParseServiceTest extends ExpressionPars
 
 	@Override
 	protected ExpressionParsingService parser() {
-		return new AndsProtocolExpressionParseService();
+		return new BerlinProtocolExpressionParseService();
 	}
 
 	@Override

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SimpleMapExpressionEvaluationServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/SimpleMapExpressionEvaluationServiceTest.java
@@ -86,7 +86,7 @@ public final class SimpleMapExpressionEvaluationServiceTest extends ExpressionEv
 
 	private SimpleMapExpression expression(String[]... pairs) {
 		return new SimpleMapExpression(//
-				new ExpressionProtocol.Ands(), // $NON-NLS-1$
+				new ExpressionProtocol.Berlin(), // $NON-NLS-1$
 				Arrays.stream(pairs)//
 						.collect(Collectors.toMap(//
 								pair -> pair[0], //


### PR DESCRIPTION
 The decision has been made to name expression protocols after european cities. Thus,
  - `ands` protocol is renamed to `berlin`
  - `munich` is added to name the current  floating protocol vision

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>