### PR TITLE
Bug 567035 implement floating license pack issuing

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/BaseServiceInvocationResult.java
@@ -35,10 +35,6 @@ public final class BaseServiceInvocationResult<T> implements ServiceInvocationRe
 		this(new BaseDiagnostic(), Optional.of(data));
 	}
 
-	public BaseServiceInvocationResult(Optional<T> data) {
-		this(new BaseDiagnostic(), data);
-	}
-
 	public BaseServiceInvocationResult(Diagnostic diagnostic) {
 		this(diagnostic, Optional.empty());
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Restrictions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Restrictions.java
@@ -56,6 +56,7 @@ public final class Restrictions implements Supplier<ServiceInvocationResult<Exam
 				registry.services().stream()//
 						.map(service -> service.examine(requirements, permissions, product)) //
 						.reduce(new SumOfCertificates())//
+						.get() // guaranteed to exist as there is at least one service
 		);
 	}
 


### PR DESCRIPTION
Side work: eliminate error-prone constructor for `BaseServiceInvocationResult`.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>