### PR TITLE
Bug 557997 - [Passage] Diagrams for Passage Operator

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -214,7 +214,7 @@
         xsi:type="setup.targlets:TargletTask">
       <targlet
           name="${scope.project.label}"
-          activeRepositoryList="2020-06">
+          activeRepositoryList="${eclipse.target.platform}">
         <requirement
             name="com.fasterxml.jackson.core.jackson-annotations"/>
         <requirement


### PR DESCRIPTION
Use ${eclipse.target.platform} as repository list name for modular
target

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>