### PR TITLE
Bug 569049 implement license acquiring

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/ArmedMiningTool.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/ArmedMiningTool.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.conditions.mining;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 import org.eclipse.passage.lic.internal.api.LicensingException;
@@ -21,7 +20,6 @@ import org.eclipse.passage.lic.internal.api.conditions.mining.ConditionTransport
 import org.eclipse.passage.lic.internal.api.conditions.mining.MiningTool;
 import org.eclipse.passage.lic.internal.api.io.KeyKeeper;
 import org.eclipse.passage.lic.internal.api.io.StreamCodec;
-import org.eclipse.passage.lic.internal.base.i18n.AccessCycleMessages;
 
 public abstract class ArmedMiningTool implements MiningTool {
 
@@ -43,15 +41,7 @@ public abstract class ArmedMiningTool implements MiningTool {
 	}
 
 	protected final byte[] decoded(Path path) throws LicensingException {
-		try {
-			return new DecodedContent(path, key, codec).get();
-		} catch (IOException e) {
-			throw new LicensingException(//
-					String.format(//
-							AccessCycleMessages.getString("ArmedMiningTool.io_failure"), //$NON-NLS-1$
-							path.toAbsolutePath().toString()), //
-					e);
-		}
+		return new DecodedContent(path, key, codec).get();
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/DecodedContent.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/DecodedContent.java
@@ -22,6 +22,7 @@ import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.io.DigestExpectation;
 import org.eclipse.passage.lic.internal.api.io.KeyKeeper;
 import org.eclipse.passage.lic.internal.api.io.StreamCodec;
+import org.eclipse.passage.lic.internal.base.i18n.AccessCycleMessages;
 
 public final class DecodedContent {
 
@@ -35,13 +36,19 @@ public final class DecodedContent {
 		this.codec = codec;
 	}
 
-	public byte[] get() throws IOException, LicensingException {
+	public byte[] get() throws LicensingException {
 		try (FileInputStream encoded = new FileInputStream(source.toFile());
 				ByteArrayOutputStream decoded = new ByteArrayOutputStream();
 				InputStream ring = key.productPublicKey()) {
 			codec.decode(encoded, decoded, ring, new DigestExpectation.None());
 			decoded.flush();
 			return decoded.toByteArray();
+		} catch (IOException e) {
+			throw new LicensingException(//
+					String.format(//
+							AccessCycleMessages.getString("DecodedContent.io_failure"), //$NON-NLS-1$
+							source.toAbsolutePath().toString()), //
+					e);
 		}
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
@@ -10,7 +10,7 @@
 # Contributors:
 #      ArSysOp - initial API and implementation
 ###############################################################################
-ArmedMiningTool.io_failure=I/O error on file content decoding: %s
+DecodedContent.io_failure=I/O error on file content decoding: %s
 Conditions.no_miners=No condition mining services are available, that means there is no one to read a license\!
 Conditions.servive_type=condition mining
 Lock.no_permission=There is no Permission granted, no way to acquire a grant

--- a/bundles/org.eclipse.passage.lic.emf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.emf/META-INF/MANIFEST.MF
@@ -24,5 +24,6 @@ Export-Package: org.eclipse.passage.lic.emf.ecore;x-friends:="org.eclipse.passag
    org.eclipse.passage.lic.users.migration,
    org.eclipse.passage.lic.users.migration.tests",
  org.eclipse.passage.lic.emf.edit;x-friends:="org.eclipse.passage.loc.workbench",
+ org.eclipse.passage.lic.internal.emf;x-friends:="org.eclipse.passage.lic.hc,org.eclipse.passage.lbc.base",
  org.eclipse.passage.lic.internal.emf.i18n;x-internal:=true
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.java
@@ -18,7 +18,6 @@ public final class AccessMessages extends NLS {
 
 	private static final String BUNDLE_NAME = "org.eclipse.passage.lic.internal.hc.i18n.AccessMessages"; //$NON-NLS-1$
 
-	public static String AccessPacks_failure;
 	public static String AccessPacks_failed_on_file;
 	public static String AccessPacks_files_gaining_failed;
 	public static String AccessPacks_insufficient_configuration;

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
@@ -11,7 +11,6 @@
 #     ArSysOp - initial API and implementation
 ###############################################################################
 
-AccessPacks_failure=Reading floating license access file failed: %s
 AccessPacks_failed_on_file=Error on reading Floating License Access file %s
 AccessPacks_files_gaining_failed = Failed to locate Floating License Access files
 AccessPacks_insufficient_configuration = Mandatory services are not found

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/AccessPacks.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/AccessPacks.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.hc.remote.impl;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,11 +87,7 @@ public final class AccessPacks implements Supplier<ServiceInvocationResult<Colle
 	}
 
 	private byte[] decoded(Path file, KeyKeeper key, StreamCodec codec) throws LicensingException {
-		try {
-			return new DecodedContent(file, key, codec).get();
-		} catch (IOException e) {
-			throw new LicensingException(String.format(AccessMessages.AccessPacks_failure, file.toAbsolutePath()), e);
-		}
+		return new DecodedContent(file, key, codec).get();
 	}
 
 	private FloatingLicenseAccess from(byte[] content) throws LicensingException {


### PR DESCRIPTION
Side work: isolate all io-failure work in DecodedContent for better reuse of the latter

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>