### PR TITLE
572833

### DIFF
--- a/bundles/org.eclipse.passage.lic.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.passage.lic.jface/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.passage.lic.jface" version="2">
+    <resource path="src/org/eclipse/passage/lic/internal/jface/actions/LicensedAction.java" type="org.eclipse.passage.lic.internal.jface.actions.LicensedAction">
+        <filter id="305365105">
+            <message_arguments>
+                <message_argument value="org.eclipse.passage.lic.internal.jface.actions.LicensedAction"/>
+                <message_argument value="org.eclipse.passage.lic.jface_1.2.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.base.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.jface
-Bundle-Version: 1.1.200.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -14,11 +14,11 @@ Require-Bundle: org.eclipse.osgi;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.base;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.equinox;bundle-version="0.4.0"
 Export-Package: org.eclipse.passage.lic.internal.jface;x-friends:="org.eclipse.passage.lic.e4.ui",
+ org.eclipse.passage.lic.internal.jface.actions;x-internal:=true,
  org.eclipse.passage.lic.internal.jface.dialogs.licensing;x-friends:="org.eclipse.passage.lic.e4.ui,org.eclipse.passage.loc.dashboard.ui,org.eclipse.passage.loc.licenses.ui",
  org.eclipse.passage.lic.internal.jface.i18n;x-internal:=true,
  org.eclipse.passage.lic.jface;x-friends:="org.eclipse.passage.loc.workbench",
  org.eclipse.passage.lic.jface.actions,
