### PR TITLE
Bug 569004 devise a strategy for under-error licensing requirement

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Lock.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Lock.java
@@ -54,21 +54,20 @@ final class Lock {
 	 * @see LicenseAcquisitionService
 	 */
 	ServiceInvocationResult<GrantLockAttempt> lock(ExaminationCertificate certificate) {
+		if (notPermissive(certificate)) { // #569004
+			return noPermission(certificate);
+		}
 		Permission permission = permission(certificate);
 		ConditionMiningTarget target = permission.conditionOrigin().miner();
 		if (acquirers.get().hasService(target)) {
-			return noAcquisitionServiceForTarget(new BaseGrantLockAttempt.Failed(certificate), target);
+			return noService(new BaseGrantLockAttempt.Failed(certificate), target);
 		}
 		ServiceInvocationResult<GrantAcqisition> grant = acquirers.get().service(target)//
 				.acquire(permission.product(), permission.condition().feature());
 		if (!grant.data().isPresent()) {
-			return new BaseServiceInvocationResult<>(//
-					grant.diagnostic(), //
-					new BaseGrantLockAttempt.Failed(certificate));
+			return noGrant(certificate, grant);
 		}
-		return new BaseServiceInvocationResult<>(//
-				grant.diagnostic(), //
-				new BaseGrantLockAttempt.Successful(certificate, grant.data().get()));//
+		return grant(certificate, grant);
 	}
 
 	ServiceInvocationResult<Boolean> unlock(GrantLockAttempt lock) {
@@ -78,22 +77,45 @@ final class Lock {
 		Permission permission = permission(lock.certificate());
 		ConditionMiningTarget target = permission.conditionOrigin().miner();
 		if (acquirers.get().hasService(target)) {
-			return noAcquisitionServiceForTarget(Boolean.FALSE, target);
+			return noService(Boolean.FALSE, target);
 		}
 		return acquirers.get().service(target).release(permission.product(), lock.grant());
 	}
 
-	private ServiceInvocationResult<Boolean> wrongLockWarning() {
-		return new BaseServiceInvocationResult<>(//
-				new BaseDiagnostic(//
-						Collections.emptyList(), //
-						Collections.singletonList(//
-								new Trouble(//
-										new ServiceFailedOnMorsel(), //
-										AccessCycleMessages.getString("Lock.wrong_release"))))); //$NON-NLS-1$
+	private ServiceInvocationResult<GrantLockAttempt> noPermission(ExaminationCertificate certificate) {
+		return new BaseServiceInvocationResult<>(// #569004
+				fail(AccessCycleMessages.getString("Lock.no_permission")), //$NON-NLS-1$
+				new BaseGrantLockAttempt.Failed(certificate));
 	}
 
-	private <T> ServiceInvocationResult<T> noAcquisitionServiceForTarget(T data, ConditionMiningTarget target) {
+	private BaseServiceInvocationResult<GrantLockAttempt> noGrant(ExaminationCertificate certificate,
+			ServiceInvocationResult<GrantAcqisition> grant) {
+		return new BaseServiceInvocationResult<>(//
+				grant.diagnostic(), //
+				new BaseGrantLockAttempt.Failed(certificate));
+	}
+
+	private BaseServiceInvocationResult<GrantLockAttempt> grant(ExaminationCertificate certificate,
+			ServiceInvocationResult<GrantAcqisition> grant) {
+		return new BaseServiceInvocationResult<>(//
+				grant.diagnostic(), //
+				new BaseGrantLockAttempt.Successful(certificate, grant.data().get()));
+	}
+
+	private ServiceInvocationResult<Boolean> wrongLockWarning() {
+		return new BaseServiceInvocationResult<>(fail("Lock.wrong_release")); //$NON-NLS-1$
+	}
+
+	private BaseDiagnostic fail(String details) {
+		return new BaseDiagnostic(//
+				Collections.emptyList(), //
+				Collections.singletonList(//
+						new Trouble(//
+								new ServiceFailedOnMorsel(), //
+								AccessCycleMessages.getString(details))));
+	}
+
+	private <T> ServiceInvocationResult<T> noService(T data, ConditionMiningTarget target) {
 		return new BaseServiceInvocationResult<T>(//
 				new BaseDiagnostic(new Trouble(//
 						new NoServicesOfType(AccessCycleMessages.getString("Lock.no_service")), //$NON-NLS-1$
@@ -104,9 +126,13 @@ final class Lock {
 				data);
 	}
 
+	private boolean notPermissive(ExaminationCertificate certificate) {
+		return certificate.satisfied().isEmpty(); // #569004
+	}
+
 	/**
-	 * Certificate must be non-restrictive: must contain at least one properly
-	 * satisfied requirement
+	 * Certificate must be permissive: must contain at least one properly satisfied
+	 * requirement // #569004
 	 */
 	private Permission permission(ExaminationCertificate certificate) {
 		Requirement any = certificate.satisfied().iterator().next(); // guaranteed to exist

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Lock.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Lock.java
@@ -59,7 +59,7 @@ final class Lock {
 		}
 		Permission permission = permission(certificate);
 		ConditionMiningTarget target = permission.conditionOrigin().miner();
-		if (acquirers.get().hasService(target)) {
+		if (!acquirers.get().hasService(target)) {
 			return noService(new BaseGrantLockAttempt.Failed(certificate), target);
 		}
 		ServiceInvocationResult<GrantAcqisition> grant = acquirers.get().service(target)//
@@ -76,7 +76,7 @@ final class Lock {
 		}
 		Permission permission = permission(lock.certificate());
 		ConditionMiningTarget target = permission.conditionOrigin().miner();
-		if (acquirers.get().hasService(target)) {
+		if (!acquirers.get().hasService(target)) {
 			return noService(Boolean.FALSE, target);
 		}
 		return acquirers.get().service(target).release(permission.product(), lock.grant());

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
@@ -12,6 +12,7 @@
 ###############################################################################
 Conditions.no_miners=No condition mining services are available, that means there is no one to read a license\!
 Conditions.servive_type=condition mining
+Lock.no_permission=There is no Permission granted, no way to acquire a grant
 Lock.no_service=License acquisition service for expected mining target
 Lock.no_service_for_target=There no License Acquisition Service found for Condition Mining target [%s]
 Lock.wrong_release=Illegal lock release: the lock has not been granted

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/CertificateIsRestrictive.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/restrictions/CertificateIsRestrictive.java
@@ -27,7 +27,7 @@ public final class CertificateIsRestrictive implements Predicate<Optional<Examin
 		if (!new NoSevereRestrictions().test(certificate.get())) {
 			return true;
 		}
-		return certificate.get().satisfied().isEmpty();
+		return false;
 	}
 
 }


### PR DESCRIPTION
Temporarily cover the case from failure.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>