### PR TITLE
Bug 569245 test coverage for client part

### DIFF
--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/LicensePacks.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/LicensePacks.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.eclipse.passage.lbc.internal.base.ServerKeyKeeper;
 import org.eclipse.passage.lic.floating.FloatingFileExtensions;
 import org.eclipse.passage.lic.floating.model.api.FloatingLicensePack;
 import org.eclipse.passage.lic.floating.model.meta.FloatingPackage;
@@ -30,6 +29,7 @@ import org.eclipse.passage.lic.internal.api.io.StreamCodec;
 import org.eclipse.passage.lic.internal.base.conditions.mining.DecodedContent;
 import org.eclipse.passage.lic.internal.base.io.FileCollection;
 import org.eclipse.passage.lic.internal.base.io.PathFromLicensedProduct;
+import org.eclipse.passage.lic.internal.base.io.PathKeyKeeper;
 import org.eclipse.passage.lic.internal.bc.BcStreamCodec;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
 
@@ -42,7 +42,7 @@ final class LicensePacks {
 
 	LicensePacks(LicensedProduct product, Supplier<Path> base) {
 		this.product = product;
-		this.key = new ServerKeyKeeper(product, base);
+		this.key = new PathKeyKeeper(product, base);
 		this.codec = new BcStreamCodec(() -> product);
 		this.base = base;
 	}

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/i18n/BaseMessages.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/i18n/BaseMessages.java
@@ -21,7 +21,6 @@ public final class BaseMessages extends NLS {
 	public static String AssembledConditions_validity_period_type_unknown;
 	public static String DecodedParam_decode_failed;
 	public static String ReassemblingMiningTool_path_failed;
-	public static String ServerKeyKeeper_input_stream_error;
 
 	static {
 		// initialize resource bundle

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/i18n/BaseMessages.properties
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/i18n/BaseMessages.properties
@@ -14,4 +14,3 @@
 AssembledConditions_validity_period_type_unknown=validity period of type %s is not supported
 DecodedParam_decode_failed=Failed to decode url param value [%s]
 ReassemblingMiningTool_path_failed=Error on gathering collection pack from %s
-ServerKeyKeeper_input_stream_error=Failed to initialize FileInputStream for KeyKeeper

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/ReassemblingMiningTool.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/ReassemblingMiningTool.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lbc.internal.base.ServerKeyKeeper;
 import org.eclipse.passage.lbc.internal.base.i18n.BaseMessages;
 import org.eclipse.passage.lic.floating.model.api.FloatingLicensePack;
 import org.eclipse.passage.lic.floating.model.api.ProductRef;
@@ -38,6 +37,7 @@ import org.eclipse.passage.lic.internal.base.conditions.BaseConditionPack;
 import org.eclipse.passage.lic.internal.base.conditions.mining.ArmedMiningTool;
 import org.eclipse.passage.lic.internal.base.diagnostic.BaseDiagnostic;
 import org.eclipse.passage.lic.internal.base.diagnostic.code.ServiceFailedOnMorsel;
+import org.eclipse.passage.lic.internal.base.io.PathKeyKeeper;
 import org.eclipse.passage.lic.internal.bc.BcStreamCodec;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
 import org.eclipse.passage.lic.internal.licenses.migration.tobemoved.XmiConditionTransport;
@@ -53,7 +53,7 @@ final class ReassemblingMiningTool extends ArmedMiningTool {
 
 	ReassemblingMiningTool(LicensedProduct product, String user, Supplier<Path> base, ConditionMiningTarget miner) {
 		super(//
-				new ServerKeyKeeper(product, base), //
+				new PathKeyKeeper(product, base), //
 				new BcStreamCodec(() -> product), //
 				new XmiConditionTransport(), //
 				miner);

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
@@ -19,3 +19,4 @@ Lock.no_service_for_target=There no License Acquisition Service found for Condit
 Lock.wrong_release=Illegal lock release: the lock has not been granted
 Restrictions.no_services=There is no examination service available. Looks suspicious.
 Restrictions.type=Requirements versus permissions examination
+PathKeyKeeper_input_stream_error=Failed to initialize FileInputStream for KeyKeeper

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/io/PathKeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/io/PathKeyKeeper.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lbc.internal.base;
+package org.eclipse.passage.lic.internal.base.io;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -18,22 +18,19 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lbc.internal.base.i18n.BaseMessages;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.io.KeyKeeper;
-import org.eclipse.passage.lic.internal.base.io.FileNameFromLicensedProduct;
-import org.eclipse.passage.lic.internal.base.io.PassageFileExtension;
-import org.eclipse.passage.lic.internal.base.io.PathFromLicensedProduct;
+import org.eclipse.passage.lic.internal.base.i18n.AccessCycleMessages;
 
-public final class ServerKeyKeeper implements KeyKeeper {
+public final class PathKeyKeeper implements KeyKeeper {
 
 	private final LicensedProduct product;
 	private final Supplier<Path> base;
 
-	public ServerKeyKeeper(LicensedProduct product, Supplier<Path> base) {
-		Objects.requireNonNull(product, "ServerKeyKeeper::product"); //$NON-NLS-1$
-		Objects.requireNonNull(base, "ServerKeyKeeper::base"); //$NON-NLS-1$
+	public PathKeyKeeper(LicensedProduct product, Supplier<Path> base) {
+		Objects.requireNonNull(product, "PathKeyKeeper::product"); //$NON-NLS-1$
+		Objects.requireNonNull(base, "PathKeyKeeper::base"); //$NON-NLS-1$
 		this.product = product;
 		this.base = new PathFromLicensedProduct(base, product);
 	}
@@ -49,7 +46,7 @@ public final class ServerKeyKeeper implements KeyKeeper {
 		try {
 			return new FileInputStream(path.toFile());
 		} catch (Exception e) {
-			throw new LicensingException(BaseMessages.ServerKeyKeeper_input_stream_error, e);
+			throw new LicensingException(AccessCycleMessages.getString("PathKeyKeeper_input_stream_error"), e); //$NON-NLS-1$
 		}
 	}
 

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/RequestConstructed.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/RequestConstructed.java
@@ -24,7 +24,7 @@ import org.eclipse.passage.lic.internal.api.conditions.ConditionAction;
 import org.eclipse.passage.lic.internal.base.StringNamedData;
 import org.eclipse.passage.lic.internal.net.LicensingAction;
 
-final class RequestConstructed implements Supplier<RawRequest> {
+public final class RequestConstructed implements Supplier<RawRequest> {
 
 	private Map<String, String> params = new HashMap<>();
 	private byte[] content;
@@ -62,6 +62,7 @@ final class RequestConstructed implements Supplier<RawRequest> {
 	}
 
 	private static final class Franky implements RawRequest {
+
 		private final Map<String, String> params;
 		private final byte[] content;
 		private final FloatingState state;


### PR DESCRIPTION
Rename and move path-resident key keeper from `lbc.base` to `lic.base`, as it is of demand and has no FLS specifics.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>