### PR TITLE
Bug 567347 no-requirements case causes empty diagnostic dialog to appear

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
@@ -27,10 +27,6 @@ public final class BaseServiceInvocationResult<T> implements ServiceInvocationRe
 	private final Diagnostic diagnostic;
 	private final Optional<T> data;
 
-	public BaseServiceInvocationResult() {
-		this(new BaseDiagnostic(), Optional.empty());
-	}
-
 	public BaseServiceInvocationResult(Trouble severe) {
 		this(new BaseDiagnostic(severe), Optional.empty());
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Assess.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Assess.java
@@ -12,11 +12,14 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.access;
 
+import java.util.Collections;
+
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.diagnostic.Diagnostic;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.internal.base.restrictions.BaseExaminationCertificate;
 
 final class Assess extends Cycle<ServiceInvocationResult<ExaminationCertificate>> {
 
@@ -41,7 +44,10 @@ final class Assess extends Cycle<ServiceInvocationResult<ExaminationCertificate>
 
 	@Override
 	protected ServiceInvocationResult<ExaminationCertificate> freeWayOut() {
-		return new BaseServiceInvocationResult<ExaminationCertificate>();
+		return new BaseServiceInvocationResult<ExaminationCertificate>(//
+				new BaseExaminationCertificate(//
+						Collections.emptyMap(), //
+						Collections.emptySet()));
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Conditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Conditions.java
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.internal.base.access;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -69,7 +70,7 @@ public final class Conditions implements Supplier<ServiceInvocationResult<Collec
 				.map(miner -> miner.all(product)) //
 				.reduce(new BaseServiceInvocationResult.Sum<>(new SumOfCollections<ConditionPack>()))//
 				.map(filter) //
-				.orElse(new BaseServiceInvocationResult<>());
+				.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
 
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Permissions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Permissions.java
@@ -55,7 +55,7 @@ public final class Permissions implements Supplier<ServiceInvocationResult<Colle
 				.map(r -> new BaseServiceInvocationResult<Collection<Permission>>(//
 						r.diagnostic(), //
 						allPermissions(r.data())))//
-				.orElseGet(BaseServiceInvocationResult<Collection<Permission>>::new);
+				.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
 	}
 
 	private Collection<Permission> allPermissions(Optional<Collection<Emission>> emissions) {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BasePermissionEmittingService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/evaluation/BasePermissionEmittingService.java
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.internal.base.conditions.evaluation;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -78,7 +79,7 @@ public final class BasePermissionEmittingService implements PermissionEmittingSe
 		return conditions.stream() //
 				.map(pack -> emitFor(pack, product))//
 				.reduce(new BaseServiceInvocationResult.Sum<Collection<Emission>>(new SumOfCollections<>()))//
-				.orElse(new BaseServiceInvocationResult<>());
+				.orElse(new BaseServiceInvocationResult<>(new ArrayList<>()));
 	}
 
 	private ServiceInvocationResult<Collection<Emission>> emitFor(ConditionPack pack, LicensedProduct product) {
@@ -86,7 +87,7 @@ public final class BasePermissionEmittingService implements PermissionEmittingSe
 				.map(condition -> emitFor(condition, pack, product))//
 				.reduce(new BaseServiceInvocationResult.Sum<Emission>(new SumOfEmissions()))//
 				.map(this::singleton)//
-				.orElse(new BaseServiceInvocationResult<Collection<Emission>>());
+				.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
 	}
 
 	private ServiceInvocationResult<Collection<Emission>> singleton(ServiceInvocationResult<Emission> origin) {

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleRequirements.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/BundleRequirements.java
@@ -14,6 +14,7 @@ package org.eclipse.passage.lic.internal.equinox.requirements;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
@@ -72,7 +73,7 @@ public final class BundleRequirements implements ResolvedRequirements {
 				.filter(Optional::isPresent)//
 				.map(Optional::get)//
 				.reduce(new BaseServiceInvocationResult.Sum<>(new SumOfCollections<Requirement>()))//
-				.orElseGet(BaseServiceInvocationResult::new);
+				.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromCapability.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementFromCapability.java
@@ -34,7 +34,6 @@ import org.osgi.framework.wiring.BundleCapability;
  * @see RequirementsFromBundle
  * @see BundleRequirements
  */
-@SuppressWarnings("restriction")
 final class RequirementFromCapability implements Supplier<ServiceInvocationResult<Collection<Requirement>>> {
 
 	private final Bundle bundle;

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/requirements/RequirementsFromBundle.java
@@ -70,7 +70,7 @@ final class RequirementsFromBundle extends BaseNamedData<ServiceInvocationResult
 					.map(capability -> new RequirementFromCapability(bundle, capability))//
 					.map(RequirementFromCapability::get)//
 					.reduce(new BaseServiceInvocationResult.Sum<>(new SumOfCollections<Requirement>()))//
-					.orElseGet(BaseServiceInvocationResult<Collection<Requirement>>::new);
+					.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
 		}
 
 		private ServiceInvocationResult<Collection<Requirement>> fromManifest(String why) {

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/jface/actions/LicensedAction.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/jface/actions/LicensedAction.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.jface.actions;
 
+import java.util.Optional;
+
 import org.eclipse.jface.action.Action;
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
-import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
 import org.eclipse.passage.lic.internal.base.restrictions.CertificateIsRestrictive;
 import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
 import org.eclipse.passage.lic.internal.jface.EquinoxPassageUI;
@@ -26,14 +27,15 @@ public class LicensedAction extends Action {
 
 	@Override
 	public void runWithEvent(Event event) {
-		ServiceInvocationResult<ExaminationCertificate> response = new BaseServiceInvocationResult<>();
+		Optional<ServiceInvocationResult<ExaminationCertificate>> response = Optional.empty();
 		try {
-			response = new EquinoxPassageUI(event.display::getActiveShell).acquireLicense(getId());
-			if (!new CertificateIsRestrictive().test(response.data())) {
+			response = Optional.of(new EquinoxPassageUI(event.display::getActiveShell).acquireLicense(getId()));
+			if (!new CertificateIsRestrictive().test(response.get().data())) {
 				super.runWithEvent(event);
 			}
 		} finally {
-			response.data().ifPresent(certificate -> new EquinoxPassage().releaseLicense(certificate));
+			response.flatMap(ServiceInvocationResult::data)//
+					.ifPresent(certificate -> new EquinoxPassage().releaseLicense(certificate));
 		}
 	}
 


### PR DESCRIPTION
- Fix `Access` cycle implementation: return positive certificate in case of free way out (no requirements are defined)
 - eliminate any possibility to return inane response from a service: prohibit default constructor

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>