### PR TITLE
569245 test coverage for client part

### DIFF
--- a/bundles/org.eclipse.passage.lbc.api/src/org/eclipse/passage/lbc/internal/api/FloatingResponse.java
+++ b/bundles/org.eclipse.passage.lbc.api/src/org/eclipse/passage/lbc/internal/api/FloatingResponse.java
@@ -24,6 +24,8 @@ public interface FloatingResponse {
 
 	Error error();
 
+	boolean carriesPayload();
+
 	/**
 	 * Leave the stream open - must be closed by a calling party.
 	 * 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/EObjectTransfer.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/EObjectTransfer.java
@@ -35,6 +35,11 @@ public final class EObjectTransfer implements FloatingResponse {
 	}
 
 	@Override
+	public boolean carriesPayload() {
+		return true;
+	}
+
+	@Override
 	public Error error() {
 		throw new IllegalStateException("Successful response does not posess error information"); //$NON-NLS-1$ // dev
 	}

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Failure.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Failure.java
@@ -34,6 +34,11 @@ public abstract class Failure implements FloatingResponse {
 	}
 
 	@Override
+	public boolean carriesPayload() {
+		return false;
+	}
+
+	@Override
 	public Error error() {
 		return new Err();
 	}

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/PlainSuceess.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/PlainSuceess.java
@@ -25,13 +25,18 @@ public final class PlainSuceess implements FloatingResponse {
 	}
 
 	@Override
+	public boolean carriesPayload() {
+		return false;
+	}
+
+	@Override
 	public Error error() {
 		throw new IllegalStateException("Successful result does not have error information"); //$NON-NLS-1$ dev
 	}
 
 	@Override
 	public void write(OutputStream output) throws IOException {
-		throw new IllegalStateException("Plainn successful result is not intended to contain any payload"); //$NON-NLS-1$ dev
+		throw new IllegalStateException("Plain successful result is not intended to contain any payload"); //$NON-NLS-1$ dev
 	}
 
 }


### PR DESCRIPTION
Extend FLS response interface (`FloatingResponse`) with the 'has payload' marker

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>