### PR TITLE
572840 condition miner failure should be treated as bearable issue

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/LocalConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/mining/LocalConditions.java
@@ -89,7 +89,11 @@ public abstract class LocalConditions implements MinedConditions {
 				new BaseDiagnostic(//
 						Collections.emptyList(), //
 						Collections.singletonList(//
-								new Trouble(new NoLicenses(), base(product).get().toAbsolutePath().toString()))//
+								new Trouble(//
+										new NoLicenses(), //
+										String.format(//
+												ConditionMiningMessages.getString("LocalConditions.no_licenses"), //$NON-NLS-1$
+												base(product).get().toAbsolutePath())))//
 				), //
 				Collections.emptyList()//
 		);

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionMiningMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/ConditionMiningMessages.properties
@@ -11,3 +11,4 @@
 #      ArSysOp - initial API and implementation
 ###############################################################################
 LocalConditions.failed=Condition mining across local file system failed
+LocalConditions.no_licenses=No licenses found in %s

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/registry/JointRegistry.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/registry/JointRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.passage.lic.internal.api.registry.ServiceId;
 import org.eclipse.passage.lic.internal.base.i18n.BaseMessages;
 
 public final class JointRegistry<I extends ServiceId, S extends Service<I>> implements Registry<I, S> {
+
 	private final List<Registry<I, S>> delegates;
 
 	public JointRegistry(List<Registry<I, S>> delegates) {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/registry/ReadOnlyRegistry.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/registry/ReadOnlyRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.passage.lic.internal.base.registry;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.eclipse.passage.lic.internal.api.registry.Registry;
 import org.eclipse.passage.lic.internal.api.registry.Service;
 import org.eclipse.passage.lic.internal.api.registry.ServiceId;
 
@@ -32,4 +33,7 @@ public final class ReadOnlyRegistry<I extends ServiceId, S extends Service<I>> e
 		super(Collections.emptyList());
 	}
 
+	public ReadOnlyRegistry(Registry<I, S> delegate) {
+		super(delegate.services());
+	}
 }

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/i18n/AccessMessages.properties
@@ -19,7 +19,7 @@ AccessPacks_no_stream_codec=No Stream Codec service for product %s
 
 EObjectFromXmiResponse_unexpected_content_type=Unexpected ContentType %s instead of %s
 
-RemoteService_no_server=No floating server configuration found. *.flaen file is expected to be present in %s.
+RemoteService_no_server=Remote condition mining do not work: no floating server configuration found. *.flaen file is expected to be present in %s.
 
 RequestParameters_encoding_failed=Failed to encode url query parameter value [%s] to UTF-8
 

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/ServiceRemote.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/internal/hc/remote/impl/ServiceRemote.java
@@ -14,15 +14,18 @@ package org.eclipse.passage.lic.internal.hc.remote.impl;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.diagnostic.Trouble;
 import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.internal.base.diagnostic.BaseDiagnostic;
 import org.eclipse.passage.lic.internal.base.diagnostic.NoSevereErrors;
 import org.eclipse.passage.lic.internal.base.diagnostic.code.AbsentLicenseAttendantFile;
 import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
+import org.eclipse.passage.lic.internal.base.io.PathFromLicensedProduct;
 import org.eclipse.passage.lic.internal.base.io.UserHomePath;
 import org.eclipse.passage.lic.internal.hc.i18n.AccessMessages;
 import org.eclipse.passage.lic.internal.hc.remote.Client;
@@ -52,7 +55,7 @@ public abstract class ServiceRemote<C extends Connection, T, D extends RemoteSer
 			return new BaseServiceInvocationResult<>(accesses.diagnostic());
 		}
 		if (accesses.data().get().isEmpty()) {
-			return new BaseServiceInvocationResult<>(noServers());
+			return noServers(parameters.product());
 		}
 		return withServers(parameters, accesses.data().get());
 	}
@@ -63,9 +66,14 @@ public abstract class ServiceRemote<C extends Connection, T, D extends RemoteSer
 				handler(access));
 	}
 
