### PR TITLE
Bug 572906 improve DiagnosticDialog UX with colors

### DIFF
--- a/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.base.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.jface
-Bundle-Version: 1.1.1.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticColors.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticColors.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
+
+import java.util.Arrays;
+
+import org.eclipse.swt.graphics.Color;
+
+final class DiagnosticColors {
+
+	private final Color failure;
+	private final Color error;
+	private final Color warning;
+	private final Color info;
+
+	DiagnosticColors() {
+		this.failure = new Color(222, 145, 145);
+		this.error = new Color(233, 175, 215);
+		this.warning = new Color(244, 228, 186);
+		this.info = new Color(178, 201, 166);
+	}
+
+	Color get(boolean severe, boolean exception) {
+		if (severe && exception) {
+			return failure;
+		} else if (severe && !exception) {
+			return error;
+		} else if (!severe && exception) {
+			return warning;
+		} else {
+			return info;
+		}
+	}
+
+	void dispose() {
+		Arrays.asList(failure, error, warning, info)//
+				.forEach(Color::dispose);
+	}
+}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,17 +21,20 @@ import org.eclipse.passage.lic.internal.base.diagnostic.DiagnosticExplained;
 import org.eclipse.passage.lic.internal.base.diagnostic.SumOfLists;
 import org.eclipse.passage.lic.internal.base.diagnostic.TroubleHasException;
 import org.eclipse.passage.lic.internal.jface.i18n.DiagnosticDialogMessages;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 
 public final class DiagnosticDialog extends NotificationDialog {
 
 	private final Diagnostic diagnostic;
+	private final DiagnosticColors colors;
 	private ButtonConfig error;
 
 	public DiagnosticDialog(Shell shell, Diagnostic diagnostic) {
 		super(shell);
 		this.diagnostic = diagnostic;
+		this.colors = new DiagnosticColors();
 	}
 
 	@Override
@@ -39,7 +42,7 @@ public final class DiagnosticDialog extends NotificationDialog {
 		super.configureShell(shell);
 		shell.setText(DiagnosticDialogMessages.DiagnosticDialog_title);
 		shell.setImage(getDefaultImage());
-		shell.setSize(850, 600);
+		shell.setSize(1250, 500);
 	}
 
 	@Override
@@ -56,10 +59,12 @@ public final class DiagnosticDialog extends NotificationDialog {
 
 	@Override
 	protected void buildUI(Composite parent) {
-		viewer = new HereTable<Trouble>(parent, Trouble.class) //
-				.withColumn(DiagnosticDialogMessages.DiagnosticDialog_column_details, 750, Trouble::details)
+		viewer = new HereTable<Trouble>(parent, Trouble.class, this::backdround) //
+				.withColumn(DiagnosticDialogMessages.DiagnosticDialog_column_details, 900, Trouble::details)
 				.withColumn(DiagnosticDialogMessages.DiagnosticDialog_column_code, 50,
 						trouble -> Integer.toString(trouble.code().code()))//
+				.withColumn(DiagnosticDialogMessages.DiagnosticDialog_column_type, 250,
+						trouble -> trouble.code().explanation())//
 				.viewer();
 	}
 
@@ -94,6 +99,15 @@ public final class DiagnosticDialog extends NotificationDialog {
 
 	private Optional<Trouble> selectedTrouble() {
 		return new FirstSelected<Trouble>(viewer.getSelection(), Trouble.class).get();
+	}
+
+	private Color backdround(Object element, int column) {
+		if (column != 1) {
+			return null; // framework driven null
+		}
+		boolean failure = ((Trouble) element).exception().isPresent();
+		boolean severe = diagnostic.severe().contains(element);
+		return colors.get(severe, failure);
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereLabelProvider.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 ArSysOp
+ * Copyright (c) 2018, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
 
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.jface.viewers.ILabelProviderListener;
@@ -25,27 +26,27 @@ class HereLabelProvider<T> implements ITableLabelProvider, ITableColorProvider {
 
 	private final Map<Integer, Function<T, String>> texts;
 	private final Class<T> cls;
+	private final BiFunction<Object, Integer, Color> background;
 
-	HereLabelProvider(Map<Integer, Function<T, String>> texts, Class<T> cls) {
+	HereLabelProvider(Map<Integer, Function<T, String>> texts, Class<T> cls,
+			BiFunction<Object, Integer, Color> background) {
 		this.texts = texts;
 		this.cls = cls;
+		this.background = background;
 	}
 
 	@Override
 	public Color getForeground(Object element, int column) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public Color getBackground(Object element, int column) {
-		// TODO Auto-generated method stub
-		return null;
+		return background.apply(element, column);
 	}
 
 	@Override
 	public Image getColumnImage(Object element, int column) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -69,6 +70,5 @@ class HereLabelProvider<T> implements ITableLabelProvider, ITableColorProvider {
 
 	@Override
 	public void removeListener(ILabelProviderListener listener) {
-		// TODO Auto-generated method stub
 	}
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereTable.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/HereTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 ArSysOp
+ * Copyright (c) 2018, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,12 +14,14 @@ package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
@@ -29,15 +31,21 @@ final class HereTable<T> {
 	private final TableViewer table;
 	private final Class<T> cls;
 	private final Map<Integer, Function<T, String>> texts = new HashMap<>();
+	private final BiFunction<Object, Integer, Color> background;
 
 	HereTable(Composite parent, Class<T> cls) {
+		this(parent, cls, (element, index) -> null); // framework-driven null
+	}
+
+	HereTable(Composite parent, Class<T> cls, BiFunction<Object, Integer, Color> background) {
 		this.table = new TableViewer(parent);
 		this.cls = cls;
+		this.background = background;
 	}
 
 	public TableViewer viewer() {
 		table.setContentProvider(new ArrayContentProvider());
-		table.setLabelProvider(new HereLabelProvider<T>(texts, cls));
+		table.setLabelProvider(new HereLabelProvider<T>(texts, cls, background));
 		table.getTable().setHeaderVisible(true);
 		table.getTable().setLinesVisible(true);
 		table.getTable().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ public class DiagnosticDialogMessages extends NLS {
 	public static String DiagnosticDialog_action_view_failure_tooltip;
 	public static String DiagnosticDialog_column_code;
 	public static String DiagnosticDialog_column_details;
+	public static String DiagnosticDialog_column_type;
 	public static String DiagnosticDialog_description;
 	public static String DiagnosticDialog_error_title;
 	public static String DiagnosticDialog_title;

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 ArSysOp and others
+# Copyright (c) 2020, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ DiagnosticDialog_action_view_failure=&View Error...
 DiagnosticDialog_action_view_failure_tooltip=Selected report mention failure. View the exception.
 DiagnosticDialog_column_code=Code
 DiagnosticDialog_column_details=Error
+DiagnosticDialog_column_type=Type
 DiagnosticDialog_description=Licensing engine experience difficulties during license coverage assessment.
 DiagnosticDialog_error_title=Error
 DiagnosticDialog_title=Licensing failure diagnostic

--- a/features/org.eclipse.passage.lic.e4.ui.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.e4.ui.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.e4.ui.feature"
       label="%featureName"
-      version="0.6.301.qualifier"
+      version="0.6.400.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.e4.ui"
       license-feature="org.eclipse.license"


### PR DESCRIPTION
- _error code_ column background is colored in one of four colors depending on a trouble  severity and exception containment
- _type_ column is added to explain the code in general


![image](https://user-images.githubusercontent.com/3014730/115011661-90c58680-9eb7-11eb-98b7-c30a05de3e1f.png)


Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>