### PR TITLE
Bug 571190 build the solution on Framework services host

### DIFF
--- a/bundles/org.eclipse.passage.lac.seal/OSGI-INF/org.eclipse.passage.lac.internal.gear.RuntimeFrameworkConstructor.xml
+++ b/bundles/org.eclipse.passage.lac.seal/OSGI-INF/org.eclipse.passage.lac.internal.gear.RuntimeFrameworkConstructor.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.passage.lac.internal.gear.RuntimeFrameworkConstructor">
+   <service>
+      <provide interface="org.eclipse.passage.lic.internal.net.api.FrameworkConstructor"/>
+   </service>
+   <implementation class="org.eclipse.passage.lac.internal.gear.RuntimeFrameworkConstructor"/>
+</scr:component>

--- a/bundles/org.eclipse.passage.lac.seal/OSGI-INF/org.eclipse.passage.lac.internal.seal.AgentFrameworkConstructor.xml
+++ b/bundles/org.eclipse.passage.lac.seal/OSGI-INF/org.eclipse.passage.lac.internal.seal.AgentFrameworkConstructor.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.passage.lac.internal.seal.AgentFrameworkConstructor">
-   <service>
-      <provide interface="org.eclipse.passage.lic.internal.net.api.FrameworkConstructor"/>
-   </service>
-   <implementation class="org.eclipse.passage.lac.internal.seal.AgentFrameworkConstructor"/>
-</scr:component>

--- a/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeConfiguration.java
+++ b/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeConfiguration.java
@@ -10,10 +10,11 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lac.internal.seal;
+package org.eclipse.passage.lac.internal.gear;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.internal.api.AccessCycleConfiguration;
@@ -55,20 +56,18 @@ import org.eclipse.passage.lic.internal.base.conditions.evaluation.BerlinProtoco
 import org.eclipse.passage.lic.internal.base.conditions.evaluation.SimpleMapExpressionEvaluationService;
 import org.eclipse.passage.lic.internal.base.conditions.mining.PathResidentConditions;
 import org.eclipse.passage.lic.internal.base.conditions.mining.PersonalLicenseMiningEquipment;
+import org.eclipse.passage.lic.internal.base.io.PathKeyKeeper;
 import org.eclipse.passage.lic.internal.base.registry.ReadOnlyRegistry;
-import org.eclipse.passage.lic.internal.base.restrictions.BasePermissionsExaminationService;
 import org.eclipse.passage.lic.internal.bc.BcStreamCodec;
-import org.eclipse.passage.lic.internal.equinox.io.BundleKeyKeeper;
 import org.eclipse.passage.lic.internal.equinox.requirements.BundleRequirements;
 import org.eclipse.passage.lic.internal.equinox.requirements.ComponentRequirements;
 import org.eclipse.passage.lic.internal.json.JsonConditionTransport;
 import org.eclipse.passage.lic.internal.licenses.migration.tobemoved.UserFilteringConditionTransport;
 import org.eclipse.passage.lic.internal.oshi.HardwareAssessmentService;
 import org.eclipse.passage.lic.internal.oshi.HardwareEnvironment;
-import org.osgi.framework.Bundle;
 
 @SuppressWarnings("restriction")
