### PR TITLE
Bug 573171  support old way of storing keys in 2.0.0

### DIFF
--- a/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/internal/bc/BcKeyPair.java
+++ b/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/internal/bc/BcKeyPair.java
@@ -97,6 +97,7 @@ final class BcKeyPair {
 	private void persist(PGPKeyRing key, OutputStream target, String error) throws LicensingException {
 		try (ArmoredOutputStream output = new ArmoredOutputStream(new BufferedOutputStream(target))) {
 			key.encode(output);
+			output.flush();
 		} catch (IOException e) {
 			throw new LicensingException(BcMessages.getString(error), e); // $NON-NLS-1$
 		}

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ConvertKeysReport.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ConvertKeysReport.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.loc.internal.products.core;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.passage.loc.internal.products.core.i18n.ConverterMessages;
+
+public final class ConvertKeysReport {
+
+	private final List<Record> records;
+
+	ConvertKeysReport(List<Record> records) {
+		this.records = records;
+	}
+
+	ConvertKeysReport(Record record) {
+		this(Collections.singletonList(record));
+	}
+
+	public List<Record> records() {
+		return records;
+	}
+
+	public static abstract class Record {
+
+		private final Path directory;
+		private final String message;
+
+		protected Record(Path directory, String message) {
+			this.directory = directory;
+			this.message = message;
+		}
+
+		public final Path origin() {
+			return directory;
+		}
+
+		public final String message() {
+			return message;
+		}
+
+	}
+
+	static final class ErrorOnScan extends Record {
+
+		ErrorOnScan(Path directory, Throwable thro) {
+			super(directory, String.format(//
+					ConverterMessages.ConvertKeysReport_e_scan, //
+					thro.getClass().getName(), //
+					thro.getMessage()));
+		}
+
+	}
+
+	static final class NoProduct extends Record {
+
+		NoProduct(Path pub) {
+			super(pub.getParent(), String.format(//
+					ConverterMessages.ConvertKeysReport_e_product, //
+					pub));
+		}
+
+	}
+
+	static final class ScrNotFound extends Record {
+
+		ScrNotFound(Path pub) {
+			super(pub.getParent(), String.format(//
+					ConverterMessages.ConvertKeysReport_e_pair, //
+					pub.getFileName()));
+		}
+
+	}
+
+	static final class ErrorOnKeyReading extends Record {
+
+		ErrorOnKeyReading(Path directory, String key, Throwable thro) {
+			super(directory, String.format(//
+					ConverterMessages.ConvertKeysReport_e_reading, //
+					key, //
+					thro.getClass().getName(), //
+					thro.getMessage()));
+		}
+
+	}
+
+	static final class ErrorOnKeyStoring extends Record {
+
+		ErrorOnKeyStoring(Path directory, String key, Throwable thro) {
+			super(directory, String.format(//
+					ConverterMessages.ConvertKeysReport_e_storing, //
+					key, //
+					thro.getClass().getName(), //
+					thro.getMessage()));
+		}
+
+	}
+
+	static final class Success extends Record {
+
+		Success(Path origin, String name, Optional<String> locator) {
+			super(origin, String.format(//
+					ConverterMessages.ConvertKeysReport_success, //
+					name, //
+					locator.orElse(ConverterMessages.ConvertKeysReport_no_locator)));
+		}
+
+	}
+}

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ConvertedKeys.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ConvertedKeys.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.loc.internal.products.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.base.BaseLicensedProduct;
+import org.eclipse.passage.lic.internal.base.io.LicensingFolder;
+import org.eclipse.passage.lic.internal.base.io.PassageFileExtension;
+import org.eclipse.passage.lic.internal.base.io.UserHomePath;
+import org.eclipse.passage.lic.keys.model.api.KeyPair;
+
+public final class ConvertedKeys {
+
+	private final String ext = new PassageFileExtension.PublicKey().get();
+	private final Consumer<ConvertKeysReport> exposure;
+
+	public ConvertedKeys(Consumer<ConvertKeysReport> exposure) {
+		this.exposure = exposure;
+	}
+
+	public ConvertedKeys() {
+		this(new ToLog());
+	}
+
+	@SuppressWarnings("resource")
+	public void persist() {
+		Path root = new LicensingFolder(new UserHomePath().get()).get();
+		Stream<Path> files;
+		try {
+			files = Files.walk(root); // resource leak never happens
+		} catch (IOException e) {
+			exposure.accept(failedToScan(root, e));
+			return;
+		}
+		exposure.accept(//
+				new ConvertKeysReport(files//
+						.filter(Files::isRegularFile)//
+						.filter(this::isPublicKey)//
+						.map(this::convert)//
+						.collect(Collectors.toList())//
+				));
+	}
+
+	private boolean isPublicKey(Path file) {
+		return file.toString().endsWith(ext);
+	}
+
+	private ConvertKeysReport.Record convert(Path pub) {
+		Optional<LicensedProduct> product = product(pub);
+		if (product.isEmpty()) {
+			return noProduct(pub);
+		}
+		Optional<Path> scr = scr(pub);
+		if (scr.isEmpty()) {
+			return noPair(pub);
+		}
+		KeyPair pair;
+		try {
+			pair = new KeyPairUpgraded(product.get(), pub, scr.get()).get();
+		} catch (IOException e) {
+			return new ConvertKeysReport.ErrorOnKeyReading(pub.getParent(), keyName(pub), e);
+		}
+		Optional<String> locator;
+		try {
+			locator = new KeyPairStored(pair).store();
+		} catch (LicensingException e) {
+			return new ConvertKeysReport.ErrorOnKeyStoring(pub.getParent(), keyName(pub), e);
+		}
+		return new ConvertKeysReport.Success(pub.getParent(), keyName(pub), locator);
+	}
+
+	private String keyName(Path pub) {
+		String path = pub.getFileName().toString();
+		return path.substring(0, path.length() - ext.length());
+	}
+
+	private ConvertKeysReport failedToScan(Path dir, IOException e) {
+		return new ConvertKeysReport(new ConvertKeysReport.ErrorOnScan(dir, e));
+	}
+
+	private ConvertKeysReport.Record noProduct(Path pub) {
+		return new ConvertKeysReport.NoProduct(pub);
+	}
+
+	private ConvertKeysReport.Record noPair(Path pub) {
+		return new ConvertKeysReport.ScrNotFound(pub);
+	}
+
+	private Optional<Path> scr(Path pub) {
+		Path scr = pub.getParent().resolve(keyName(pub) + new PassageFileExtension.PrivateKey().get());
+		return Files.exists(scr) && Files.isRegularFile(scr) //
+				? Optional.of(scr) //
+				: Optional.empty();
+	}
+
+	private Optional<LicensedProduct> product(Path pub) {
+		String name = keyName(pub);
+		int separator = name.lastIndexOf('_');
+		if (separator < 0 || separator >= name.length()) {
+			return productFromFolders(pub);
+		}
+		return Optional.of(new BaseLicensedProduct(//
+				name.substring(0, separator), //
+				name.substring(separator + 1)));
+	}
+
+	private Optional<LicensedProduct> productFromFolders(Path pub) {
+		if (pub.getParent().getParent() == null) { // nio null
+			return Optional.empty();
+		}
+		return Optional.of(new BaseLicensedProduct(//
+				pub.getParent().getParent().getFileName().toString(), //
+				pub.getParent().getFileName().toString()));
+	}
+
+	static final class ToLog implements Consumer<ConvertKeysReport> {
+
+		private final Logger log = LogManager.getLogger(ConvertedKeys.class);
+
+		@Override
+		public void accept(ConvertKeysReport report) {
+			report.records().forEach(this::print);
+		}
+
+		private void print(ConvertKeysReport.Record record) {
+			log.info(String.format(//
+					"%s || %s", //$NON-NLS-1$
+					record.origin().toAbsolutePath(), //
+					record.message()));
+		}
+
+	}
+}

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/KeyPairStored.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/KeyPairStored.java
@@ -23,15 +23,15 @@ import org.eclipse.passage.loc.internal.api.workspace.ResourceHandle;
 import org.eclipse.passage.loc.internal.equinox.OperatorGearAware;
 
 @SuppressWarnings("restriction")
-final class KeyPairStored {
+public final class KeyPairStored {
 
 	private final KeyPair pair;
 
-	KeyPairStored(KeyPair pair) {
+	public KeyPairStored(KeyPair pair) {
 		this.pair = pair;
 	}
 
-	public Optional<String> get() throws LicensingException {
+	public Optional<String> store() throws LicensingException {
 		return new OperatorGearAware().withGear(gear -> store(gear.workspace().keys()));
 	}
 

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/KeyPairUpgraded.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/KeyPairUpgraded.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.loc.internal.products.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.passage.lic.internal.api.LicensedProduct;
+import org.eclipse.passage.lic.internal.api.io.EncryptionAlgorithm;
+import org.eclipse.passage.lic.internal.api.io.EncryptionKeySize;
+import org.eclipse.passage.lic.keys.model.api.KeyPair;
+import org.eclipse.passage.lic.keys.model.api.ProductRef;
+import org.eclipse.passage.lic.keys.model.meta.KeysFactory;
+
+public final class KeyPairUpgraded {
+
+	private final LicensedProduct product;
+	private final Path pub;
+	private final Path scr;
+
+	public KeyPairUpgraded(LicensedProduct product, Path pub, Path scr) {
+		this.product = product;
+		this.pub = pub;
+		this.scr = scr;
+	}
+
+	public KeyPair get() throws IOException {
+		KeyPair pair = KeysFactory.eINSTANCE.createKeyPair();
+		pair.setProduct(product());
+		pair.setAlgorithm(new EncryptionAlgorithm.Default().name());
+		pair.setKey(new EncryptionKeySize.Default().size());
+		pair.setPub(fileContent(pub));
+		pair.setScr(fileContent(scr));
+		return pair;
+	}
+
+	private ProductRef product() {
+		ProductRef ref = KeysFactory.eINSTANCE.createProductRef();
+		ref.setIdentifier(product.identifier());
+		ref.setVersion(product.version());
+		return ref;
+	}
+
+	private String fileContent(Path file) throws IOException {
+		return new String(Files.readAllBytes(file));
+	}
+}

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ProductVersionKeys.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/ProductVersionKeys.java
@@ -117,7 +117,7 @@ final class ProductVersionKeys {
 	}
 
 	private Optional<String> store(KeyPair pair) throws LicensingException {
-		return new KeyPairStored(pair).get();
+		return new KeyPairStored(pair).store();
 	}
 
 	private KeyPair generate(ProductVersionDescriptor target, LicensedProduct product, StreamCodec codec)
@@ -125,8 +125,6 @@ final class ProductVersionKeys {
 		try (ByteArrayOutputStream open = new ByteArrayOutputStream();
 				ByteArrayOutputStream secret = new ByteArrayOutputStream()) {
 			codec.createKeyPair(open, secret, product.identifier(), new ProductVersionPassword(target).get());
-			open.flush();
-			secret.flush();
 			return new KeyPairGeneraged(codec, open.toByteArray(), secret.toByteArray()).get();
 		} catch (Exception e) {
 			throw new LicensingException("failed to generate keys", e); //$NON-NLS-1$ // TODO: l10n

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ConverterMessages.java
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ConverterMessages.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.loc.internal.products.core.i18n;
+
+import org.eclipse.osgi.util.NLS;
+
+public class ConverterMessages extends NLS {
+	private static final String BUNDLE_NAME = "org.eclipse.passage.loc.internal.products.core.i18n.ConverterMessages"; //$NON-NLS-1$
+	public static String ConvertKeysReport_e_pair;
+	public static String ConvertKeysReport_e_product;
+	public static String ConvertKeysReport_e_reading;
+	public static String ConvertKeysReport_e_scan;
+	public static String ConvertKeysReport_e_storing;
+	public static String ConvertKeysReport_no_locator;
+	public static String ConvertKeysReport_success;
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, ConverterMessages.class);
+	}
+
+	private ConverterMessages() {
+	}
+}

--- a/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ConverterMessages.properties
+++ b/bundles/org.eclipse.passage.loc.products.core/src/org/eclipse/passage/loc/internal/products/core/i18n/ConverterMessages.properties
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (c) 2021 ArSysOp
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     ArSysOp - initial API and implementation
+###############################################################################
+
+ConvertKeysReport_e_pair=Cancelled: no secret key found for %s
+ConvertKeysReport_e_product=Cancelled: product version cannot be deduced for %s
+ConvertKeysReport_e_reading=Failed: key %s reading failed with %s (%s) 
+ConvertKeysReport_e_scan=Failed: directory scan failed with %s (%s)
+ConvertKeysReport_e_storing=Failed: key pair %s storing failed with %s (%s) 
+ConvertKeysReport_no_locator=no locator
+ConvertKeysReport_success=Converted: %s to %s

--- a/bundles/org.eclipse.passage.loc.products.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.products.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.passage.lic.products.e4.ui;bundle-version="0.5.201",
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
  org.eclipse.passage.loc.products.core;bundle-version="0.0.0";visibility:=reexport,
- org.eclipse.passage.loc.workbench;bundle-version="0.0.0"
+ org.eclipse.passage.loc.workbench;bundle-version="0.0.0",
+ org.eclipse.passage.lic.keys.model;bundle-version="0.0.0",
+ org.apache.logging.log4j;bundle-version="2.8.2"
 Import-Package: javax.inject;version="1.0.0"
 Export-Package: org.eclipse.passage.loc.internal.products.ui;x-friends:="org.eclipse.passage.loc.dashboard.ui",
  org.eclipse.passage.loc.internal.products.ui.i18n;x-internal:=true,

--- a/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/products/ui/handlers/ConvertKeysHandle.java
+++ b/bundles/org.eclipse.passage.loc.products.ui/src/org/eclipse/passage/loc/products/ui/handlers/ConvertKeysHandle.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.loc.products.ui.handlers;
+
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.passage.loc.internal.products.core.ConvertedKeys;
+
+@SuppressWarnings("restriction")
+public final class ConvertKeysHandle {
+
+	@Execute
+	public void convert() {
+		new ConvertedKeys().persist();
+	}
+
+}


### PR DESCRIPTION
- implement (pub+scr) -> (.keys_xmi) conversion in 'ConvertedKeys'
- employ the converter in a ui handle (unplugged)

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>