### PR TITLE
Bug 569721 scan network interfaces

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/EnvironmentProperties.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/EnvironmentProperties.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.oshi;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.inspection.EnvironmentProperty;
+
+final class EnvironmentProperties {
+
+	private final Map<EnvironmentProperty, String> properties = new HashMap<>();
+
+	void store(Supplier<String> value, EnvironmentProperty key) {
+		Optional<String> read;
+		try {
+			read = Optional.ofNullable(value.get());
+		} catch (Throwable e) { // native errors
+			read = Optional.empty();
+		}
+		read.ifPresent(valuable -> properties.put(key, valuable));
+	}
+
+	String get(EnvironmentProperty property) {
+		return properties.get(property);
+	}
+
+	Set<EnvironmentProperty> all() {
+		return properties.keySet();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/FragileData.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/FragileData.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.oshi;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ * Data supplier dynamically fail on various native use cases with non-checked
+ * platform-dependent exceptions.
+ * </p>
+ * <p>
+ * Any failure is legal and means only that the actual data will not be
+ * presented.
+ * </p>
+ */
+final class FragileData<T> {
+
+	private final Supplier<T> aspect;
+	private final Consumer<T> read;
+
+	FragileData(Supplier<T> aspect, Consumer<T> read) {
+		this.aspect = aspect;
+		this.read = read;
+	}
+
+	void supply() {
+		T descriptor;
+		try {
+			descriptor = aspect.get();
+		} catch (Throwable any) {
+			return; // legal; 'read' just isn't going to happen
+		}
+		read.accept(descriptor);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/GlanceOfState.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/GlanceOfState.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.eclipse.passage.lic.internal.api.inspection.EnvironmentProperty;
-import org.eclipse.passage.lic.internal.base.inspection.hardware.Disk;
 
 final class GlanceOfState implements Supplier<String> {
 
@@ -37,18 +36,8 @@ final class GlanceOfState implements Supplier<String> {
 				.collect(Collectors.groupingBy(EnvironmentProperty::family))//
 				.entrySet().stream() //
 				.forEach(e -> appendFamily(e.getKey(), e.getValue(), out));
-		IntStream.range(0, state.disksAmount()) //
-				.forEach(no -> appendDisk(no, out));
+		state.swaths().forEach(swath -> appendSwath(swath, out));
 		return out.toString();
-	}
-
-	private void appendDisk(int no, StringBuilder out) {
-		out.append(new Disk.Model().family())//
-				.append(" #")//$NON-NLS-1$
-				.append(no)//
-				.append("\r\n"); //$NON-NLS-1$
-		state.diskProperties(no).stream() //
-				.forEach(p -> appendProperty(p, state.diskValue(no, p), out));
 	}
 
 	private void appendFamily(String family, List<EnvironmentProperty> properties, StringBuilder out) {
@@ -65,4 +54,17 @@ final class GlanceOfState implements Supplier<String> {
 		return out;
 	}
 
+	private void appendSwath(Swath<?> swath, StringBuilder out) {
+		IntStream.range(0, swath.capacity()) //
+				.forEach(no -> appendSwathMember(swath, no, out));
+	}
+
+	private void appendSwathMember(Swath<?> swath, int no, StringBuilder out) {
+		out.append(swath.family())//
+				.append(" #")//$NON-NLS-1$
+				.append(no)//
+				.append("\r\n"); //$NON-NLS-1$
+		swath.properties(no).stream() //
+				.forEach(p -> appendProperty(p, swath.value(no, p), out));
+	}
 }

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/NetHardwareAddress.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/NetHardwareAddress.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.oshi;
+
+import java.net.SocketException;
+import java.util.function.Supplier;
+
+import oshi.hardware.NetworkIF;
+
+final class NetHardwareAddress implements Supplier<String> {
+
+	private final NetworkIF net;
+
+	NetHardwareAddress(NetworkIF net) {
+		this.net = net;
+	}
+
+	@Override
+	public String get() {
+		byte[] address;
+		try {
+			address = net.getNetworkInterface().getHardwareAddress();
+		} catch (SocketException e) {
+			return null; // mimic null: supports OSHI reading policy
+		}
+		return enlisted(address);
+	}
+
+	private String enlisted(byte[] bytes) {
+		StringBuilder out = new StringBuilder();
+		for (int one : bytes) {
+			out.append(one);
+		}
+		return out.toString();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/Swath.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/internal/oshi/Swath.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.oshi;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.passage.lic.internal.api.inspection.EnvironmentProperty;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.Disk;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.NetworkInterface;
+
+import oshi.SystemInfo;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.NetworkIF;
+
+/**
+ * Pack of sibling entities in a hardware description
+ */
+abstract class Swath<T> {
+
+	private final String family;
+
+	protected final List<EnvironmentProperties> properties = new ArrayList<>();
+
+	Swath(String family) {
+		this.family = family;
+	}
+
+	final boolean relates(String anotehr) {
+		return this.family.equals(anotehr);
+	}
+
+	final int capacity() {
+		return properties.size();
+	}
+
+	final Set<EnvironmentProperty> properties(int no) {
+		return properties.get(no).all();
+	}
+
+	final String value(int no, EnvironmentProperty key) {
+		return properties.get(no).get(key);
+	}
+
+	final String family() {
+		return family;
+	}
+
+	final boolean hasValue(EnvironmentProperty property, String regexp) {
+		return properties.stream()//
+				.map(props -> Optional.ofNullable(props.get(property)))//
+				.filter(Optional::isPresent)//
+				.map(Optional::get)//
+				.anyMatch(value -> value.matches(regexp));
+	}
+
+	final void read(SystemInfo system) {
+		new FragileData<>(() -> source(system), this::readSource).supply();
+	}
+
+	private void readSource(T[] source) {
+		Arrays.stream(source).forEach(src -> properties.add(fillProperties(src, new EnvironmentProperties())));
+	}
+
+	protected abstract T[] source(SystemInfo system);
+
+	protected abstract EnvironmentProperties fillProperties(T source, EnvironmentProperties props);
+
+	static final class Disks extends Swath<HWDiskStore> {
+
+		Disks() {
+			super(new Disk.Name().family());
+		}
+
+		@Override
+		protected HWDiskStore[] source(SystemInfo system) {
+			return system.getHardware().getDiskStores();
+		}
+
+		@Override
+		protected EnvironmentProperties fillProperties(HWDiskStore source, EnvironmentProperties props) {
+			props.store(source::getName, new Disk.Name());
+			props.store(source::getModel, new Disk.Model());
+			props.store(source::getSerial, new Disk.Serial());
+			return props;
+		}
+
+	}
+
+	static final class Nets extends Swath<NetworkIF> {
+
+		Nets() {
+			super(new NetworkInterface.Name().family());
+		}
+
+		@Override
+		protected NetworkIF[] source(SystemInfo system) {
+			return system.getHardware().getNetworkIFs();
+		}
+
+		@Override
+		protected EnvironmentProperties fillProperties(NetworkIF source, EnvironmentProperties props) {
+			props.store(source::getName, new NetworkInterface.Name());
+			props.store(source::getDisplayName, new NetworkInterface.DisplayName());
+			props.store(source::getMacaddr, new NetworkInterface.MacAddress());
+			props.store(new NetHardwareAddress(source), new NetworkInterface.HwAddress());
+			return props;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Extract work with disks from hardware State and generalize to be used for network interfaces as well.
- Support network interfaces state reading and evaluation


Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>