### PR TITLE
Passage Operator UI manifest updates

### DIFF
--- a/bundles/org.eclipse.passage.loc.features.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.features.ui/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.features.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.features.ui;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.7.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.core.contexts;bundle-version="0.0.0",
  org.eclipse.e4.core.di;bundle-version="0.0.0",
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.ui.workbench;bundle-version="0.0.0",
  org.eclipse.jface;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
+ org.eclipse.passage.lic.features.e4.ui;bundle-version="0.5.201",
  org.eclipse.passage.lic.features.model;bundle-version="1.0.0",
  org.eclipse.passage.loc.features.core;bundle-version="1.0.0",
  org.eclipse.passage.loc.workbench;bundle-version="0.0.0"

--- a/bundles/org.eclipse.passage.loc.licenses.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.licenses.ui/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-SymbolicName: org.eclipse.passage.loc.licenses.ui;singleton:=true
-Bundle-Version: 0.6.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Version: 0.7.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.core.contexts;bundle-version="0.0.0",
  org.eclipse.e4.core.di;bundle-version="0.0.0",
@@ -19,6 +19,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.jface;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
+ org.eclipse.passage.lic.licenses.e4.ui;bundle-version="0.5.201",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
  org.eclipse.passage.loc.licenses.core;bundle-version="0.0.0",

--- a/bundles/org.eclipse.passage.loc.products.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.products.ui/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.products.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.products.ui;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.7.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.core.contexts;bundle-version="0.0.0",
  org.eclipse.e4.core.di;bundle-version="0.0.0",
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.ui.workbench;bundle-version="0.0.0",
  org.eclipse.jface;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
+ org.eclipse.passage.lic.products.e4.ui;bundle-version="0.5.201",
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
  org.eclipse.passage.loc.products.core;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.loc.workbench;bundle-version="0.0.0"

--- a/bundles/org.eclipse.passage.loc.users.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.users.ui/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-SymbolicName: org.eclipse.passage.loc.users.ui;singleton:=true
-Bundle-Version: 0.7.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Version: 0.8.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.e4.core.contexts;bundle-version="0.0.0",
  org.eclipse.e4.core.di.annotations;bundle-version="0.0.0",
@@ -19,6 +19,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.jface;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.5.200",
  org.eclipse.passage.lic.jface;bundle-version="0.6.100",
+ org.eclipse.passage.lic.users.e4.ui;bundle-version="0.5.201",
  org.eclipse.passage.loc.api;bundle-version="0.6.0",
  org.eclipse.passage.loc.products.core;bundle-version="0.6.0",
  org.eclipse.passage.loc.report.core;bundle-version="0.1.0",


### PR DESCRIPTION
Add explicit dependency from loc.<domain>.ui to lic.<domain>.e4.ui
Upgrade touched LOC bundles to Java 11

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>