### PR TITLE
Bug 572231 - [Passage][Floating] access cycle fails on NPE

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.passage.ldc.pde.ui.templates;singleton:=true
-Bundle-Version: 0.5.500.qualifier
+Bundle-Version: 0.5.501.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.eclipse.passage.ldc.internal.pde.ui.templates;x-internal:=true,
  org.eclipse.passage.ldc.internal.pde.ui.templates.i18n;x-internal:=true

--- a/bundles/org.eclipse.passage.lic.hc/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.hc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.hc
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.hc
-Bundle-Version: 1.0.102.qualifier
+Bundle-Version: 1.0.103.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
@@ -19,7 +19,7 @@ AccessPacks_no_stream_codec=No Stream Codec service for product %s
 
 EObjectFromXmiResponse_unexpected_content_type=Unexpected ContentType %s instead of %s
 
-RemoteService_no_server=No floating server configuration found. *.flaen file is expected to be present.
+RemoteService_no_server=No floating server configuration found. *.flaen file is expected to be present in %s.
 
 RequestParameters_encoding_failed=Failed to encode url query parameter value [%s] to UTF-8
 

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/NetConnection.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/NetConnection.java
@@ -15,6 +15,7 @@ package org.eclipse.passage.lic.internal.hc.remote.impl;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.util.Optional;
 
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.api.conditions.mining.ContentType;
@@ -74,7 +75,7 @@ public final class NetConnection implements Connection {
 
 	@Override
 	public ContentType contentType() throws LicensingException {
-		return new ContentType.Of(connection.getContentType());
+		return new ContentType.Of(Optional.ofNullable(connection.getContentType()).orElse("none")); //$NON-NLS-1$
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/ServiceRemote.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/ServiceRemote.java
@@ -69,7 +69,8 @@ public abstract class ServiceRemote<C extends Connection, T, D extends RemoteSer
 	}
 
 	private Trouble noServers() {
-		return new Trouble(new AbsentLicenseAttendantFile(), AccessMessages.RemoteService_no_server);
+		return new Trouble(new AbsentLicenseAttendantFile(),
+				String.format(AccessMessages.RemoteService_no_server, source.get().toAbsolutePath()));
 	}
 
 	private ServiceInvocationResult<Collection<FloatingLicenseAccess>> accesses(LicensedProduct product) {

--- a/bundles/org.eclipse.passage.seal.demo/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.seal.demo/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="3.8.0",
  org.eclipse.passage.lic.bc;bundle-version="0.5.100",
  org.eclipse.passage.lic.licenses.migration;bundle-version="0.5.200",
  org.eclipse.passage.lic.oshi;bundle-version="1.0.0",
- org.eclipse.passage.lic.e4.ui;bundle-version="1.0.0"
+ org.eclipse.passage.lic.e4.ui;bundle-version="1.0.0",
+ org.apache.logging.log4j;bundle-version="2.8.2"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.passage.seal.internal.demo;x-friends:="org.eclipse.passage.seal.demo.tests"

--- a/bundles/org.eclipse.passage.seal.demo/config/log4j2.xml
+++ b/bundles/org.eclipse.passage.seal.demo/config/log4j2.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG"
+	packages="org.eclipse.passage.lic">
+
+	<Appenders>
+
+		<Console name="ToSysOut" target="SYSTEM_OUT">
+			<PatternLayout
+				pattern="** %d{HH:mm:ss} [%t] %-5level %logger{36}: %msg%n" />
+		</Console>
+
+		<Routing name="ToFile">
+			<Routes pattern="$${sd:type}">
+				<Route>
+					<RollingFile name="logs-AC"
+						fileName="logs/access-cycle.log" filePattern="logs/access-cycle.%i.log.gz">
+						<PatternLayout>
+							<pattern>** %d{HH:mm:ss} %p %c{3.} [%t] %m%n</pattern>
+						</PatternLayout>
+						<SizeBasedTriggeringPolicy size="500000" />
+					</RollingFile>
+				</Route>
+			</Routes>
+		</Routing>
+
+	</Appenders>
+
+	<Loggers>
+
+		<Root level="debug">
+			<AppenderRef ref="ToSysOut" />
+			<AppenderRef ref="ToFile" />
+		</Root>
+
+	</Loggers>
+
+</Configuration>

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
@@ -12,19 +12,31 @@
  *******************************************************************************/
 package org.eclipse.passage.seal.internal.demo;
 
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.passage.lic.internal.api.AccessCycleConfiguration;
 import org.eclipse.passage.lic.internal.api.Framework;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.base.InvalidLicensedProduct;
+import org.eclipse.passage.lic.internal.base.logging.Logging;
 import org.eclipse.passage.lic.internal.equinox.LicensedApplication;
+import org.osgi.framework.FrameworkUtil;
 
+@SuppressWarnings("restriction")
 final class DemoFramework extends BaseFramework {
 
 	static final Framework demo = new DemoFramework();
 
+	private final Logger log;
+
 	private DemoFramework() {
-		super();
+		configureLogging();
+		this.log = LogManager.getLogger(getClass());
+		logConfiguration();
 	}
 
 	@Override
@@ -41,6 +53,22 @@ final class DemoFramework extends BaseFramework {
 	@Override
 	protected AccessCycleConfiguration configuration(LicensedProduct product) {
 		return new SealedAccessCycleConfiguration(() -> product);
+	}
+
+	private void configureLogging() {
+		new Logging(this::logConfig).configure();
+	}
+
+	private Path logConfig() throws Exception {
+		return FileLocator.getBundleFile(FrameworkUtil.getBundle(getClass())).toPath()//
+				.resolve("config") //$NON-NLS-1$
+				.resolve("log4j2.xml"); //$NON-NLS-1$
+	}
+
+	private void logConfiguration() {
+		log.debug(String.format("%s runs for %s", //$NON-NLS-1$
+				getClass().getName(), //
+				product()));
 	}
 
 }

--- a/features/org.eclipse.passage.lic.hc.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.hc.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.hc.feature"
       label="%featureName"
-      version="1.0.100.qualifier"
+      version="1.0.101.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.hc"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.loc.workbench.feature/feature.xml
+++ b/features/org.eclipse.passage.loc.workbench.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.loc.workbench.feature"
       label="%featureName"
-      version="1.0.100.qualifier"
+      version="1.0.101.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
- process 'null' content type as it is been born outside of passage's reach
- improve diagnostic
- plug logging to passage access cycle

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>