### PR TITLE
Bug 569540 - [Passage] rename the template of Licensed E4 RCP

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.ldc.pde.ui.templates;singleton:=true
-Bundle-Version: 0.5.400.qualifier
+Bundle-Version: 0.5.500.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.passage.ldc.internal.pde.ui.templates;x-internal:=true,
  org.eclipse.passage.ldc.internal.pde.ui.templates.i18n;x-internal:=true

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.ldc.pde.ui.templates
 ###############################################################################
-# Copyright (c) 2019, 2020 ArSysOp and others
+# Copyright (c) 2019, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LDC PDE UI Templates
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2019, 2020 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2019, 2021 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/OSGI-INF/l10n/bundle.properties
@@ -29,14 +29,14 @@ pluginContent.LicensedE3Product.description=\
 <li>org.eclipse.core.runtime.applications</li>\
 <li>org.eclipse.core.runtime.products</li>\
 
-pluginContent.LicensedE4Product.name = Licensed RCP 4.x (minimal)
+pluginContent.LicensedE4Product.name = Licensed RCP (minimal)
 pluginContent.LicensedE4Product.description=\
-<p>This wizard creates a minimal Eclipse 4.x product with license management support.</p>\
+<p>This wizard creates a minimal Eclipse product with license management support.</p>\
 <p><b>Extensions Used</b></p>\
 <li>org.eclipse.core.runtime.products</li>
 
-pluginContent.LicensedE4FullFeatherProduct.name = Licensed RCP 4.x (full feather)
+pluginContent.LicensedE4FullFeatherProduct.name = Licensed RCP (full feather)
 pluginContent.LicensedE4FullFeatherProduct.description=\
-<p>This wizard creates a full feather Eclipse 4.x product with license management support.</p>\
+<p>This wizard creates a full feather Eclipse product with license management support.</p>\
 <p><b>Extensions Used</b></p>\
 <li>org.eclipse.core.runtime.products</li>

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/LicensedE4ProductTemplateSection.java
@@ -51,7 +51,7 @@ public class LicensedE4ProductTemplateSection extends BaseLicensedTemplateSectio
 
 	private void createOptions() {
 		addOption(KEY_WINDOW_TITLE, PdeUiTemplatesMessages.LicensedE4ProductTemplateSection_key_window_title_label,
-				"Licensed E4 RCP", 0); //$NON-NLS-1$
+				"Licensed RCP", 0); //$NON-NLS-1$
 		addOption(KEY_PACKAGE_NAME, PdeUiTemplatesMessages.LicensedE4ProductTemplateSection_key_package_name_label,
 				(String) null, 0);
 	}

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.properties
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/i18n/PdeUiTemplatesMessages.properties
@@ -18,5 +18,5 @@ LicensedE3ProductTemplateSection_page_description=This template creates a minima
 LicensedE3ProductTemplateSection_page_title=Licensed E3 RCP
 LicensedE4ProductTemplateSection_key_package_name_label=Pa&ckage name:
 LicensedE4ProductTemplateSection_key_window_title_label=Application window &title:
-LicensedE4ProductTemplateSection_page_description=This template creates a minimal Eclipse 4 RCP application with license management support.
-LicensedE4ProductTemplateSection_page_title=Licensed E4 RCP
+LicensedE4ProductTemplateSection_page_description=This template creates a minimal Eclipse RCP application with license management support.
+LicensedE4ProductTemplateSection_page_title=Licensed RCP


### PR DESCRIPTION
Removed 4.x postfix

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>