### PR TITLE
Bug 567032 issue floating license configuration wizard

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/FrameworkAware.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/FrameworkAware.java
@@ -46,7 +46,7 @@ public abstract class FrameworkAware {
 	private final BundleContext context;
 
 	protected FrameworkAware() {
-		this.context = FrameworkUtil.getBundle(getClass()).getBundleContext();
+		this.context = FrameworkUtil.getBundle(FrameworkAware.class).getBundleContext();
 	}
 
 	private Collection<ServiceReference<FrameworkSupplier>> frameworks() {


### PR DESCRIPTION
 Make FramewordAware service construction safe and less dependent on Equinox bundle loading decisions.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>