### PR TITLE
Bug 569359 Passage interface test coverage

### DIFF
--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ConditionsTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ConditionsTest.java
@@ -52,7 +52,7 @@ public final class ConditionsTest {
 
 	private List<LicenseGrant> mineForUserAndProduct(String user, String product, int conditions)
 			throws IOException, LicensingException {
-		FloatingResponse response = new Conditions(request(user, product), new LicFolder()).get();
+		FloatingResponse response = new Conditions(request(user, product), new TestLicFolder()).get();
 		assertFalse(response.failed());
 		EList<LicenseGrant> grants = new License(response).get().getLicenseGrants();
 		assertEquals(conditions, grants.size());

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveAcquiringTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveAcquiringTest.java
@@ -52,7 +52,7 @@ public final class ExtensiveAcquiringTest {
 
 	private Set<Future<FloatingResponse>> runConcurrentAcquireRequest(int amount) throws InterruptedException {
 		ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
-		FloatingState state = new EagerFloatingState(new LicFolder());
+		FloatingState state = new EagerFloatingState(new TestLicFolder());
 		Set<Future<FloatingResponse>> futures = IntStream.range(0, amount)//
 				.mapToObj(i -> pool.submit(new Acq(state)))//
 				.collect(Collectors.toSet());

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
@@ -63,7 +63,7 @@ public final class ExtensiveReleaseTest {
 
 	private Set<Future<Result>> runProtectedActionsConcurrently(int amount) throws InterruptedException {
 		ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
-		FloatingState state = new EagerFloatingState(new LicFolder());
+		FloatingState state = new EagerFloatingState(new TestLicFolder());
 		Set<Future<Result>> futures = IntStream.range(0, amount)//
 				.mapToObj(i -> pool.submit(new ProtectedAction(state)))//
 				.collect(Collectors.toSet());

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/TestLicFolder.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/TestLicFolder.java
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Supplier;
 
-public final class LicFolder implements Supplier<Path> {
+final class TestLicFolder implements Supplier<Path> {
 
 	@Override
 	public Path get() {

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/AcquireTest.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/AcquireTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Path;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lbc.base.tests.LicFolder;
 import org.eclipse.passage.lbc.base.tests.TestData;
 import org.eclipse.passage.lbc.internal.api.FloatingResponse;
 import org.eclipse.passage.lbc.internal.api.FloatingState;
@@ -41,7 +40,7 @@ import org.junit.Test;
 public final class AcquireTest {
 
 	private final TestData data = new TestData();
-	private final Supplier<Path> source = new LicFolder();
+	private final Supplier<Path> source = new TestLicFolder();
 	private final FloatingState server = new EagerFloatingState(source);
 
 	@Test

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/MineTest.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/MineTest.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lbc.base.tests.LicFolder;
 import org.eclipse.passage.lbc.base.tests.TestData;
 import org.eclipse.passage.lbc.internal.api.FloatingResponse;
 import org.eclipse.passage.lbc.internal.api.FloatingState;
@@ -45,7 +44,7 @@ import org.junit.Test;
 public final class MineTest {
 
 	private final TestData data = new TestData();
-	private final Supplier<Path> source = new LicFolder();
+	private final Supplier<Path> source = new TestLicFolder();
 
 	@Test
 	public void mine() {

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/TestLicFolder.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/TestLicFolder.java
@@ -1,0 +1,14 @@
+package org.eclipse.passage.lic.internal.hc.tests.remote;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+
+final class TestLicFolder implements Supplier<Path> {
+
+	@Override
+	public Path get() {
+		return Paths.get("resource").resolve("lics"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+}


### PR DESCRIPTION
Hide 'LicFolder' as it is based on a bundle-dependent path

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>