### PR TITLE
Bug 571147 extend 'lic.net' with common facilities

### DIFF
--- a/bundles/org.eclipse.passage.lac/src/org/eclipse/passage/internal/lac/base/AgentCycle.java
+++ b/bundles/org.eclipse.passage.lac/src/org/eclipse/passage/internal/lac/base/AgentCycle.java
@@ -16,8 +16,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.eclipse.passage.lic.internal.api.PassageAction;
-import org.eclipse.passage.lic.internal.net.handle.Chore;
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.Chore;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 import org.eclipse.passage.lic.internal.net.handle.NetServices;
 
 public final class AgentCycle extends NetServices<NetRequest> {

--- a/bundles/org.eclipse.passage.lac/src/org/eclipse/passage/internal/lac/base/AgentRequestHandled.java
+++ b/bundles/org.eclipse.passage.lac/src/org/eclipse/passage/internal/lac/base/AgentRequestHandled.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.internal.lac.base;
 
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 import org.eclipse.passage.lic.internal.net.handle.RequestHandledByServices;
 
 public final class AgentRequestHandled extends RequestHandledByServices<NetRequest> {

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Acquire.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Acquire.java
@@ -15,7 +15,7 @@ package org.eclipse.passage.lbc.internal.base;
 import org.eclipse.passage.lbc.internal.base.acquire.Acquisition;
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lic.internal.api.LicensingException;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 final class Acquire extends ChoreDraft {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/ChoreDraft.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/ChoreDraft.java
@@ -19,9 +19,9 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lic.internal.api.EvaluationInstructions;
 import org.eclipse.passage.lic.internal.api.LicensingException;
-import org.eclipse.passage.lic.internal.net.handle.Chore;
+import org.eclipse.passage.lic.internal.net.api.handle.Chore;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 
 abstract class ChoreDraft implements Chore {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/EObjectTransfer.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/EObjectTransfer.java
@@ -16,7 +16,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
 import org.eclipse.passage.lic.internal.emf.EObjectToBytes;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 public final class EObjectTransfer implements NetResponse {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/FloatingCycle.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/FloatingCycle.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
 
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lic.internal.api.PassageAction;
-import org.eclipse.passage.lic.internal.net.handle.Chore;
+import org.eclipse.passage.lic.internal.net.api.handle.Chore;
 import org.eclipse.passage.lic.internal.net.handle.NetServices;
 
 final class FloatingCycle extends NetServices<RawRequest> {

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Mine.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Mine.java
@@ -14,7 +14,7 @@ package org.eclipse.passage.lbc.internal.base;
 
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lbc.internal.base.mine.Conditions;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 final class Mine extends ChoreDraft {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/PlainSuceess.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/PlainSuceess.java
@@ -13,7 +13,7 @@
 package org.eclipse.passage.lbc.internal.base;
 
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 public final class PlainSuceess implements NetResponse {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Release.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/Release.java
@@ -15,7 +15,7 @@ package org.eclipse.passage.lbc.internal.base;
 import org.eclipse.passage.lbc.internal.base.acquire.Acquisition;
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lic.internal.api.LicensingException;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 final class Release extends ChoreDraft {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/ServerAuthenticationInstructions.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/ServerAuthenticationInstructions.java
@@ -20,7 +20,7 @@ import org.eclipse.passage.lic.floating.model.net.ServerAuthenticationType;
 import org.eclipse.passage.lic.internal.api.EvaluationInstructions;
 import org.eclipse.passage.lic.internal.api.EvaluationType;
 import org.eclipse.passage.lic.internal.base.conditions.BaseEvaluationInstructions;
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 
 final class ServerAuthenticationInstructions implements Supplier<Optional<EvaluationInstructions>> {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/Acquisition.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/Acquisition.java
@@ -29,8 +29,8 @@ import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.FeatureIdentifier;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 
 public final class Acquisition {
 

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/api/RawRequest.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/api/RawRequest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lbc.internal.base.api;
 
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
-import org.eclipse.passage.lic.internal.net.handle.WithState;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.WithState;
 
 /**
  * @since 1.1

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/Conditions.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/Conditions.java
@@ -33,8 +33,8 @@ import org.eclipse.passage.lic.internal.base.diagnostic.NoErrors;
 import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
 import org.eclipse.passage.lic.internal.base.io.PathFromLicensedProduct;
 import org.eclipse.passage.lic.internal.base.io.UserHomePath;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 import org.eclipse.passage.lic.licenses.model.api.LicensePack;
 
 public final class Conditions implements Supplier<NetResponse> {

--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/StatedRequest.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/StatedRequest.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 import org.eclipse.passage.lbc.internal.base.api.FloatingState;
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 
 final class StatedRequest implements RawRequest {
 

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyHandler.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyHandler.java
@@ -24,8 +24,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 /**
  * There is one single instance of the handler for a server. All of the rest in

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyRequest.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyRequest.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.passage.lic.internal.net.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 
 public final class JettyRequest implements NetRequest {
 

--- a/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
@@ -16,6 +16,13 @@ Export-Package: org.eclipse.passage.lic.internal.net;
    org.eclipse.passage.lic.hc,
    org.eclipse.passage.lbc.jetty,
    org.eclipse.passage.lbc.base.tests",
+ org.eclipse.passage.lic.internal.net.api.handle;
+  x-friends:="org.eclipse.passage.lac,
+   org.eclipse.passage.lac.jetty,
+   org.eclipse.passage.lbc.base,
+   org.eclipse.passage.lbc.base.tests,
+   org.eclipse.passage.lbc.jetty,
+   org.eclipse.passage.lic.jetty",
  org.eclipse.passage.lic.internal.net.connect,
  org.eclipse.passage.lic.internal.net.handle;
   x-friends:="org.eclipse.passage.lac,

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/Chore.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/Chore.java
@@ -10,14 +10,10 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
-import java.io.IOException;
+public interface Chore {
 
-public interface NetRequest {
-
-	String parameter(String name);
-
-	byte[] content() throws IOException;
+	NetResponse getDone();
 
 }

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/Chores.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/Chores.java
@@ -10,10 +10,10 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
-import java.util.function.Supplier;
+public interface Chores<R extends NetRequest> {
 
-public interface NetRequestHandled extends Supplier<NetResponse> {
+	NetResponse workOut(R request);
 
 }

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequest.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequest.java
@@ -10,31 +10,14 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
-import org.eclipse.passage.lic.internal.api.LicensingException;
-import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
+import java.io.IOException;
 
-/**
- * @since 1.0
- */
-public interface NetResponse {
+public interface NetRequest {
 
-	boolean failed();
+	String parameter(String name);
 
-	Error error();
-
-	boolean carriesPayload();
-
-	byte[] payload() throws LicensingException;
-
-	public static interface Error {
-
-		int code();
-
-		String message();
-	}
-
-	ContentType contentType();
+	byte[] content() throws IOException;
 
 }

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequestHandled.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequestHandled.java
@@ -10,10 +10,10 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
-public interface Chore {
+import java.util.function.Supplier;
 
-	NetResponse getDone();
+public interface NetRequestHandled extends Supplier<NetResponse> {
 
 }

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetResponse.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetResponse.java
@@ -10,10 +10,31 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
-public interface Chores<R extends NetRequest> {
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
 
-	NetResponse workOut(R request);
+/**
+ * @since 1.0
+ */
+public interface NetResponse {
+
+	boolean failed();
+
+	Error error();
+
+	boolean carriesPayload();
+
+	byte[] payload() throws LicensingException;
+
+	public static interface Error {
+
+		int code();
+
+		String message();
+	}
+
+	ContentType contentType();
 
 }

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/WithState.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/WithState.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.net.handle;
+package org.eclipse.passage.lic.internal.net.api.handle;
 
 public interface WithState<S> {
 

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/Failure.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/Failure.java
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.internal.net.handle;
 
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 public abstract class Failure implements NetResponse {
 

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/NetServices.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/NetServices.java
@@ -18,6 +18,10 @@ import java.util.function.Function;
 
 import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.net.LicensingAction;
+import org.eclipse.passage.lic.internal.net.api.handle.Chore;
+import org.eclipse.passage.lic.internal.net.api.handle.Chores;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 public abstract class NetServices<R extends NetRequest> implements Chores<R> {
 

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/RequestHandledByServices.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/RequestHandledByServices.java
@@ -14,6 +14,11 @@ package org.eclipse.passage.lic.internal.net.handle;
 
 import java.util.Objects;
 
+import org.eclipse.passage.lic.internal.net.api.handle.Chores;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
+import org.eclipse.passage.lic.internal.net.api.handle.NetRequestHandled;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
+
 public abstract class RequestHandledByServices<R extends NetRequest> implements NetRequestHandled {
 
 	private final R request;

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/BaseFlotingRequestHandledTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/BaseFlotingRequestHandledTest.java
@@ -19,8 +19,8 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.passage.lbc.internal.base.FlotingRequestHandled;
 import org.eclipse.passage.lbc.internal.base.api.RawRequest;
 import org.eclipse.passage.lic.internal.api.PassageAction;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 import org.junit.Test;
 
 public final class BaseFlotingRequestHandledTest {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ConditionsTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ConditionsTest.java
@@ -26,7 +26,7 @@ import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.base.ProductIdentifier;
 import org.eclipse.passage.lic.internal.base.ProductVersion;
 import org.eclipse.passage.lic.internal.net.LicenseUser;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.licenses.model.api.LicenseGrant;
 import org.junit.Test;
 

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveAcquiringTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveAcquiringTest.java
@@ -31,7 +31,7 @@ import org.eclipse.passage.lbc.internal.base.acquire.NoGrantsAvailable;
 import org.eclipse.passage.lbc.internal.base.api.FloatingState;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.PassageAction;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.junit.Test;
 
 public final class ExtensiveAcquiringTest {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
@@ -39,7 +39,7 @@ import org.eclipse.passage.lic.floating.model.meta.FloatingPackage;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.junit.Test;
 
 public final class ExtensiveReleaseTest {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/FloatingCycleActionsDryRunTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/FloatingCycleActionsDryRunTest.java
@@ -31,7 +31,7 @@ import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.BaseLicensedProduct;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.junit.Test;
 
 public final class FloatingCycleActionsDryRunTest {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/License.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/License.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.licenses.model.api.LicensePack;
 
 final class License {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/MineTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/MineTest.java
@@ -25,8 +25,8 @@ import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.ProductIdentifier;
 import org.eclipse.passage.lic.internal.base.ProductVersion;
 import org.eclipse.passage.lic.internal.base.StringNamedData;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 import org.junit.Test;
 
 public final class MineTest {

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ServerAuthenticationTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ServerAuthenticationTest.java
@@ -21,8 +21,8 @@ import org.eclipse.passage.lic.floating.model.net.ServerAuthenticationType;
 import org.eclipse.passage.lic.internal.api.EvaluationType;
 import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.StringNamedData;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.eclipse.passage.lic.internal.net.handle.Failure;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
 import org.junit.Test;
 
 public final class ServerAuthenticationTest {

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/AcquireTest.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/AcquireTest.java
@@ -33,7 +33,7 @@ import org.eclipse.passage.lic.internal.base.registry.ReadOnlyRegistry;
 import org.eclipse.passage.lic.internal.bc.BcStreamCodec;
 import org.eclipse.passage.lic.internal.hc.remote.Client;
 import org.eclipse.passage.lic.internal.hc.remote.impl.acquire.RemoteAcquisitionService;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/MineTest.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/MineTest.java
@@ -37,7 +37,7 @@ import org.eclipse.passage.lic.internal.bc.BcStreamCodec;
 import org.eclipse.passage.lic.internal.hc.remote.Client;
 import org.eclipse.passage.lic.internal.hc.remote.impl.mine.RemoteConditions;
 import org.eclipse.passage.lic.internal.licenses.migration.tobemoved.XmiConditionTransport;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/ShortcutClient.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/ShortcutClient.java
@@ -24,7 +24,7 @@ import org.eclipse.passage.lic.internal.hc.remote.Client;
 import org.eclipse.passage.lic.internal.hc.remote.Request;
 import org.eclipse.passage.lic.internal.hc.remote.ResponseHandler;
 import org.eclipse.passage.lic.internal.hc.remote.impl.ResultsTransfered;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 final class ShortcutClient<T> implements Client<ShortcutConnection, T> {
 

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/ShortcutConnection.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/ShortcutConnection.java
@@ -20,7 +20,7 @@ import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
 import org.eclipse.passage.lic.internal.hc.remote.Connection;
 import org.eclipse.passage.lic.internal.hc.remote.QueryParameters;
-import org.eclipse.passage.lic.internal.net.handle.NetResponse;
+import org.eclipse.passage.lic.internal.net.api.handle.NetResponse;
 
 final class ShortcutConnection implements Connection {
 


### PR DESCRIPTION
Extract `api` package to emulate unnecessary `net.api` bundle

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>