-public final class AgentConfiguration implements AccessCycleConfiguration {
+public final class RuntimeConfiguration implements AccessCycleConfiguration {
 
 	private final Registry<StringServiceId, ResolvedRequirements> requirements;
 	private final Registry<ConditionMiningTarget, MinedConditions> conditions;
@@ -83,8 +82,7 @@ public final class AgentConfiguration implements AccessCycleConfiguration {
 	private final Registry<EvaluationType, RuntimeEnvironment> environments;
 	private final Registry<StringServiceId, PermissionsExaminationService> examinators;
 
-	public AgentConfiguration(Supplier<Path> source, Supplier<String> user, Supplier<LicensedProduct> product,
-			Supplier<Bundle> bundle) {
+	public RuntimeConfiguration(Supplier<Path> source, Supplier<String> user, Supplier<LicensedProduct> product) {
 		requirements = new ReadOnlyRegistry<>(Arrays.asList(//
 				new BundleRequirements(), //
 				new ComponentRequirements() //
@@ -100,7 +98,7 @@ public final class AgentConfiguration implements AccessCycleConfiguration {
 				new UserFilteringConditionTransport(user) //
 		));
 		codecs = new ReadOnlyRegistry<>(new BcStreamCodec(product));
-		keys = new ReadOnlyRegistry<>(new BundleKeyKeeper(product, bundle));
+		keys = new ReadOnlyRegistry<>(new PathKeyKeeper(product.get(), source));
 		emitters = new ReadOnlyRegistry<>(Arrays.asList(//
 				new BasePermissionEmittingService(//
 						expressionParsers(), //
@@ -119,9 +117,7 @@ public final class AgentConfiguration implements AccessCycleConfiguration {
 		environments = new ReadOnlyRegistry<>(Arrays.asList(//
 				new HardwareEnvironment() //
 		));
-		examinators = new ReadOnlyRegistry<>(Arrays.asList(//
-				new BasePermissionsExaminationService()//
-		));
+		examinators = new ReadOnlyRegistry<>(Collections.emptyList());
 	}
 
 	final MiningEquipment miningEquipment() {

--- a/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeFramework.java
+++ b/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeFramework.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lac.internal.seal;
+package org.eclipse.passage.lac.internal.gear;
 
 import java.util.function.Supplier;
 
@@ -21,20 +21,18 @@ import org.eclipse.passage.lic.internal.api.conditions.mining.LicenseReadingServ
 import org.eclipse.passage.lic.internal.api.io.UnemployedCodecs;
 import org.eclipse.passage.lic.internal.base.io.UserHomePath;
 import org.eclipse.passage.lic.internal.net.handle.ProductUserRequest;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 @SuppressWarnings("restriction")
-final class AgentFramework implements Framework {
+final class RuntimeFramework implements Framework {
 
 	private final Supplier<String> user;
 	private final Supplier<LicensedProduct> product;
 
-	public AgentFramework(ProductUserRequest<?> request) {
+	public RuntimeFramework(ProductUserRequest<?> request) {
 		this(request.user()::get, request.product()::get);
 	}
 
-	public AgentFramework(Supplier<String> user, Supplier<LicensedProduct> product) {
+	public RuntimeFramework(Supplier<String> user, Supplier<LicensedProduct> product) {
 		this.user = user;
 		this.product = product;
 	}
@@ -46,7 +44,7 @@ final class AgentFramework implements Framework {
 
 	@Override
 	public AccessCycleConfiguration accessCycleConfiguration() {
-		return new AgentConfiguration(new UserHomePath(), user, product, this::bundle);
+		return new RuntimeConfiguration(new UserHomePath(), user, product);
 	}
 
 	@Override
@@ -59,7 +57,4 @@ final class AgentFramework implements Framework {
 		throw new UnsupportedOperationException();
 	}
 
-	private Bundle bundle() {
-		return FrameworkUtil.getBundle(getClass());
-	}
 }

--- a/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeFrameworkConstructor.java
+++ b/bundles/org.eclipse.passage.lac.seal/src/org/eclipse/passage/lac/internal/gear/RuntimeFrameworkConstructor.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lac.internal.seal;
+package org.eclipse.passage.lac.internal.gear;
 
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.lic.internal.net.api.FrameworkConstructor;
@@ -19,11 +19,11 @@ import org.eclipse.passage.lic.internal.net.handle.ProductUserRequest;
 import org.osgi.service.component.annotations.Component;
 
 @Component
-public final class AgentFrameworkConstructor implements FrameworkConstructor {
+public final class RuntimeFrameworkConstructor implements FrameworkConstructor {
 
 	@Override
 	public <R extends NetRequest> Framework forRequest(ProductUserRequest<R> request) {
-		return new AgentFramework(request);
+		return new RuntimeFramework(request);
 	}
 
 }


### PR DESCRIPTION
Any application, that serves as Passage (licensing agent or Floating server) can declare a Framework for it's own runtime to empower Passage facilities.

From the other side, if this application itself is licensed with Passage, it should have sort of `seal` bundle with another Framework
declaration.

This bundle's units are renamed according to these statements. This bundle itself is to be renamed in accordance with a convention yet to come.


Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>