### PR TITLE
Bug 568792 extend access cycle with a license grant acquire/release

### DIFF
--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
@@ -56,7 +56,6 @@ public final class EquinoxPassageUI implements PassageUI {
 			Supplier<ServiceInvocationResult<T>> gain, //
 			Function<T, ExaminationCertificate> get, //
 			Predicate<Optional<ExaminationCertificate>> ok) {
-
 		ServiceInvocationResult<T> result = gain.get();
 		while (exposeAndMayBeEvenFix(result, get, ok)) {
 			result = gain.get();

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
@@ -29,7 +29,6 @@ import org.eclipse.passage.lic.internal.api.conditions.ValidityPeriod;
 import org.eclipse.passage.lic.internal.api.conditions.mining.LicenseReadingService;
 import org.eclipse.passage.lic.internal.api.diagnostic.Diagnostic;
 import org.eclipse.passage.lic.internal.base.conditions.BaseValidityPeriodClosed;
-import org.eclipse.passage.lic.internal.base.diagnostic.DiagnosticExplained;
 import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
 import org.eclipse.passage.lic.internal.equinox.LicenseReadingServiceRequest;
 import org.eclipse.passage.lic.internal.jface.i18n.ImportLicenseDialogMessages;
@@ -155,7 +154,8 @@ public final class ImportLicenseDialog extends NotificationDialog {
 	}
 
 	private void reportError(Diagnostic diagnostic) {
-		setErrorMessage(new DiagnosticExplained(diagnostic).get());
+		setErrorMessage(ImportLicenseDialogMessages.ImportLicenseDialog_lic_read_failed);
+		new DiagnosticDialog(getShell(), diagnostic).open();
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
@@ -10,7 +10,7 @@
 # Contributors:
 #     ArSysOp - initial API and implementation
 ###############################################################################
-DiagnosticDialog_action_copy=Co&py
+DiagnosticDialog_action_copy=Co&py diagnostic
 DiagnosticDialog_action_copy_tooltip=Copy diagnostic state into clipboard.
 DiagnosticDialog_action_view_failure=&View Error...
 DiagnosticDialog_action_view_failure_tooltip=Selected report mention failure. View the exception.

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.java
@@ -23,6 +23,7 @@ public class ImportLicenseDialogMessages extends NLS {
 	public static String ImportLicenseDialog_import_title;
 	public static String ImportLicenseDialog_import_tooltip;
 	public static String ImportLicenseDialog_io_error;
+	public static String ImportLicenseDialog_lic_read_failed;
 	public static String ImportLicenseDialog_path_label;
 	public static String ImportLicenseDialog_prelude;
 	public static String ImportLicenseDialog_title;

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
@@ -17,6 +17,7 @@ ImportLicenseDialog_column_period=Valid
 ImportLicenseDialog_import_title=&Import this license
 ImportLicenseDialog_import_tooltip=Copy this license file to a dedicated directory 
 ImportLicenseDialog_io_error=License import failed due to I/O error: %s
+ImportLicenseDialog_lic_read_failed=Failed to read the license pointed
 ImportLicenseDialog_path_label=From license file:
 ImportLicenseDialog_prelude=Point license file to see what's inside
 ImportLicenseDialog_title=Import License


### PR DESCRIPTION
Usability fix: use dedicated diagnostic dialog to expose possible error on an arbitrary license reading

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>