### PR TITLE
Bug 567032 issue floating license configuration wizard

### DIFF
--- a/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/floating/IssueLicenseRequestPage.java
+++ b/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/floating/IssueLicenseRequestPage.java
@@ -33,7 +33,6 @@ public final class IssueLicenseRequestPage implements Supplier<IWizardPage> {
 	private final Supplier<Optional<Collection<UserDescriptor>>> users;
 	private final Supplier<Optional<ProductVersionDescriptor>> product;
 	private final Supplier<Optional<List<LocalDate>>> period;
-	private final Supplier<Optional<Integer>> capacity;
 	private final ComposedPage page;
 
 	IssueLicenseRequestPage(IEclipseContext context, FloatingDataPack initial) {
@@ -42,7 +41,6 @@ public final class IssueLicenseRequestPage implements Supplier<IWizardPage> {
 		users = page.withUsers();
 		product = page.withProductVersion(initial.product());
 		period = page.withPeriod();
-		capacity = page.withCapacity();
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/license/LabeledField.java
+++ b/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/license/LabeledField.java
@@ -50,7 +50,7 @@ abstract class LabeledField<T> implements Field<T> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public final Optional<T> data() {
-		return Optional.ofNullable((T) widget.getData());
+		return Optional.ofNullable(widget).flatMap(w -> Optional.ofNullable((T) w.getData()));
 	}
 
 	private void installLabel(Composite parent) {

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/request/FLoatingLicenseData.java
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/request/FLoatingLicenseData.java
@@ -32,7 +32,6 @@ public final class FLoatingLicenseData extends GeneralLicenseData implements Flo
 		super(plan, product, from, until);
 		Objects.requireNonNull(users, "PersonalLicenseData::users"); //$NON-NLS-1$
 		this.users = users; // FIXME: work for caching function: keep Map and reimplement retrieves
-
 	}
 
 	public FLoatingLicenseData(Collection<UserDescriptor> users, LicensePlanDescriptor plan,
@@ -68,7 +67,7 @@ public final class FLoatingLicenseData extends GeneralLicenseData implements Flo
 		return users.stream()//
 				.filter(user -> identifier.equals(user.getIdentifier()))//
 				.findAny()//
-				.get(); // yah, fail if not found, it's a developer's
+				.get(); // yah, fail if not found, it's a development problem
 	}
 
 }


### PR DESCRIPTION
1. No need in editing capacity for a license pack as a whole. The decision has been made to attach capacity to a particular grant and let a floating server operate with grants.

2. Fix NPE on early data access for a licensing request page field.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>