### PR TITLE
567252: Requirement resolution can be completely blocked by any invalid bundle in launch config

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Export-Package: org.eclipse.passage.lic.internal.api;
    org.eclipse.passage.loc.api,
    org.eclipse.passage.lic.base,
    org.eclipse.passage.lic.jface,
-   org.eclipse.passage.lic.hc",
+   org.eclipse.passage.lic.hc,
+   org.eclipse.passage.lic.equinox,
+   org.eclipse.passage.lic.equinox.tests",
  org.eclipse.passage.lic.internal.api.conditions;
   x-friends:="org.eclipse.passage.lbc.api,
    org.eclipse.passage.lbc.base,

--- a/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Export-Package: org.eclipse.passage.lic.internal.api;
    org.eclipse.passage.lic.jface,
    org.eclipse.passage.lic.hc,
    org.eclipse.passage.lic.equinox,
-   org.eclipse.passage.lic.equinox.tests",
+   org.eclipse.passage.lic.equinox.tests,
+   org.eclipse.passage.lic.base.tests",
  org.eclipse.passage.lic.internal.api.conditions;
   x-friends:="org.eclipse.passage.lbc.api,
    org.eclipse.passage.lbc.base,

--- a/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
@@ -34,11 +34,19 @@ Export-Package: org.eclipse.passage.lic.internal.api;
    org.eclipse.passage.lbc.base,
    org.eclipse.passage.lic.json,
    org.eclipse.passage.lic.hc",
- org.eclipse.passage.lic.internal.api.diagnostic;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.jface,org.eclipse.passage.lic.hc",
+ org.eclipse.passage.lic.internal.api.diagnostic;
+  x-friends:="org.eclipse.passage.lic.base,
+   org.eclipse.passage.lic.jface,
+   org.eclipse.passage.lic.hc,
+   org.eclipse.passage.lic.equinox",
  org.eclipse.passage.lic.internal.api.inspection;x-friends:="org.eclipse.passage.lic.base",
  org.eclipse.passage.lic.internal.api.io;x-friends:="org.eclipse.passage.lbc.api",
  org.eclipse.passage.lic.internal.api.observatory;x-friends:="org.eclipse.passage.lic.base",
  org.eclipse.passage.lic.internal.api.registry;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.hc",
- org.eclipse.passage.lic.internal.api.requirements;x-friends:="org.eclipse.passage.lic.base",
- org.eclipse.passage.lic.internal.api.restrictions;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.loc.workbench.emfforms,org.eclipse.passage.lic.products",
+ org.eclipse.passage.lic.internal.api.requirements;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.equinox",
+ org.eclipse.passage.lic.internal.api.restrictions;
+  x-friends:="org.eclipse.passage.lic.base,
+   org.eclipse.passage.loc.workbench.emfforms,
+   org.eclipse.passage.lic.products,
+   org.eclipse.passage.lic.equinox",
  org.eclipse.passage.lic.internal.api.version;x-friends:="org.eclipse.passage.lic.base"

--- a/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.api/META-INF/MANIFEST.MF
@@ -44,7 +44,7 @@ Export-Package: org.eclipse.passage.lic.internal.api;
  org.eclipse.passage.lic.internal.api.io;x-friends:="org.eclipse.passage.lbc.api",
  org.eclipse.passage.lic.internal.api.observatory;x-friends:="org.eclipse.passage.lic.base",
  org.eclipse.passage.lic.internal.api.registry;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.hc",
- org.eclipse.passage.lic.internal.api.requirements;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.equinox",
+ org.eclipse.passage.lic.internal.api.requirements;x-friends:="org.eclipse.passage.lic.base,org.eclipse.passage.lic.equinox,org.eclipse.passage.lic.equinox.tests",
  org.eclipse.passage.lic.internal.api.restrictions;
   x-friends:="org.eclipse.passage.lic.base,
    org.eclipse.passage.loc.workbench.emfforms,

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Export-Package: org.eclipse.passage.lic.internal.base;
  org.eclipse.passage.lic.internal.base.conditions;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lic.json,org.eclipse.passage.lic.hc",
  org.eclipse.passage.lic.internal.base.conditions.evaluation;x-internal:=true,
  org.eclipse.passage.lic.internal.base.conditions.mining;x-friends:="org.eclipse.passage.lic.jface,org.eclipse.passage.lic.hc",
- org.eclipse.passage.lic.internal.base.diagnostic;x-internal:=true,
+ org.eclipse.passage.lic.internal.base.diagnostic;x-friends:="org.eclipse.passage.lic.equinox.tests",
  org.eclipse.passage.lic.internal.base.diagnostic.code;x-friends:="org.eclipse.passage.lic.hc,org.eclipse.passage.lic.equinox",
  org.eclipse.passage.lic.internal.base.i18n;x-internal:=true,
  org.eclipse.passage.lic.internal.base.inspection;x-internal:=true,

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -9,10 +9,11 @@ Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.passage.lic.api;bundle-version="1.0.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.internal.base;
-  x-friends:="org.eclipse.passage.lic.jface,
-   org.eclipse.passage.lbc.base,
+  x-friends:="org.eclipse.passage.lbc.base,
+   org.eclipse.passage.lic.equinox,
    org.eclipse.passage.lic.hc,
