### PR TITLE
569004 devise a strategy for below-`error` licensing requirement

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/TentativeFeatureAccess.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/TentativeFeatureAccess.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.access;
+
+import java.util.Date;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.acquire.GrantAcqisition;
+import org.eclipse.passage.lic.internal.base.acquire.BaseGrantAcquisition;
+
+final class TentativeFeatureAccess implements Supplier<GrantAcqisition>, Predicate<GrantAcqisition> {
+
+	private final String feature;
+	private final String tentative = "tentative"; //$NON-NLS-1$
+
+	TentativeFeatureAccess(String feature) {
+		this.feature = feature;
+	}
+
+	TentativeFeatureAccess() {
+		this("any"); //$NON-NLS-1$
+	}
+
+	@Override
+	public GrantAcqisition get() {
+		return new BaseGrantAcquisition(//
+				String.format("%s-id", tentative), //$NON-NLS-1$
+				String.format("%s-grant", tentative), //$NON-NLS-1$
+				feature, //
+				String.format("%s-user", tentative), //$NON-NLS-1$
+				new Date());
+	}
+
+	@Override
+	public boolean test(GrantAcqisition grant) {
+		return grant.identifier().startsWith(tentative) //
+				&& grant.grant().startsWith(tentative) //
+				&& grant.user().startsWith(tentative);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/AccessCycleMessages.properties
@@ -13,9 +13,9 @@
 DecodedContent.io_failure=I/O error on file content decoding: %s
 Conditions.no_miners=No condition mining services are available, that means there is no one to read a license\!
 Conditions.servive_type=condition mining
-Lock.no_permission=There is no Permission granted, no way to acquire a grant
 Lock.no_service=License acquisition service for expected mining target
 Lock.no_service_for_target=There no License Acquisition Service found for Condition Mining target [%s]
+Lock.temp_access=Temporary access granted for feature %s
 Lock.wrong_release=Illegal lock release: the lock has not been granted
 Restrictions.no_services=There is no examination service available. Looks suspicious.
 Restrictions.type=Requirements versus permissions examination

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
@@ -73,7 +73,7 @@ public final class EquinoxPassageUI implements PassageUI {
 
 	/**
 	 * @return {@code true} if licensing state has been changed and new assessment
-	 *         have sense. {@code false} otherwise.
+	 *         have sense, {@code false} otherwise.
 	 */
 	private <T> boolean exposeAndMayBeEvenFix(//
 			ServiceInvocationResult<T> result, //


### PR DESCRIPTION
Tentative grant acquisition is created for the case, when a certificate contains neither direct prohibitions (unsatisfied restrictions are of below-`error` levels) and nor direct permissions.

Such an acquisition is a client-resident, does not correspond to anything on a server, and is simply destroyed instead of releasing.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>