### PR TITLE
Bug 569359 Passage interface test coverage

### DIFF
--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedCodecsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedCodecsRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.StreamCodecsRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedCodecsRegistryTest extends StreamCodecsRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedConitionMiningServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedConitionMiningServicesRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.RequirementResolutionServicesRegitryTes
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedConitionMiningServicesRegistryTest extends RequirementResolutionServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionEvaluatorsServiceRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionEvaluatorsServiceRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.ExpressionParsingServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedExpressionEvaluatorsServiceRegistryTest extends ExpressionParsingServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionParsersRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedExpressionParsersRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.ExpressionParsingServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedExpressionParsersRegistryTest extends ExpressionParsingServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedKeyKeepersRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedKeyKeepersRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.KeyKeepersRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedKeyKeepersRegistryTest extends KeyKeepersRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionEmttingServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionEmttingServicesRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.PermissionEmittingServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedPermissionEmttingServicesRegistryTest extends PermissionEmittingServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionsExaminationServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedPermissionsExaminationServicesRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.PermissionEmittingServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedPermissionsExaminationServicesRegistryTest extends PermissionEmittingServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRequirementsResolutionServicesRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRequirementsResolutionServicesRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.ConditionMiningServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedRequirementsResolutionServicesRegistryTest extends ConditionMiningServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRuntimeEnvironmentRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedRuntimeEnvironmentRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.RuntimeEnvironmentRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedRuntimeEnvironmentRegistryTest extends RuntimeEnvironmentRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTokenAssessorsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTokenAssessorsRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.ExpressionTokenAssessmentServicesRegitr
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedTokenAssessorsRegistryTest extends ExpressionTokenAssessmentServicesRegitryTest {
 
 	@Override

--- a/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTransportsRegistryTest.java
+++ b/tests/org.eclipse.passage.seal.demo.tests/src/org/eclipse/passage/seal/demo/tests/registries/SealedTransportsRegistryTest.java
@@ -18,7 +18,6 @@ import org.eclipse.passage.lic.api.tests.ConditionTransportServicesRegitryTest;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.seal.internal.demo.DemoFrameworkSupplier;
 
-@SuppressWarnings("restriction")
 public final class SealedTransportsRegistryTest extends ConditionTransportServicesRegitryTest {
 
 	@Override


### PR DESCRIPTION
remove redundant suppress-warning annotations

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>