-   org.eclipse.passage.lic.equinox",
+   org.eclipse.passage.lic.jface,
+   org.eclipse.passage.lic.base.tests",
  org.eclipse.passage.lic.internal.base.access;x-internal:=true,
  org.eclipse.passage.lic.internal.base.conditions;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lic.json,org.eclipse.passage.lic.hc",
  org.eclipse.passage.lic.internal.base.conditions.evaluation;x-internal:=true,

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -8,13 +8,17 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.passage.lic.api;bundle-version="1.0.0";visibility:=reexport
-Export-Package: org.eclipse.passage.lic.internal.base;x-friends:="org.eclipse.passage.lic.jface,org.eclipse.passage.lbc.base,org.eclipse.passage.lic.hc",
+Export-Package: org.eclipse.passage.lic.internal.base;
+  x-friends:="org.eclipse.passage.lic.jface,
+   org.eclipse.passage.lbc.base,
+   org.eclipse.passage.lic.hc,
+   org.eclipse.passage.lic.equinox",
  org.eclipse.passage.lic.internal.base.access;x-internal:=true,
  org.eclipse.passage.lic.internal.base.conditions;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lic.json,org.eclipse.passage.lic.hc",
  org.eclipse.passage.lic.internal.base.conditions.evaluation;x-internal:=true,
  org.eclipse.passage.lic.internal.base.conditions.mining;x-friends:="org.eclipse.passage.lic.jface,org.eclipse.passage.lic.hc",
  org.eclipse.passage.lic.internal.base.diagnostic;x-internal:=true,
- org.eclipse.passage.lic.internal.base.diagnostic.code;x-friends:="org.eclipse.passage.lic.hc",
+ org.eclipse.passage.lic.internal.base.diagnostic.code;x-friends:="org.eclipse.passage.lic.hc,org.eclipse.passage.lic.equinox",
  org.eclipse.passage.lic.internal.base.i18n;x-internal:=true,
  org.eclipse.passage.lic.internal.base.inspection;x-internal:=true,
  org.eclipse.passage.lic.internal.base.inspection.hardware;x-internal:=true,

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
@@ -68,6 +68,7 @@ public final class BaseServiceInvocationResult<T> implements ServiceInvocationRe
 		return data;
 	}
 
