### PR TITLE
Bug 566482 implement license grants uploading interface

### DIFF
--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsCommands.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsCommands.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lbc.internal.jetty;
+
+import org.osgi.framework.BundleContext;
+
+final class FlsCommands {
+
+	void register(BundleContext context, String name) {
+		new UploadLicense(name).register(context);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsJettyActivator.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsJettyActivator.java
@@ -21,6 +21,7 @@ import org.eclipse.passage.lic.internal.equinox.io.FileFromBundle;
 import org.eclipse.passage.lic.internal.jetty.JettyHandler;
 import org.eclipse.passage.lic.internal.jetty.interaction.LicensedJettyActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 public final class FlsJettyActivator extends LicensedJettyActivator {
@@ -32,6 +33,11 @@ public final class FlsJettyActivator extends LicensedJettyActivator {
 	}
 
 	@Override
+	protected String name() {
+		return "fls"; //$NON-NLS-1$
+	}
+
+	@Override
 	protected JettyHandler handler() {
 		return new JettyHandler(request -> new FlotingRequestHandled(new StatedRequest(request, state)).get());
 	}
@@ -40,6 +46,11 @@ public final class FlsJettyActivator extends LicensedJettyActivator {
 	protected Path logConfig() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 		return new FileFromBundle(bundle, "config/log4j2.xml").get(); //$NON-NLS-1$
+	}
+
+	@Override
+	protected void registerCustomCommands(BundleContext context) {
+		new FlsCommands().register(context, name());
 	}
 
 }

--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/UploadLicense.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/UploadLicense.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lbc.internal.jetty;
+
+import org.eclipse.passage.lic.internal.jetty.interaction.Command;
+import org.eclipse.passage.lic.internal.jetty.interaction.Scope;
+
+final class UploadLicense extends Command {
+
+	public UploadLicense(String scope) {
+		super(new Scope.Of(scope), new String[] { "upload" }); //$NON-NLS-1$
+	}
+
+	public void upload(String from) {
+		// new IncomingLicense(from).upload();
+	}
+
+	public void upload(String from, String product, String version) {
+		// new IncomingLicense(from).uploadForProduct(product, version);
+	}
+
+	public void upload(String... args) {
+		if (args.length == 1) {
+			upload(args[0]);
+		} else if (args.length == 3) {
+			upload(args[0], args[1], args[2]);
+		} else {
+			System.out.println(help());
+		}
+	}
+
+	private String help() {
+		return "[fls:upload] places the given floating license pack at the Server's disposal.\n" + //$NON-NLS-1$
+				"Usage:\n\t" + //$NON-NLS-1$
+				scope.id() + ":upload <path-to-license-pack-folder>\n\t" + //$NON-NLS-1$
+				scope.id() + ":upload <path-to-license-pack-folder> <product-id> <product-version>\n"; //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/io/ExternalLicense.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/io/ExternalLicense.java
@@ -10,30 +10,33 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
+package org.eclipse.passage.lic.internal.base.io;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
-import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
-import org.eclipse.passage.lic.internal.base.io.PathFromLicensedProduct;
-import org.eclipse.passage.lic.internal.base.io.UserHomePath;
 
-final class ExternalLicense {
+public final class ExternalLicense {
 
 	private final LicensedProduct product;
 
-	ExternalLicense(LicensedProduct product) {
+	public ExternalLicense(LicensedProduct product) {
 		this.product = product;
 	}
 
-	void install(Path license) throws IOException {
+	public void install(Path... pack) throws IOException {
+		for (Path file : pack) {
+			installLicenseFile(file);
+		}
+	}
+
+	private void installLicenseFile(Path file) throws IOException {
 		Path target = new PathFromLicensedProduct(new LicensingFolder(new UserHomePath()), product).get()
-				.resolve(license.getFileName());
+				.resolve(file.getFileName());
 		target.toFile().getParentFile().mkdirs();
-		Files.copy(license, target);
+		Files.copy(file, target);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyServer.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyServer.java
@@ -52,6 +52,14 @@ public final class JettyServer {
 		}
 	}
 
+	public String state() throws JettyException {
+		try {
+			return server.getState();
+		} catch (Exception e) {
+			throw new JettyException(Messages.error_onstate, e);
+		}
+	}
+
 	private void logAndRethrow(Exception e, String template) throws JettyException {
 		String message = String.format(template, e.getClass(), e.getMessage());
 		log.error(message, e);

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.java
@@ -30,6 +30,7 @@ public final class Messages {
 	public static final String not_running = getString("server_not_running"); //$NON-NLS-1$
 	public static final String error_onstart = getString("error_onstart"); //$NON-NLS-1$
 	public static final String error_onstop = getString("error_onstop"); //$NON-NLS-1$
+	public static final String error_onstate = getString("error_onstate"); //$NON-NLS-1$
 
 	private Messages() {
 	}

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.properties
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.properties
@@ -17,3 +17,4 @@ server_already_running=Server is already running \n
 server_not_running=No running server found \n
 error_onstart=Server couldn't be started due to %s: %s \n
 error_onstop=Server couldn't be stopped due to %s: %s \n
+error_onstate=Server failed to report its state

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Command.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Command.java
@@ -12,9 +12,13 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jetty.interaction;
 
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleContext;
+
 public abstract class Command {
 
-	private final Scope scope;
+	protected final Scope scope;
 	private final String[] names;
 
 	public Command(Scope scope, String[] names) {
@@ -22,12 +26,11 @@ public abstract class Command {
 		this.names = names;
 	}
 
-	public final Scope scope() {
-		return scope;
-	}
-
-	public final String[] commands() {
-		return names;
+	public final void register(BundleContext context) {
+		Hashtable<String, Object> properties = new Hashtable<>();
+		properties.put("osgi.command.scope", scope.id());//$NON-NLS-1$
+		properties.put("osgi.command.function", names);//$NON-NLS-1$
+		context.registerService(getClass().getName(), this, properties);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Commands.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Commands.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jetty.interaction;
 
-import java.util.Hashtable;
-
 import org.eclipse.passage.lic.internal.jetty.JettyServer;
 import org.osgi.framework.BundleContext;
 
@@ -21,9 +19,9 @@ final class Commands {
 
 	private ServerHandles server;
 
-	void register(BundleContext context, JettyServer jetty) {
+	void register(BundleContext context, JettyServer jetty, String name) {
 		registerSelfStatus(context);
-		registerServerHandles(context, jetty);
+		registerServerHandles(context, jetty, name);
 	}
 
 	ServerHandles server() {
@@ -31,21 +29,12 @@ final class Commands {
 	}
 
 	private void registerSelfStatus(BundleContext context) {
-		register(context, new LicenseStatus());
+		new LicenseStatus().register(context);
 	}
 
-	private void registerServerHandles(BundleContext context, JettyServer jetty) {
-		this.server = new ServerHandles(jetty);
-		register(context, server);
-	}
-
-	private void register(BundleContext context, Command command) {
-		Hashtable<String, Object> props = new Hashtable<>();
-		props.put("osgi.command.scope", //$NON-NLS-1$
-				command.scope().id());
-		props.put("osgi.command.function", //$NON-NLS-1$
-				command.commands());
-		context.registerService(command.getClass().getName(), command, props);
+	private void registerServerHandles(BundleContext context, JettyServer jetty, String name) {
+		this.server = new ServerHandles(jetty, name);
+		this.server.register(context);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
@@ -49,7 +49,7 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 		Commands commands = new Commands();
 		commands.register(context, jetty, name());
 		this.server = commands.server();
-		// registerCustomCommands(context);
+		registerCustomCommands(context);
 	}
 
 	protected abstract String name();
@@ -58,6 +58,6 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 
 	protected abstract Path logConfig() throws Exception;
 
-	// protected abstract void registerCustomCommands(BundleContext context);
+	protected abstract void registerCustomCommands(BundleContext context);
 
 }

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
@@ -33,7 +33,7 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 	@Override
 	public final void start(BundleContext context) throws Exception {
 		registerCommands(context);
-		server.start();
+		server.start(); // temporal coupling here: server is initialized during commands registration
 	}
 
 	@Override
@@ -47,12 +47,17 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 
 	private void registerCommands(BundleContext context) {
 		Commands commands = new Commands();
-		commands.register(context, jetty);
+		commands.register(context, jetty, name());
 		this.server = commands.server();
+		// registerCustomCommands(context);
 	}
+
+	protected abstract String name();
 
 	protected abstract JettyHandler handler();
 
 	protected abstract Path logConfig() throws Exception;
+
+	// protected abstract void registerCustomCommands(BundleContext context);
 
 }

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
@@ -26,13 +26,14 @@ final class ServerHandles extends Command {
 	private final Port port;
 	private final LicenseProtection license = new LicenseProtection();
 
-	ServerHandles(JettyServer server) {
+	ServerHandles(JettyServer server, String name) {
 		super(//
-				new Scope.Server(), //
+				new Scope.Of(name), //
 				new String[] { //
 						"start", //$NON-NLS-1$
 						"stop", //$NON-NLS-1$
-						"restart" //$NON-NLS-1$
+						"restart", //$NON-NLS-1$
+						"state" //$NON-NLS-1$
 				});
 		this.server = server;
 		this.port = new Port(Platform.getApplicationArgs(), 8090);
@@ -61,6 +62,14 @@ final class ServerHandles extends Command {
 	public void restart() {
 		stop();
 		start();
+	}
+
+	public void state() {
+		try {
+			System.out.println(server.state());
+		} catch (JettyException e) {
+			log.error("failed to report state of Jetty server", e); //$NON-NLS-1$
+		}
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
@@ -29,6 +29,7 @@ import org.eclipse.passage.lic.internal.api.conditions.ValidityPeriod;
 import org.eclipse.passage.lic.internal.api.conditions.mining.LicenseReadingService;
 import org.eclipse.passage.lic.internal.api.diagnostic.Diagnostic;
 import org.eclipse.passage.lic.internal.base.conditions.BaseValidityPeriodClosed;
+import org.eclipse.passage.lic.internal.base.io.ExternalLicense;
 import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
 import org.eclipse.passage.lic.internal.equinox.LicenseReadingServiceRequest;
 import org.eclipse.passage.lic.internal.jface.i18n.ImportLicenseDialogMessages;


### PR DESCRIPTION
General jetty-based serverv activator evolution:
- make server's command set replenishable
- make server's handles to reside in domain specific scope
- add `state` server command 

FLS cli:
- design `upload license` command

General codebase changes:
- promote `ExternalLicense` installation util for reuse