-	private Trouble noServers() {
-		return new Trouble(new AbsentLicenseAttendantFile(),
-				String.format(AccessMessages.RemoteService_no_server, source.get().toAbsolutePath()));
+	private ServiceInvocationResult<T> noServers(LicensedProduct product) {
+		return new BaseServiceInvocationResult<>(//
+				new BaseDiagnostic(Collections.singletonList(//
+						new Trouble(//
+								new AbsentLicenseAttendantFile(), //
+								String.format(//
+										AccessMessages.RemoteService_no_server, //
+										new PathFromLicensedProduct(source, product).get().toAbsolutePath())))));
 	}
 
 	private ServiceInvocationResult<Collection<FloatingLicenseAccess>> accesses(LicensedProduct product) {

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
@@ -54,7 +54,7 @@ final class DemoFramework extends BaseFramework {
 
 	@Override
 	protected AccessCycleConfiguration configuration(LicensedProduct product) {
-		return new SealedAccessCycleConfiguration(() -> product);
+		return new FocusedAccessCycleConfiguration.Wide(() -> product);
 	}
 
 	private void configureLogging() {

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/DemoFramework.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/FocusedAccessCycleConfiguration.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/FocusedAccessCycleConfiguration.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.internal.demo;
+
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.acquire.LicenseAcquisitionServicesRegistry;
+import org.eclipse.passage.lic.internal.api.conditions.mining.MinedConditionsRegistry;
+import org.eclipse.passage.lic.internal.api.io.HashesRegistry;
+import org.osgi.framework.FrameworkUtil;
+
+@SuppressWarnings("restriction")
+abstract class FocusedAccessCycleConfiguration extends BaseAccessCycleConfiguration {
+
+	protected LicensingDirection delegate; // lateinit, practically final and not null
+
+	FocusedAccessCycleConfiguration(Supplier<LicensedProduct> product) {
+		super(product, () -> FrameworkUtil.getBundle(FocusedAccessCycleConfiguration.class));
+	}
+
+	@Override
+	public MinedConditionsRegistry conditionMiners() {
+		return delegate.conditionMiners();
+	}
+
+	@Override
+	public LicenseAcquisitionServicesRegistry acquirers() {
+		return delegate.acquirers();
+	}
+
+	@Override
+	public HashesRegistry hashes() {
+		return delegate.hashes();
+	}
+
+	/**
+	 * Focuses Access Cycle Configuration on local license mining
+	 */
+	static final class Personal extends FocusedAccessCycleConfiguration {
+
+		Personal(Supplier<LicensedProduct> product) {
+			super(product);
+			this.delegate = new PersonalLicensing(super::miningEquipment);
+		}
+
+	}
+
+	/**
+	 * Focuses Access Cycle Configuration on remote license mining
+	 */
+	static final class Floating extends FocusedAccessCycleConfiguration {
+
+		Floating(Supplier<LicensedProduct> product) {
+			super(product);
+			this.delegate = new FloatingLicensing(super.keyKeepers(), super.codecs(), super.transports());
+		}
+
+	}
+
+	/**
+	 * Adapts Access Cycle Configuration to both local and remote license mining
+	 */
+	static final class Wide extends FocusedAccessCycleConfiguration {
+
+		Wide(Supplier<LicensedProduct> product) {
+			super(product);
+			this.delegate = new LicensingDirection.Joint(//
+					new PersonalLicensing(super::miningEquipment), //
+					new FloatingLicensing(super.keyKeepers(), super.codecs(), super.transports()));
+		}
+
+	}
+
+}

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/LicensingDirection.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/LicensingDirection.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.seal.internal.demo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.internal.api.acquire.LicenseAcquisitionServicesRegistry;
+import org.eclipse.passage.lic.internal.api.conditions.mining.MinedConditionsRegistry;
+import org.eclipse.passage.lic.internal.api.io.HashesRegistry;
+import org.eclipse.passage.lic.internal.api.registry.Registry;
+import org.eclipse.passage.lic.internal.api.registry.Service;
+import org.eclipse.passage.lic.internal.api.registry.ServiceId;
+import org.eclipse.passage.lic.internal.base.registry.JointRegistry;
+
+@SuppressWarnings("restriction")
+interface LicensingDirection {
+
+	public MinedConditionsRegistry conditionMiners();
+
+	public LicenseAcquisitionServicesRegistry acquirers();
+
+	public HashesRegistry hashes();
+
+	static final class Joint implements LicensingDirection {
+
+		private final List<LicensingDirection> delegates;
+
+		Joint(LicensingDirection... delegates) {
+			this.delegates = Arrays.asList(delegates);
+		}
+
+		private <I extends ServiceId, S extends Service<I>> Registry<I, S> registries(
+				Function<LicensingDirection, Supplier<Registry<I, S>>> retrieve) {
+			return new JointRegistry<>(delegates.stream()//
+					.map(delegate -> retrieve.apply(delegate).get())//
+					.collect(Collectors.toList()));
+		}
+
+		@Override
+		public MinedConditionsRegistry conditionMiners() {
+			return () -> registries(LicensingDirection::conditionMiners);
+		}
+
+		@Override
+		public LicenseAcquisitionServicesRegistry acquirers() {
+			return () -> registries(LicensingDirection::acquirers);
+		}
+
+		@Override
+		public HashesRegistry hashes() {
+			return () -> registries(LicensingDirection::hashes);
+		}
+
+	}
+
+}

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/LicensingDirection.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/LicensingDirection.java
@@ -25,6 +25,7 @@ import org.eclipse.passage.lic.internal.api.registry.Registry;
 import org.eclipse.passage.lic.internal.api.registry.Service;
 import org.eclipse.passage.lic.internal.api.registry.ServiceId;
 import org.eclipse.passage.lic.internal.base.registry.JointRegistry;
+import org.eclipse.passage.lic.internal.base.registry.ReadOnlyRegistry;
 
 @SuppressWarnings("restriction")
 interface LicensingDirection {
@@ -45,9 +46,10 @@ interface LicensingDirection {
 
 		private <I extends ServiceId, S extends Service<I>> Registry<I, S> registries(
 				Function<LicensingDirection, Supplier<Registry<I, S>>> retrieve) {
-			return new JointRegistry<>(delegates.stream()//
-					.map(delegate -> retrieve.apply(delegate).get())//
-					.collect(Collectors.toList()));
+			return new ReadOnlyRegistry<>(//
+					new JointRegistry<>(delegates.stream()//
+							.map(delegate -> retrieve.apply(delegate).get())//
+							.collect(Collectors.toList())));
 		}
 
 		@Override

--- a/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/PersonalLicensing.java
+++ b/bundles/org.eclipse.passage.seal.demo/src/org/eclipse/passage/seal/internal/demo/PersonalLicensing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,12 +15,12 @@ package org.eclipse.passage.seal.internal.demo;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lic.internal.api.LicensedProduct;
 import org.eclipse.passage.lic.internal.api.acquire.LicenseAcquisitionService;
 import org.eclipse.passage.lic.internal.api.acquire.LicenseAcquisitionServicesRegistry;
 import org.eclipse.passage.lic.internal.api.conditions.ConditionMiningTarget;
 import org.eclipse.passage.lic.internal.api.conditions.mining.MinedConditions;
 import org.eclipse.passage.lic.internal.api.conditions.mining.MinedConditionsRegistry;
+import org.eclipse.passage.lic.internal.api.conditions.mining.MiningEquipment;
 import org.eclipse.passage.lic.internal.api.io.Hashes;
 import org.eclipse.passage.lic.internal.api.io.HashesRegistry;
 import org.eclipse.passage.lic.internal.api.registry.Registry;
@@ -32,22 +32,20 @@ import org.eclipse.passage.lic.internal.equinox.acquire.ConfigurationLicenseAcqu
 import org.eclipse.passage.lic.internal.equinox.acquire.InstallationLicenseAcquisitionService;
 import org.eclipse.passage.lic.internal.equinox.conditions.ConfigurationResidentConditions;
 import org.eclipse.passage.lic.internal.equinox.conditions.InstallationResidentConditions;
-import org.osgi.framework.FrameworkUtil;
 
 @SuppressWarnings("restriction")
-final class SealedAccessCycleConfiguration extends BaseAccessCycleConfiguration {
+final class PersonalLicensing implements LicensingDirection {
 
 	private final Registry<ConditionMiningTarget, MinedConditions> conditions;
 	private final Registry<ConditionMiningTarget, LicenseAcquisitionService> acquirers;
 
-	SealedAccessCycleConfiguration(Supplier<LicensedProduct> product) {
-		super(product, () -> FrameworkUtil.getBundle(SealedAccessCycleConfiguration.class));
-		conditions = new ReadOnlyRegistry<>(Arrays.asList(//
-				new UserHomeResidentConditions(miningEquipment()), //
-				new InstallationResidentConditions(miningEquipment()), //
-				new ConfigurationResidentConditions(miningEquipment())//
+	PersonalLicensing(Supplier<MiningEquipment> equipment) {
+		this.conditions = new ReadOnlyRegistry<>(Arrays.asList(//
+				new UserHomeResidentConditions(equipment.get()), //
+				new InstallationResidentConditions(equipment.get()), //
+				new ConfigurationResidentConditions(equipment.get())//
 		));
-		acquirers = new ReadOnlyRegistry<>(Arrays.asList(//
+		this.acquirers = new ReadOnlyRegistry<>(Arrays.asList(//
 				new UserHomeLicenseAcquisitionService(), //
 				new InstallationLicenseAcquisitionService(), //
 				new ConfigurationLicenseAcquisitionService()//
@@ -55,17 +53,17 @@ final class SealedAccessCycleConfiguration extends BaseAccessCycleConfiguration 
 	}
 
 	@Override
-	public MinedConditionsRegistry conditionMiners() {
+	public final MinedConditionsRegistry conditionMiners() {
 		return () -> conditions;
 	}
 
 	@Override
-	public LicenseAcquisitionServicesRegistry acquirers() {
+	public final LicenseAcquisitionServicesRegistry acquirers() {
 		return () -> acquirers;
 	}
 
 	@Override
-	public HashesRegistry hashes() {
+	public final HashesRegistry hashes() {
 		return () -> new ReadOnlyRegistry<StringServiceId, Hashes>();
 	}
 


### PR DESCRIPTION
- demote `remote condition miner` service malfunction error to warning
- improve diagnostic messages for the case if a lpcal condition mining directory possesses no license files
- Include `remote condition miner`  into default `seal.demo` configuration