### PR TITLE
Bug 572366 verify product's public key on hc-fls interaction

### DIFF
--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/RequestParameters.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/RequestParameters.java
@@ -21,14 +21,15 @@ import java.util.stream.Collectors;
 import org.eclipse.passage.lic.floating.model.api.FloatingLicenseAccess;
 import org.eclipse.passage.lic.floating.model.net.ServerAuthenticationExpression;
 import org.eclipse.passage.lic.floating.model.net.ServerAuthenticationType;
-import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.NamedData;
 import org.eclipse.passage.lic.internal.base.ProductIdentifier;
 import org.eclipse.passage.lic.internal.base.ProductVersion;
 import org.eclipse.passage.lic.internal.hc.i18n.AccessMessages;
 import org.eclipse.passage.lic.internal.hc.remote.QueryParameters;
+import org.eclipse.passage.lic.internal.net.EncodingAlgorithm;
 import org.eclipse.passage.lic.internal.net.LicenseUser;
 import org.eclipse.passage.lic.internal.net.LicensingAction;
 
@@ -36,10 +37,12 @@ public abstract class RequestParameters implements QueryParameters {
 
 	private final LicensedProduct product;
 	private final FloatingLicenseAccess access;
+	private final String hash;
 
-	protected RequestParameters(LicensedProduct product, FloatingLicenseAccess access) {
+	protected RequestParameters(LicensedProduct product, FloatingLicenseAccess access, String hash) {
 		this.product = product;
 		this.access = access;
+		this.hash = hash;
 	}
 
 	@Override
@@ -67,6 +70,8 @@ public abstract class RequestParameters implements QueryParameters {
 				new ProductVersion(encode(product.version())), //
 				new LicensingAction(action()), //
 				new LicenseUser(access.getUser()), //
+				new LicenseUser(access.getUser()), //
+				new EncodingAlgorithm(hash), //
 				new ServerAuthenticationType(access.getServer().getAuthentication().getType()), //
 				new ServerAuthenticationExpression(encode(access.getServer().getAuthentication().getExpression())));
 

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/AcquireRequestParameters.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/AcquireRequestParameters.java
@@ -16,9 +16,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.passage.lic.floating.model.api.FloatingLicenseAccess;
-import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.FeatureIdentifier;
 import org.eclipse.passage.lic.internal.base.NamedData;
 import org.eclipse.passage.lic.internal.hc.remote.impl.RequestParameters;
@@ -27,8 +27,8 @@ final class AcquireRequestParameters extends RequestParameters {
 
 	private final String feature;
 
-	AcquireRequestParameters(LicensedProduct product, String feature, FloatingLicenseAccess access) {
-		super(product, access);
+	AcquireRequestParameters(LicensedProduct product, String feature, FloatingLicenseAccess access, String hash) {
+		super(product, access, hash);
 		this.feature = feature;
 	}
 

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/ReleaseRequestParameters.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/ReleaseRequestParameters.java
@@ -16,9 +16,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.passage.lic.floating.model.api.FloatingLicenseAccess;
-import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.PassageAction;
 import org.eclipse.passage.lic.internal.base.FeatureIdentifier;
 import org.eclipse.passage.lic.internal.base.NamedData;
 import org.eclipse.passage.lic.internal.hc.remote.impl.RequestParameters;
@@ -27,8 +27,8 @@ final class ReleaseRequestParameters extends RequestParameters {
 
 	private final String feature;
 
-	ReleaseRequestParameters(LicensedProduct product, String feature, FloatingLicenseAccess access) {
-		super(product, access);
+	ReleaseRequestParameters(LicensedProduct product, String feature, FloatingLicenseAccess access, String hash) {
+		super(product, access, hash);
 		this.feature = feature;
 	}
 

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/RemoteAcquire.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/RemoteAcquire.java
@@ -82,7 +82,7 @@ final class RemoteAcquire<C extends Connection> extends ServiceAny<C, GrantAcqui
 
 		@Override
 		public RequestParameters parameters() {
-			return new AcquireRequestParameters(data.product(), data.feature(), access);
+			return new AcquireRequestParameters(data.product(), data.feature(), access, hash);
 		}
 
 		@Override

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/RemoteRelease.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/acquire/RemoteRelease.java
@@ -78,7 +78,7 @@ final class RemoteRelease<C extends Connection>
 
 		@Override
 		public RequestParameters parameters() {
-			return new ReleaseRequestParameters(product, data.payload().feature(), access);
+			return new ReleaseRequestParameters(product, data.payload().feature(), access, hash);
 		}
 
 		private byte[] payload() throws LicensingException {

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/mine/MineRequestParameters.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/mine/MineRequestParameters.java
@@ -24,8 +24,8 @@ import org.eclipse.passage.lic.internal.hc.remote.impl.RequestParameters;
 
 final class MineRequestParameters extends RequestParameters {
 
-	MineRequestParameters(LicensedProduct product, FloatingLicenseAccess access) {
-		super(product, access);
+	MineRequestParameters(LicensedProduct product, FloatingLicenseAccess access, String hash) {
+		super(product, access, hash);
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/mine/RemoteConditionsRequest.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/mine/RemoteConditionsRequest.java
@@ -29,7 +29,7 @@ public final class RemoteConditionsRequest<C extends Connection> extends RemoteR
 
 	@Override
 	public RequestParameters parameters() {
-		return new MineRequestParameters(product, access);
+		return new MineRequestParameters(product, access, hash);
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/EncodingAlgorithm.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/EncodingAlgorithm.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.net;
+
+import java.util.function.Function;
+
+import org.eclipse.passage.lic.internal.base.StringNamedData;
+
+public final class EncodingAlgorithm extends StringNamedData {
+
+	public EncodingAlgorithm(String value) {
+		super(value);
+	}
+
+	public EncodingAlgorithm(Function<String, String> retrieve) {
+		super(retrieve);
+	}
+
+	@Override
+	public String key() {
+		return "algo"; //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/ProductUserRequest.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/handle/ProductUserRequest.java
@@ -19,6 +19,7 @@ import org.eclipse.passage.lic.internal.api.LicensingException;
 import org.eclipse.passage.lic.internal.base.BaseLicensedProduct;
 import org.eclipse.passage.lic.internal.base.ProductIdentifier;
 import org.eclipse.passage.lic.internal.base.ProductVersion;
+import org.eclipse.passage.lic.internal.net.EncodingAlgorithm;
 import org.eclipse.passage.lic.internal.net.LicenseUser;
 import org.eclipse.passage.lic.internal.net.api.handle.NetRequest;
 
@@ -27,11 +28,13 @@ public final class ProductUserRequest<R extends NetRequest> {
 	private final R raw;
 	private final Optional<LicensedProduct> product;
 	private final Optional<String> user;
+	private final Optional<String> algorithm;
 
 	public ProductUserRequest(R raw) throws LicensingException {
 		this.raw = raw;
 		this.product = extractProduct();
 		this.user = extractUser();
+		this.algorithm = extractAlgorithm();
 	}
 
 	private Optional<LicensedProduct> extractProduct() throws LicensingException {
@@ -49,6 +52,10 @@ public final class ProductUserRequest<R extends NetRequest> {
 		return new LicenseUser(raw::parameter).get();
 	}
 
+	private Optional<String> extractAlgorithm() {
+		return new EncodingAlgorithm(raw::parameter).get();
+	}
+
 	public R raw() {
 		return raw;
 	}
@@ -61,4 +68,7 @@ public final class ProductUserRequest<R extends NetRequest> {
 		return user;
 	}
 
+	public Optional<String> algorithm() {
+		return algorithm;
+	}
 }


### PR DESCRIPTION
- add 'algo' parameter to all HC requests for the server to be aware of encoding applied
- read the parameter for all net request handlers

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>