### PR TITLE
Bug 569539 - [Passage] prepare 1.1.0 RC2

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -237,6 +237,8 @@
             name="org.apache.commons.csv"
             versionRange="[1.4.0,2.0.0)"/>
         <requirement
+            name="org.apache.logging.log4j"/>
+        <requirement
             name="org.bouncycastle.bcpg"/>
         <requirement
             name="org.bouncycastle.bcpkix"/>
@@ -288,7 +290,7 @@
           <repository
               url="https://download.eclipse.org/cbi/updates/license/"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.18milestones/S-4.18M1a-202010120320/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.18milestones/S-4.18RC2-202012021800/"/>
           <repository
               url="https://download.eclipse.org/ecp/releases/releases_125/1250/"/>
           <repository

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -22,7 +22,7 @@
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/eclipse/updates/4.18milestones/S-4.18M1a-202010120320/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.18milestones/S-4.18RC2-202012021800/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group" version="0.0.0"/>
@@ -81,6 +81,7 @@
 			<unit id="javax.activation" version="0.0.0"/>
 			<unit id="javax.mail" version="0.0.0"/>
 			<unit id="org.apache.commons.csv" version="0.0.0"/>
+			<unit id="org.apache.logging.log4j" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcpg" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcpg.source" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcpkix" version="0.0.0"/>
@@ -91,7 +92,6 @@
 			<unit id="org.slf4j.api" version="0.0.0"/>
 			<unit id="org.slf4j.api.source" version="0.0.0"/>
 			<unit id="org.slf4j.apis.log4j" version="0.0.0"/>
-			<unit id="org.apache.logging.log4j" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Update to Platform 4.18 RC2
Sort dependencies in target
Add org.apache.logging.log4j to setup

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>