### PR TITLE
Bug 571327 issue floating license wizard sticks to a first data selection

### DIFF
--- a/bundles/org.eclipse.passage.loc.api/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.api/META-INF/MANIFEST.MF
@@ -40,3 +40,4 @@ Require-Bundle: org.eclipse.e4.core.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.products;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.passage.lic.users;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.passage.lic.users.model;bundle-version="1.0.0"
+Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/license/SelectableField.java
+++ b/bundles/org.eclipse.passage.loc.dashboard.ui/src/org/eclipse/passage/loc/dashboard/ui/wizards/license/SelectableField.java
@@ -40,7 +40,7 @@ abstract class SelectableField<T> extends LabeledField<T> {
 
 	@Override
 	public Optional<String> error() {
-		return data().isEmpty() ? Optional.of(errorText()) : Optional.empty();
+		return noData() ? Optional.of(errorText()) : Optional.empty();
 	}
 
 	@Override
@@ -73,6 +73,17 @@ abstract class SelectableField<T> extends LabeledField<T> {
 		select.setText(IssueLicensePageMessages.IssueLicenseRequestPage_btn_select_text);
 		select.addSelectionListener(widgetSelectedAdapter(event -> installData(select(text))));
 		select.setLayoutData(GridDataFactory.fillDefaults().create());
+	}
+
+	private boolean noData() {
+		Optional<T> data = data();
+		if (!data.isPresent()) {
+			return true;
+		}
+		if (data.get() instanceof Collection<?>) {
+			return ((Collection<?>) data.get()).isEmpty();
+		}
+		return false;
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/FloatingLicensePackFromRequest.java
+++ b/bundles/org.eclipse.passage.loc.licenses.core/src/org/eclipse/passage/loc/internal/licenses/core/FloatingLicensePackFromRequest.java
@@ -182,20 +182,13 @@ final class FloatingLicensePackFromRequest implements Supplier<FloatingLicensePa
 		FeatureGrant grant = FloatingFactory.eINSTANCE.createFeatureGrant();
 		String fid = feature.getFeatureIdentifier();
 		grant.setFeature(fid);
-		grant.setCapacity(featureGrantCapacity(fid));
+		grant.setCapacity(request.defaultCapacity());
 		grant.setIdentifier(String.format("%s#%d", request.identifier(), no)); //$NON-NLS-1$
 		grant.setPack(pack);
 		grant.setValid(featureGrantPeriod(fid));
 		grant.setVivid(featureGrantVivid(fid));
 		grant.setVersion(version(feature));
 		return grant;
-	}
-
-	private int featureGrantCapacity(String feature) {
-		return template//
-				.flatMap(l -> forFeature(l.getFeatures(), feature)) //
-				.map(FeatureGrant::getCapacity)//
-				.orElseGet(request::defaultCapacity);
 	}
 
 	private ValidityPeriod featureGrantPeriod(String feature) {


### PR DESCRIPTION
Issue Floating License Wizard fixes:
---
- 'Users' field validation is fixed together with each possible collection editing fields 
- `License Request` - `License Pack` pages relations are fixed: always use `default capacity` request value for new License Pack creation
- `License Pack` page generation is fixed: emfforms do not double their's controls with each new 'License Pack' instance

Bug 571326 cannot set preferred condition type for new User
---
- OperatorGearAware is fixed to properly supply _the Gear_
