### PR TITLE
Bug 567250 cannot get existing resource file from jar-ed bundle

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/BundleKeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/io/BundleKeyKeeper.java
@@ -21,12 +21,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.io.KeyKeeper;
 import org.eclipse.passage.lic.internal.base.io.FileNameFromLicensedProduct;
 import org.eclipse.passage.lic.internal.base.io.PassageFileExtension;
+import org.eclipse.passage.lic.internal.equinox.BundleResource;
 import org.eclipse.passage.lic.internal.equinox.i18n.EquinoxMessages;
 import org.osgi.framework.Bundle;
 
@@ -77,10 +77,7 @@ public final class BundleKeyKeeper implements KeyKeeper {
 	 * {@linkplain LicensingException}
 	 */
 	private URL resource(Path path) throws LicensingException {
-		Optional<URL> url = Optional.ofNullable(//
-				FileLocator.find(//
-						bundle, //
-						new org.eclipse.core.runtime.Path(path.toString())));
+		Optional<URL> url = new BundleResource(bundle, path).get();
 		if (!url.isPresent()) {
 			throw new LicensingException(String.format(//
 					EquinoxMessages.BundleKeyKeeper_failed_to_find_file, //


### PR DESCRIPTION
Switch the implementation to the extracted `BundleResource` facility

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>