### PR TITLE
Bug 571548 - [Passage] publish composite update sites

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.api.base
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.base
-Bundle-Version: 1.0.101.qualifier
+Bundle-Version: 1.0.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.base/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.base/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.lic.base
 ###############################################################################
-# Copyright (c) 2018, 2020 ArSysOp and others
+# Copyright (c) 2018, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC Base
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.emf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.emf.edit
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.emf
-Bundle-Version: 1.0.101.qualifier
+Bundle-Version: 1.0.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.emf/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.emf/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.lic.emf
 ###############################################################################
-# Copyright (c) 2018, 2020 ArSysOp and others
+# Copyright (c) 2018, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC EMF
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018, 2020 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lbc.execute.feature/feature.properties
+++ b/features/org.eclipse.passage.lbc.execute.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2020 ArSysOp and others
+# Copyright (c) 2018, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 featureName=Passage LBC Server 
 providerName=Eclipse Passage
 description=Passage Licensing Back-end Components: OSGi-based server to manage licensing data.
-copyright=Copyright (c) 2018, 2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2018, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lbc.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.execute.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lbc.execute.feature"
       label="%featureName"
-      version="1.0.2.qualifier"
+      version="1.0.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lbc.target.feature/feature.properties
+++ b/features/org.eclipse.passage.lbc.target.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019-2020 ArSysOp and others
+# Copyright (c) 2019, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 featureName=Passage LBC Target
 providerName=Eclipse Passage
 description=Passage Licensing Back-end Components: required target dependencies.
-copyright=Copyright (c) 2019-2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2019, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lbc.target.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.target.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lbc.target.feature"
       label="%featureName"
-      version="1.0.2.qualifier"
+      version="1.0.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lic.hc.feature/feature.properties
+++ b/features/org.eclipse.passage.lic.hc.feature/feature.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.lic.hc.feature
 ###############################################################################
-# Copyright (c) 2020 ArSysOp and others
+# Copyright (c) 2020, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
 featureName=Passage LIC HC
 providerName=Eclipse Passage
 description=Passage Licensing Integration Components HTTP components integration
-copyright=Copyright (c) 2019, 2020 ArSysOp and others.\n\
+copyright=Copyright (c) 2019, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/features/org.eclipse.passage.lic.hc.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.hc.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.hc.feature"
       label="%featureName"
-      version="1.0.2.qualifier"
+      version="1.0.100.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.hc"
       license-feature="org.eclipse.license"

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -43,7 +43,7 @@
 		<cbi-snapshots-repo.url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</cbi-snapshots-repo.url>
 
 		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.19-I-builds/</eclipserun-repo>
-		<released.baseline>https://download.eclipse.org/passage/updates/release/1.1.0/</released.baseline>
+		<released.baseline>https://download.eclipse.org/passage/updates/release/1.1.2/</released.baseline>
 		<staging.baseline>https://download.eclipse.org/passage/drops/integration/latest/</staging.baseline>
 
 		<!-- Declaration of properties that contribute to the arg line for the tycho-surefire-plugin. 


### PR DESCRIPTION
Switch released.baseline to
https://download.eclipse.org/passage/updates/release/1.1.2

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>