+	// FIXME: pull it up
 	public static final class Sum<T> implements BinaryOperator<ServiceInvocationResult<T>> {
 
 		private final BinaryOperator<T> sum;

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/KeyValuePairs.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/KeyValuePairs.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+
+public final class KeyValuePairs {
+
+	private final String source;
+	private final String error;
+
+	public KeyValuePairs(String source, String error) {
+		Objects.requireNonNull(source, "KeyValuePairs::source"); //$NON-NLS-1$
+		this.source = source;
+		this.error = error;
+	}
+
+	public Properties get() throws LicensingException {
+		Properties properties = new Properties();
+		try (StringReader reader = new StringReader(source)) {
+			properties.load(reader);
+		} catch (IOException e) {
+			throw fail(e);
+		}
+		return properties;
+	}
+
+	private LicensingException fail(IOException e) {
+		return new LicensingException(error, e);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/KeyValuePairs.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/KeyValuePairs.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.base.i18n.BaseMessages;
 
 public final class KeyValuePairs {
 
@@ -26,8 +27,13 @@ public final class KeyValuePairs {
 
 	public KeyValuePairs(String source, String error) {
 		Objects.requireNonNull(source, "KeyValuePairs::source"); //$NON-NLS-1$
+		Objects.requireNonNull(error, "KeyValuePairs::error"); //$NON-NLS-1$
 		this.source = source;
 		this.error = error;
+	}
+
+	public KeyValuePairs(String source) {
+		this(source, BaseMessages.getString("KeyValuePairs.default_error")); //$NON-NLS-1$
 	}
 
 	public Properties get() throws LicensingException {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/DiagnosticExplained.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/diagnostic/DiagnosticExplained.java
@@ -58,7 +58,7 @@ public final class DiagnosticExplained implements Supplier<String> {
 	}
 
 	private void append(Trouble trouble, StringBuilder out) {
-		out.append("\t") //$NON-NLS-1$
+		out.append("\r\n\t") //$NON-NLS-1$
 				.append(trouble.details()) //
 				.append(" (") //$NON-NLS-1$
 				.append(trouble.code().code()) //

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/BaseMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/BaseMessages.properties
@@ -38,6 +38,7 @@ ConditionMiners_mine_task_name=Found licensing conditions for configuration: %s 
 ConditionMiners.e_mining_failed=Error for configuration: %s (%s)
 FileCollection.failure=Files collecting failed
 JointRegistry.retrieve_absent=No service for id %s can be found among %d following registries: \n\t%s
+KeyValuePairs.default_error=Failed to parse string to properties
 LicensingConditions_validation_invalid_from=Valid from starts in the future for condition %s
 LicensingConditions_validation_invalid_until=Valid until ends in the past for condition %s
 LicensingConditions_validation_no_from=Valid from not specified for condition %s

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/BundleResource.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/BundleResource.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.osgi.framework.Bundle;
+
+public final class BundleResource implements Supplier<Optional<URL>> {
+	private final Bundle bundle;
+	private final Path path;
+
+	public BundleResource(Bundle bundle, Path path) {
+		this.bundle = bundle;
+		this.path = path;
+	}
+
+	@Override
+	public Optional<URL> get() {
+		return Optional.ofNullable(FileLocator.find(bundle, new org.eclipse.core.runtime.Path(path.toString())));
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/AccessMessages.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/AccessMessages.java
@@ -17,6 +17,12 @@ import org.eclipse.osgi.util.NLS;
 public class AccessMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.passage.lic.internal.equinox.i18n.AccessMessages"; //$NON-NLS-1$
 	public static String EquinoxPassage_no_framewrok;
+	public static String RequirementCapabilitiesFromManifest_ioe;
+	public static String RequirementsFromBundle_no_capabilities;
+	public static String RequirementsFromBundle_no_wiring;
+	public static String RequirementsFromManifest_failure;
+	public static String RequirementsFromManifest_no_manifest;
+	public static String RequirementsFromManifest_reading_error;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, AccessMessages.class);

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/AccessMessages.properties
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/i18n/AccessMessages.properties
@@ -1,1 +1,7 @@
 EquinoxPassage_no_framewrok=Passage is looking for licensing framework supplier - and finds none
+RequirementCapabilitiesFromManifest_ioe=Failed to recognize manifest structure in \r\n%s\r\n
+RequirementsFromBundle_no_capabilities=Failed to decompose Bundle to Requirements: no capabilities
+RequirementsFromBundle_no_wiring=Failed to decompose Bundle to Requirements: no wiring
+RequirementsFromManifest_failure=Manifest reading error is treated as sabotage
+RequirementsFromManifest_no_manifest=Failed to read manifest file %s has not been found in %s
+RequirementsFromManifest_reading_error=Failed to read manifest file of %s

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifest.java
@@ -43,7 +43,7 @@ final class BundleManifest {
 			throw noManifest();
 		}
 		try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(url.get().openStream()))) {
-			return reader.lines().collect(Collectors.joining());
+			return reader.lines().collect(Collectors.joining("\n")); //$NON-NLS-1$
 		} catch (IOException e) {
 			throw errorOnReading(e);
 		}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.equinox.BundleResource;
+import org.eclipse.passage.lic.internal.equinox.i18n.AccessMessages;
+import org.osgi.framework.Bundle;
+
+final class BundleManifest {
+
+	private final Bundle bundle;
+	private final Path midpath = Paths.get("META-INF").resolve("MANIFEST.MF"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	public BundleManifest(Bundle bundle) {
+		Objects.requireNonNull(bundle, "BundleManifest::bundle"); //$NON-NLS-1$
+		this.bundle = bundle;
+	}
+
+	public String get() throws LicensingException {
+		Optional<URL> url = new BundleResource(bundle, midpath).get();
+		if (!url.isPresent()) {
+			throw noManifest();
+		}
+		try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(url.get().openStream()))) {
+			return reader.lines().collect(Collectors.joining());
+		} catch (IOException e) {
+			throw errorOnReading(e);
+		}
+	}
+
+	private LicensingException errorOnReading(IOException e) {
+		return new LicensingException(String.format(//
+				AccessMessages.RequirementsFromManifest_reading_error, //
+				e));
+	}
+
+	private LicensingException noManifest() {
+		return new LicensingException(String.format(//
+				AccessMessages.RequirementsFromManifest_no_manifest, //
+				midpath, //
+				bundle.getSymbolicName()));
+	}
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureId.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureId.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class CapabilityLicFeatureId extends CapabilityLicFeatureInfo {
 
 	public CapabilityLicFeatureId(Requirement requirement) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureInfo.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureInfo.java
@@ -31,7 +31,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * @see NamedData
  * @see NamedData.Writable
  */
-@SuppressWarnings("restriction")
 abstract class CapabilityLicFeatureInfo extends StringNamedData {
 
 	public CapabilityLicFeatureInfo(String value) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureLevel.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureLevel.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class CapabilityLicFeatureLevel extends CapabilityLicFeatureInfo {
 
 	public CapabilityLicFeatureLevel(Requirement requirement) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureName.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureName.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class CapabilityLicFeatureName extends CapabilityLicFeatureInfo {
 
 	public CapabilityLicFeatureName(Requirement requirement) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureProvider.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureProvider.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class CapabilityLicFeatureProvider extends CapabilityLicFeatureInfo {
 
 	public CapabilityLicFeatureProvider(Requirement requirement) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureVersion.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/CapabilityLicFeatureVersion.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class CapabilityLicFeatureVersion extends CapabilityLicFeatureInfo {
 
 	public CapabilityLicFeatureVersion(Requirement requirement) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureId.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureId.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class ComponentLicFeatureId extends StringNamedData {
 
 	public ComponentLicFeatureId(String identifier) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureLevel.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureLevel.java
@@ -24,7 +24,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class ComponentLicFeatureLevel extends StringNamedData {
 
 	public ComponentLicFeatureLevel(String version) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureName.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureName.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class ComponentLicFeatureName extends StringNamedData {
 
 	public ComponentLicFeatureName(String version) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureProvider.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureProvider.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class ComponentLicFeatureProvider extends StringNamedData {
 
 	public ComponentLicFeatureProvider(String identifier) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureVersion.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ComponentLicFeatureVersion.java
@@ -23,7 +23,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData
  */
-@SuppressWarnings("restriction")
 public final class ComponentLicFeatureVersion extends StringNamedData {
 
 	public ComponentLicFeatureVersion(String version) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityAttributesFromDeclaration.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityAttributesFromDeclaration.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.KeyValuePairs;
+
+/**
+ * Looks for {@linkplain Requirement} declaration in a single
+ * {@code Capability}.
+ * 
+ * @see RequirementsFromBundle
+ * @see BundleRequirements
+ */
+final class LicCapabilityAttributesFromDeclaration {
+
+	private final String declarations;
+
+	public LicCapabilityAttributesFromDeclaration(String declarations) {
+		this.declarations = declarations;
+	}
+
+	public Collection<Map<String, Object>> get() throws LicensingException {
+		String namespace = new LicCapabilityNamespace().get();
+		List<String> sources = Arrays.stream(declarations.split(",")) //$NON-NLS-1$
+				.map(String::trim) //
+				.filter(source -> source.startsWith(namespace)) //
+				.filter(declaration -> !declaration.isEmpty())//
+				.map(source -> source.substring(0, namespace.length()))//
+				.collect(Collectors.toList());
+		List<Map<String, Object>> structured = new ArrayList<>();
+		for (String source : sources) {
+			structured.add(attributes(source));
+		} // morsel failure is contagious
+		return structured;
+	}
+
+	private Map<String, Object> attributes(String source) throws LicensingException {
+		Properties properties = new KeyValuePairs(//
+				lined(source), //
+				"Failed to compose licensing requirement declaration") //$NON-NLS-1$
+						.get();
+		return properties.keySet().stream() //
+				.map(String.class::cast)//
+				.collect(Collectors.toMap(Function.identity(), properties::get));
+	}
+
+	private String lined(String source) {
+		return source.replaceAll(";", "\n"); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicensingFeatureCapabilitiesFromBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/LicensingFeatureCapabilitiesFromBundle.java
@@ -33,7 +33,6 @@ import org.osgi.framework.wiring.BundleWiring;
  * {@code bundle}.
  * </p>
  */
-@SuppressWarnings("restriction")
 final class LicensingFeatureCapabilitiesFromBundle extends BaseNamedData<List<BundleCapability>> {
 
 	protected LicensingFeatureCapabilitiesFromBundle(Bundle bundle) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.equinox.i18n.AccessMessages;
+
+final class ProvidedCapabilitiesFromManifest {
+
+	private final String manifest;
+
+	ProvidedCapabilitiesFromManifest(String manifest) {
+		Objects.requireNonNull(manifest, "ProvidedCapabilitiesFromManifest::manifest"); //$NON-NLS-1$
+		this.manifest = manifest;
+	}
+
+	public Optional<String> get() throws LicensingException {
+		Properties properties = new Properties();
+		try {
+			properties.load(new StringReader(lined()));
+		} catch (IOException e) {
+			throw fail(e);
+		}
+		return Optional.ofNullable(properties.getProperty(new RequirementsToBundle().key()));
+	}
+
+	private String lined() {
+		return manifest//
+				.replaceAll("\r\n ", "\\\\\r\n") // -- windows -- //$NON-NLS-1$//$NON-NLS-2$
+				.replaceAll("\n ", "\\\\\n"); // -- nix -- //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	private LicensingException fail(IOException e) {
+		return new LicensingException(AccessMessages.RequirementCapabilitiesFromManifest_ioe, e);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifest.java
@@ -12,13 +12,11 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.equinox.requirements;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 
 import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.base.KeyValuePairs;
 import org.eclipse.passage.lic.internal.equinox.i18n.AccessMessages;
 
 final class ProvidedCapabilitiesFromManifest {
@@ -31,23 +29,17 @@ final class ProvidedCapabilitiesFromManifest {
 	}
 
 	public Optional<String> get() throws LicensingException {
-		Properties properties = new Properties();
-		try {
-			properties.load(new StringReader(lined()));
-		} catch (IOException e) {
-			throw fail(e);
-		}
-		return Optional.ofNullable(properties.getProperty(new RequirementsToBundle().key()));
+		return Optional.ofNullable(//
+				new KeyValuePairs(//
+						lined(), //
+						AccessMessages.RequirementCapabilitiesFromManifest_ioe).get()//
+								.getProperty(new RequirementsToBundle().key()));
 	}
 
 	private String lined() {
 		return manifest//
 				.replaceAll("\r\n ", "\\\\\r\n") // -- windows -- //$NON-NLS-1$//$NON-NLS-2$
 				.replaceAll("\n ", "\\\\\n"); // -- nix -- //$NON-NLS-1$//$NON-NLS-2$
-	}
-
-	private LicensingException fail(IOException e) {
-		return new LicensingException(AccessMessages.RequirementCapabilitiesFromManifest_ioe, e);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromAttributes.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromAttributes.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.diagnostic.Trouble;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.api.restrictions.RestrictionLevel;
+import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.internal.base.diagnostic.code.ServiceFailedOnMorsel;
+import org.eclipse.passage.lic.internal.base.requirements.BaseFeature;
+import org.eclipse.passage.lic.internal.base.requirements.BaseRequirement;
+import org.eclipse.passage.lic.internal.base.restrictions.DefaultRestrictionLevel;
+import org.eclipse.passage.lic.internal.base.version.DefaultVersion;
+import org.eclipse.passage.lic.internal.base.version.SafeVersion;
+import org.eclipse.passage.lic.internal.equinox.i18n.EquinoxMessages;
+import org.osgi.framework.Bundle;
+
+/**
+ * Looks for {@linkplain Requirement} declaration in a single
+ * {@code Capability}.
+ * 
+ * @see RequirementsFromBundle
+ * @see BundleRequirements
+ */
+@SuppressWarnings("restriction")
+final class RequirementFromAttributes implements Supplier<ServiceInvocationResult<Collection<Requirement>>> {
+
+	private final Bundle bundle;
+	private final Map<String, Object> attributes;
+
+	public RequirementFromAttributes(Bundle bundle, Map<String, Object> attributes) {
+		this.bundle = bundle;
+		this.attributes = attributes;
+	}
+
+	@Override
+	public ServiceInvocationResult<Collection<Requirement>> get() {
+		Optional<String> feature = new CapabilityLicFeatureId(attributes).get();
+		if (!feature.isPresent()) {
+			return fail(NLS.bind(EquinoxMessages.RequirementsFromCapability_no_feature_id, //
+					new LicCapabilityNamespace().get(), new BundleName(bundle).get()));
+		}
+		return succeed(requirementFromAttributes(feature.get()));
+	}
+
+	private Requirement requirementFromAttributes(String feature) {
+		String version = new CapabilityLicFeatureVersion(attributes).get()//
+				.map(value -> new SafeVersion(value).value())//
+				.orElse(new DefaultVersion().value());
+		String name = new CapabilityLicFeatureName(attributes).get()//
+				.orElse(feature);
+		String provider = new CapabilityLicFeatureProvider(attributes).get()//
+				.orElseGet(new BundleVendor(bundle));
+		RestrictionLevel level = new CapabilityLicFeatureLevel(attributes).get()//
+				.<RestrictionLevel>map(RestrictionLevel.Of::new) //
+				.orElseGet(new DefaultRestrictionLevel());
+		BaseRequirement requirement = new BaseRequirement(//
+				new BaseFeature(feature, version, name, provider), //
+				level, //
+				bundle.getSymbolicName());
+		return requirement;
+	}
+
+	private ServiceInvocationResult<Collection<Requirement>> fail(String explanation) {
+		return new BaseServiceInvocationResult<>(new Trouble(new ServiceFailedOnMorsel(), explanation));
+	}
+
+	private ServiceInvocationResult<Collection<Requirement>> succeed(Requirement requirement) {
+		return new BaseServiceInvocationResult<>(Collections.singleton(requirement));
+	}
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromAttributes.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromAttributes.java
@@ -86,4 +86,5 @@ final class RequirementFromAttributes implements Supplier<ServiceInvocationResul
 	private ServiceInvocationResult<Collection<Requirement>> succeed(Requirement requirement) {
 		return new BaseServiceInvocationResult<>(Collections.singleton(requirement));
 	}
+
 }

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementToCapability.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementToCapability.java
@@ -34,7 +34,6 @@ import org.eclipse.passage.lic.internal.base.StringNamedData;
  * 
  * @see NamedData.Writable
  */
-@SuppressWarnings("restriction")
 public final class RequirementToCapability implements NamedData<Requirement> {
 
 	private final Requirement requirement;

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromBundle.java
@@ -48,6 +48,7 @@ final class RequirementsFromBundle extends BaseNamedData<ServiceInvocationResult
 	}
 
 	private final static class FromBundle {
+
 		private final Bundle bundle;
 
 		FromBundle(Bundle bundle) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifest.java
@@ -14,6 +14,7 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -40,6 +41,7 @@ final class RequirementsFromManifest implements Supplier<ServiceInvocationResult
 	private final Bundle bundle;
 
 	public RequirementsFromManifest(Bundle bundle) {
+		Objects.requireNonNull(bundle, "RequirementsFromManifest::bundle"); //$NON-NLS-1$
 		this.bundle = bundle;
 	}
 

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.diagnostic.Trouble;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.internal.base.diagnostic.code.ServiceFailedOnMorsel;
+import org.eclipse.passage.lic.internal.equinox.i18n.AccessMessages;
+import org.osgi.framework.Bundle;
+
+/**
+ * Some bundles come to runtime in invalid state. Nevertheless we must look for
+ * {@linkplain Requirement}s in these bundles too. Thus, we try to read
+ * MANIFEST.MF manually and scan the content for licensing requirement
+ * declarations.
+ * 
+ * @see RequirementsFromBundle
+ */
+@SuppressWarnings("restriction")
+final class RequirementsFromManifest implements Supplier<ServiceInvocationResult<Collection<Requirement>>> {
+
+	private final Bundle bundle;
+	private final Trouble hiring;
+	private final String target;
+
+	public RequirementsFromManifest(Bundle bundle, Trouble hiring, String target) {
+		this.bundle = bundle;
+		this.hiring = hiring;
+		this.target = target;
+	}
+
+	@Override
+	public ServiceInvocationResult<Collection<Requirement>> get() {
+		try {
+			return scan();
+		} catch (LicensingException e) {
+			return new BaseServiceInvocationResult<>(new Trouble(//
+					new ServiceFailedOnMorsel(), //
+					AccessMessages.RequirementsFromManifest_failure));
+		}
+	}
+
+	private ServiceInvocationResult<Collection<Requirement>> scan() throws LicensingException {
+		String manifest = new BundleManifest(bundle).get();
+		Optional<String> provided = new ProvidedCapabilitiesFromManifest(manifest).get();
+		if (!provided.isPresent()) {
+			return none();
+		}
+		return null;// FIXME: implement
+	}
+
+	private ServiceInvocationResult<Collection<Requirement>> none() {
+		return new BaseServiceInvocationResult<>(new ArrayList<Requirement>());
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsToBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsToBundle.java
@@ -34,7 +34,6 @@ import org.eclipse.passage.lic.internal.base.NamedData;
  * 
  * @see NamedData.Writable
  */
-@SuppressWarnings("restriction")
 public final class RequirementsToBundle implements NamedData<List<Requirement>> {
 
 	private final List<Requirement> requirements;

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/KeyValuePairsTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/KeyValuePairsTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Properties;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.base.KeyValuePairs;
+import org.junit.Test;
+
+public final class KeyValuePairsTest {
+
+	@Test
+	public void empty() {
+		assertTrue(properties("").isEmpty()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void single() {
+		Properties properties = properties("key=value");//$NON-NLS-1$
+		assertEquals(1, properties.size());
+		assertProperty(properties, "key", "value"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void sequential() {
+		Properties properties = properties("key1=value1\nkey2=value2");//$NON-NLS-1$
+		assertEquals(2, properties.size());
+		assertProperty(properties, "key1", "value1"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertProperty(properties, "key2", "value2"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void incomplete() {
+		Properties properties = properties("key");//$NON-NLS-1$
+		assertEquals(1, properties.size());
+		assertProperty(properties, "key", ""); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Test
+	public void spacesAndQuotes() {
+		Properties properties = properties(//
+				"licensing.feature=\"PI\"\nversion=\"3.14.15\"\nname=\"PI of version PI\"\nlevel=\"error\""); //$NON-NLS-1$
+		assertEquals(4, properties.size());
+		assertProperty(properties, "licensing.feature", "\"PI\""); //$NON-NLS-1$ //$NON-NLS-2$
+		assertProperty(properties, "version", "\"3.14.15\""); //$NON-NLS-1$ //$NON-NLS-2$
+		assertProperty(properties, "name", "\"PI of version PI\""); //$NON-NLS-1$ //$NON-NLS-2$
+		assertProperty(properties, "level", "\"error\""); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private void assertProperty(Properties properties, String key, String value) {
+		assertTrue(properties.containsKey(key));
+		assertEquals(value, properties.get(key));
+	}
+
+	private Properties properties(String source) {
+		try {
+			return new KeyValuePairs(source, "intended").get(); //$NON-NLS-1$
+		} catch (LicensingException e) {
+			fail("Is not intended to fail on valid data"); //$NON-NLS-1$
+			return new Properties();// unreachable
+		}
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void sourceIsMandatory() {
+		new KeyValuePairs(null, "intended"); //$NON-NLS-1$
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void errorContextIsMandatory() {
+		new KeyValuePairs("should not be parsed", null); //$NON-NLS-1$
+	}
+}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifestTest.java
@@ -22,6 +22,11 @@ import org.osgi.framework.FrameworkUtil;
 
 public final class BundleManifestTest {
 
+	@Test(expected = NullPointerException.class)
+	public void sourceIsMandatory() {
+		new BundleManifest(null);
+	}
+
 	@Test
 	public void readManifest() {
 		try {

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleManifestTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+public final class BundleManifestTest {
+
+	@Test
+	public void readManifest() {
+		try {
+			assertFalse(new BundleManifest(bundle()).get().isEmpty());
+		} catch (LicensingException e) {
+			fail("Manifest reading failed"); //$NON-NLS-1$
+		}
+	}
+
+	private Bundle bundle() {
+		return FrameworkUtil.getBundle(getClass());
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityAttributesFromDeclarationTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/LicCapabilityAttributesFromDeclarationTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.junit.Test;
+
+public final class LicCapabilityAttributesFromDeclarationTest {
+
+	@Test
+	public void empty() {
+		assertTrue(packs("").isEmpty()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void foreign() {
+		assertTrue(packs("foreign.capability-first;property1=value1;property2=value2," //$NON-NLS-1$
+				+ " foreign.capability-second;property1=value1;property2=value2" //$NON-NLS-1$
+		).isEmpty());
+	}
+
+	@Test
+	public void several() {
+		Collection<Map<String, Object>> packs = packs(
+				"licensing.feature;licensing.feature=\"PI\";version=\"3.14.15\";name=\"PI of version PI\";level=\"error\",\r\n" //$NON-NLS-1$
+						+ " licensing.feature;licensing.feature=\"E\";version=\"2.71.82\";name=\"Euler number\";level=\"info\";provider=\"Euler\",\r\n" //$NON-NLS-1$
+						+ " licensing.feature;licensing.feature=\"Incomplete\",\r\n" //$NON-NLS-1$
+						+ " licensing.feature"); //$NON-NLS-1$
+		assertEquals(4, packs.size()); // all read
+		assertEquals(1, packs.stream().filter(Map::isEmpty).count()); // including the empty one
+		Optional<Map<String, Object>> pi = packs.stream()//
+				.filter(map -> "PI".equals(map.get("licensing.feature"))) //$NON-NLS-1$ //$NON-NLS-2$
+				.findFirst();
+		assertTrue(pi.isPresent());
+		assertEquals("3.14.15", pi.get().get("version")); //$NON-NLS-1$//$NON-NLS-2$
+		assertEquals("PI of version PI", pi.get().get("name")); //$NON-NLS-1$//$NON-NLS-2$
+		assertEquals("error", pi.get().get("level")); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void sourceIsMandatory() {
+		new LicCapabilityAttributesFromDeclaration(null);
+	}
+
+	private Collection<Map<String, Object>> packs(String source) {
+		try {
+			return new LicCapabilityAttributesFromDeclaration(source).get();
+		} catch (LicensingException e) {
+			fail("Not intended to fail on valid data"); //$NON-NLS-1$
+			return Collections.emptySet(); // unreachable
+		}
+
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/ProvidedCapabilitiesFromManifestTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.junit.Test;
+
+public final class ProvidedCapabilitiesFromManifestTest {
+
+	@Test
+	public void empty() {
+		String manifest = "Manifest-Version: 1.0\r\n" //$NON-NLS-1$
+				+ "Automatic-Module-Name: org.eclipse.passage.lic.equinox.tests\r\n" //$NON-NLS-1$
+				+ "Bundle-ManifestVersion: 2\r\n" //$NON-NLS-1$
+				+ "Bundle-SymbolicName: org.eclipse.passage.lic.equinox.tests\r\n" //$NON-NLS-1$
+				+ "Bundle-Version: 0.6.0.qualifier\r\n" //$NON-NLS-1$
+				+ "Bundle-RequiredExecutionEnvironment: JavaSE-1.8\r\n" //$NON-NLS-1$
+				+ "Bundle-Name: %Bundle-Name\r\n" //$NON-NLS-1$
+				+ "Bundle-Vendor: %Bundle-Vendor\r\n" //$NON-NLS-1$
+				+ "Bundle-Copyright: %Bundle-Copyright\r\n" //$NON-NLS-1$
+				+ "Fragment-Host: org.eclipse.passage.lic.equinox\r\n" //$NON-NLS-1$
+				+ "Require-Bundle: org.junit;bundle-version=\"0.0.0\",\r\n" //$NON-NLS-1$
+				+ " org.eclipse.passage.lic.api.tests;bundle-version=\"1.0.0\""; //$NON-NLS-1$
+		try {
+			assertFalse(new ProvidedCapabilitiesFromManifest(manifest).get().isPresent());
+		} catch (LicensingException e) {
+			fail("Manifest scanning is not supposed to fail on valid data"); //$NON-NLS-1$
+		}
+	}
+
+	@Test
+	public void existingWindowsLineEndings() {
+		testExistingDeclarations("\r\n"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void existingNixLineEndings() {
+		testExistingDeclarations("\n"); //$NON-NLS-1$
+	}
+
+	private void testExistingDeclarations(String ending) {
+		try {
+			Optional<String> declarations = new ProvidedCapabilitiesFromManifest(manifest(ending)).get();
+			assertTrue(declarations.isPresent());
+			assertTrue(declarations.get().startsWith("licensing.feature;")); //$NON-NLS-1$
+			assertTrue(declarations.get().endsWith("licensing.feature")); //$NON-NLS-1$
+			assertTrue(declarations.get().contains("\"Euler number\"")); //$NON-NLS-1$
+			assertTrue(declarations.get().contains(";level=\"error\"")); //$NON-NLS-1$
+		} catch (LicensingException e) {
+			fail("Manifest scanning is not supposed to fail on valid data"); //$NON-NLS-1$
+		}
+	}
+
+	private String manifest(String ending) {
+		return "Manifest-Version: 1.0" + ending //$NON-NLS-1$
+				+ "Automatic-Module-Name: org.eclipse.passage.lic.equinox.tests.data.requirements" + ending //$NON-NLS-1$
+				+ "Bundle-ManifestVersion: 2" + ending //$NON-NLS-1$
+				+ "Bundle-SymbolicName: org.eclipse.passage.lic.equinox.tests.data.requirements;singleton:=true" //$NON-NLS-1$
+				+ ending + "Bundle-Version: 0.1.0.qualifier" + ending //$NON-NLS-1$
+				+ "Bundle-RequiredExecutionEnvironment: JavaSE-1.8" + ending //$NON-NLS-1$
+				+ "Bundle-Name: Data for Passage LIC Equinox requirements tests" + ending //$NON-NLS-1$
+				+ "Bundle-Vendor: Eclipse Passage " + ending //$NON-NLS-1$
+				+ "Bundle-Copyright: %Bundle-Copyright" + ending //$NON-NLS-1$
+				+ "Provide-Capability: licensing.feature;licensing.feature=\"PI\";version=\"3.14.15\";name=\"PI of version PI\";level=\"error\"," //$NON-NLS-1$
+				+ ending
+				+ " licensing.feature;licensing.feature=\"E\";version=\"2.71.82\";name=\"Euler number\";level=\"info\";provider=\"Euler\"," //$NON-NLS-1$
+				+ ending + " licensing.feature;licensing.feature=\"Incomplete\"," + ending //$NON-NLS-1$
+				+ " licensing.feature" + ending //$NON-NLS-1$
+				+ "Service-Component: OSGI-INF/*.xml" + ending //$NON-NLS-1$
+				+ "Bundle-ActivationPolicy: lazy" + ending //$NON-NLS-1$
+				+ "Require-Bundle: org.eclipse.osgi.services;bundle-version=\"3.8.0\""; //$NON-NLS-1$
+	}
+}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromManifestTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.requirements;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.requirements.Requirement;
+import org.eclipse.passage.lic.internal.base.diagnostic.NoErrors;
+import org.eclipse.passage.lic.internal.base.diagnostic.NoSevereErrors;
+import org.junit.Test;
+import org.osgi.framework.FrameworkUtil;
+
+public class RequirementsFromManifestTest {
+
+	@Test
+	public void empty() {
+		ServiceInvocationResult<Collection<Requirement>> response = new RequirementsFromManifest(
+				FrameworkUtil.getBundle(getClass())).get();
+		assertTrue(new NoErrors().test(response.diagnostic()));
+		assertTrue(response.data().isPresent());
+		assertTrue(response.data().get().isEmpty());
+	}
+
+	@Test
+	public void several() {
+		ServiceInvocationResult<Collection<Requirement>> response = //
+				new RequirementsFromManifest(new DataBundle().bundle()).get();
+		assertFalse(new NoSevereErrors().test(response.diagnostic()));
+		assertTrue(response.data().isPresent());
+		assertEquals(3, response.data().get().size());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void sourceIsMandatory() {
+		new RequirementsFromManifest(null);
+	}
+
+}

--- a/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/user/TestCustomers.java
+++ b/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/user/TestCustomers.java
@@ -60,7 +60,6 @@ abstract class TestCustomers implements TestData<CustomerStorage> {
 							"Михайло Васиильевич Ломоноосов" } //$NON-NLS-1$
 			});
 		}
-
 	}
 
 	static final class Empty extends TestCustomers {


### PR DESCRIPTION
The solution has been implemented: if a bundle cannot be scanned for Requirements by means of the Equinox facilities, it's manifest is read manually.