- org.eclipse.passage.lic.internal.jface.actions,
  org.eclipse.passage.lic.jface.resource;
   x-friends:="org.eclipse.passage.loc.dashboard.ui,
    org.eclipse.passage.loc.workbench,

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
@@ -52,12 +52,12 @@ public final class EquinoxPassageUI implements PassageUI {
 	}
 
 	private <T> ServiceInvocationResult<T> investigate(//
-			Supplier<ServiceInvocationResult<T>> gain, //
-			Function<T, ExaminationCertificate> get, //
+			Supplier<ServiceInvocationResult<T>> service, //
+			Function<T, ExaminationCertificate> certificate, //
 			Predicate<Optional<ExaminationCertificate>> ok) {
-		ServiceInvocationResult<T> result = gain.get();
-		while (exposeAndMayBeEvenFix(result, get, ok)) {
-			result = gain.get();
+		ServiceInvocationResult<T> result = service.get();
+		while (exposeAndMayBeEvenFix(result, certificate, ok)) {
+			result = service.get();
 		}
 		return result;
 	}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/actions/LicensedAction.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/actions/LicensedAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 ArSysOp
+ * Copyright (c) 2018, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,19 +12,10 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jface.actions;
 
-import java.util.Optional;
-
 import org.eclipse.jface.action.Action;
-import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
-import org.eclipse.passage.lic.internal.api.access.GrantLockAttempt;
-import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
-import org.eclipse.passage.lic.internal.jface.EquinoxPassageUI;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 
-/**
- * @since 1.1
- */
 public abstract class LicensedAction extends Action {
 
 	protected abstract void doAction();
@@ -40,23 +31,7 @@ public abstract class LicensedAction extends Action {
 	}
 
 	private void runEverywhere(Display display) {
-		Optional<ServiceInvocationResult<GrantLockAttempt>> response = Optional.empty();
-		try {
-			response = Optional.of(new EquinoxPassageUI(display::getActiveShell).acquireLicense(getId()));
-			if (grantAcquired(response)) {
-				doAction();
-			}
-		} finally {
-			response.flatMap(ServiceInvocationResult::data)//
-					.ifPresent(lock -> new EquinoxPassage().releaseLicense(lock));
-		}
-	}
-
-	private boolean grantAcquired(Optional<ServiceInvocationResult<GrantLockAttempt>> response) {
-		return response//
-				.flatMap(ServiceInvocationResult::data)//
-				.map(GrantLockAttempt::successful)//
-				.orElse(false);
+		new LicensedRunnable(display::getActiveShell, getId(), this::doAction).run();
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/actions/LicensedRunnable.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/actions/LicensedRunnable.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.jface.actions;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.internal.api.access.GrantLockAttempt;
+import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
+import org.eclipse.passage.lic.internal.jface.EquinoxPassageUI;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+public final class LicensedRunnable implements Runnable {
+
+	private final Supplier<Shell> shell;
+	private final String feature;
+	private final Runnable action;
+
+	public LicensedRunnable(Supplier<Shell> shell, String feature, Runnable action) {
+		this.shell = shell;
+		this.feature = feature;
+		this.action = action;
+	}
+
+	public LicensedRunnable(String feature, Runnable action) {
+		this(Display.getDefault()::getActiveShell, feature, action);
+	}
+
+	@Override
+	public void run() {
+		Optional<ServiceInvocationResult<GrantLockAttempt>> response = Optional.empty();
+		try {
+			response = Optional.of(new EquinoxPassageUI(shell).acquireLicense(feature));
+			if (grantAcquired(response)) {
+				action.run();
+			}
+		} finally {
+			response.flatMap(ServiceInvocationResult::data)//
+					.ifPresent(lock -> new EquinoxPassage().releaseLicense(lock));
+		}
+	}
+
+	private boolean grantAcquired(Optional<ServiceInvocationResult<GrantLockAttempt>> response) {
+		return response//
+				.flatMap(ServiceInvocationResult::data)//
+				.map(GrantLockAttempt::successful)//
+				.orElse(false);
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/DiagnosticDialogMessages.properties
@@ -10,9 +10,9 @@
 # Contributors:
 #     ArSysOp - initial API and implementation
 ###############################################################################
-DiagnosticDialog_action_copy=Co&py diagnostic
+DiagnosticDialog_action_copy=Co&py
 DiagnosticDialog_action_copy_tooltip=Copy diagnostic state into clipboard.
-DiagnosticDialog_action_view_failure=&View Error...
+DiagnosticDialog_action_view_failure=&Error...
 DiagnosticDialog_action_view_failure_tooltip=Selected report mention failure. View the exception.
 DiagnosticDialog_column_code=Code
 DiagnosticDialog_column_details=Error

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 ArSysOp and others
+# Copyright (c) 2020, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ ImportLicenseDialog_browse_dialog_title=Import from File
 ImportLicenseDialog_column_evaluation=Evaluation
 ImportLicenseDialog_column_feature=Feature
 ImportLicenseDialog_column_period=Valid
-ImportLicenseDialog_import_title=&Import this license
+ImportLicenseDialog_import_title=&Import
 ImportLicenseDialog_import_tooltip=Copy this license file to a dedicated directory 
 ImportLicenseDialog_io_error=License import failed due to I/O error: %s
 ImportLicenseDialog_lic_read_failed=Failed to read the license pointed

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/LicenseStatusDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/LicenseStatusDialogMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 ArSysOp and others
+# Copyright (c) 2020, 2021 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,9 +14,9 @@ LicenseStatusDialog_column_id=Name
 LicenseStatusDialog_column_status=Verdict
 LicenseStatusDialog_intention_copy=Co&py
 LicenseStatusDialog_intention_copy_tooltip=Copy licensing status and diagnostic data to clip board
-LicenseStatusDialog_intention_import=&Import License...
+LicenseStatusDialog_intention_import=&Import...
 LicenseStatusDialog_intention_import_tooltip=Locate a license to import it to a discoverable location
-LicenseStatusDialog_intention_request=&Request License...
+LicenseStatusDialog_intention_request=&Request...
 LicenseStatusDialog_intention_request_tooltip=Explore your environment state to get input for licensing
 LicenseStatusDialog_intention_diagnose=&Diagnostic
 LicenseStatusDialog_intention_diagnose_tooltip=There is a diagnostic information available, view it in a dedicated dialog

--- a/bundles/org.eclipse.passage.loc.operator.seal/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.operator.seal/META-INF/MANIFEST.MF
@@ -16,8 +16,5 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses.migration;bundle-version="0.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="0.0.0",
  org.apache.logging.log4j;bundle-version="2.8.2"
-Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.product";name="Eclipse Passage Operator";version="2.0.0";provider="Eclispe Passage";level="warning",
- licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.issuepersonal";version="2.0.0";name="Issue Personal License";level="warning";provider="Eclipse Passage",
- licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.issuefloating";version="2.0.0";name="Issue Floating License";level="warning";provider="Eclipse Passage"
 Service-Component: OSGI-INF/*.xml
 

--- a/bundles/org.eclipse.passage.loc.operator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.operator/META-INF/MANIFEST.MF
@@ -11,3 +11,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.passage.loc.workbench;bundle-version="0.0.0",
  org.eclipse.passage.lic.e4.ui;bundle-version="0.0.0"
 Eclipse-BundleShape: dir
+Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.product";name="Eclipse Passage Operator";version="2.0.0";provider="Eclispe Passage";level="warn",
+ licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.issuepersonal";version="2.0.0";name="Issue Personal License";level="error";provider="Eclipse Passage",
+ licensing.feature;licensing.feature="org.eclipse.passage.loc.operator.issuefloating";version="2.0.0";name="Issue Floating License";level="warn";provider="Eclipse Passage"

--- a/bundles/org.eclipse.passage.loc.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.workbench
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.workbench;singleton:=true
-Bundle-Version: 1.0.300.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -29,7 +29,7 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.products.model;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.passage.loc.api;bundle-version="1.0.0",
  org.apache.logging.log4j;bundle-version="2.8.2",
- org.eclipse.passage.lic.e4.ui;bundle-version="1.0.1"
+ org.eclipse.passage.lic.e4.ui;bundle-version="0.0.0"
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
   javax.inject;version="1.0.0"
 Export-Package: org.eclipse.passage.loc.internal.workbench;


### PR DESCRIPTION
- declare Operator's licensing requirements in the branding `loc.operator` bundle instead of `loc.operator.seal`
- extract `LicensedRunnable` for better reuse of grant acquisition and release mechanics