### PR TITLE
Bug 572650 - upgrade `licenses` domain model

### DIFF
--- a/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
+++ b/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
@@ -12,6 +12,10 @@
       abstract="true" interface="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="ProductRefDescriptor" instanceClassName="org.eclipse.passage.lic.licenses.ProductRefDescriptor"
       abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UserRefDescriptor" instanceClassName="org.eclipse.passage.lic.licenses.UserRefDescriptor"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="CompanyRefDescriptor" instanceClassName="org.eclipse.passage.lic.licenses.CompanyRefDescriptor"
+      abstract="true" interface="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="LicenseRequisitesDescriptor" instanceClassName="org.eclipse.passage.lic.licenses.LicenseRequisitesDescriptor"
       abstract="true" interface="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="PersonalLicenseRequisitesDescriptor"
@@ -44,7 +48,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="licensePlanFeatures" upperBound="-1"
         eType="#//LicensePlanFeatureDescriptor" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="personal" upperBound="-1"
-        eType="#//LicensePack" containment="true"/>
+        eType="#//PersonalLicensePack" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="floating" upperBound="-1"
         eType="#//FloatingLicensePack" containment="true"/>
   </eClassifiers>
@@ -57,23 +61,10 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="licensePlan" lowerBound="1"
         eType="#//LicensePlan"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="LicensePack" eSuperTypes="#//LicensePackDescriptor">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
-        iD="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="issueDate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="userIdentifier" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="userFullName" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="requestIdentifier" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="planIdentifier" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="productIdentifier" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="productVersion" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="licenseGrants" upperBound="-1"
+  <eClassifiers xsi:type="ecore:EClass" name="PersonalLicensePack" eSuperTypes="#//LicensePackDescriptor">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="license" lowerBound="1"
+        eType="#//PersonalLicenseRequisites" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="grants" upperBound="-1"
         eType="#//LicenseGrant" containment="true" eOpposite="#//LicenseGrant/licensePack"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="LicenseGrant" eSuperTypes="#//LicenseGrantDescriptor">
@@ -95,7 +86,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="capacity" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
         defaultValueLiteral="1"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="licensePack" lowerBound="1"
-        eType="#//LicensePack" eOpposite="#//LicensePack/licenseGrants"/>
+        eType="#//PersonalLicensePack" eOpposite="#//PersonalLicensePack/grants"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FloatingLicensePack" eSuperTypes="#//FloatingLicensePackDescriptor">
     <eStructuralFeatures xsi:type="ecore:EReference" name="license" lowerBound="1"
@@ -119,17 +110,28 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="PersonalLicenseRequisites" eSuperTypes="#//LicenseRequisites #//PersonalLicenseRequisitesDescriptor">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="user" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="user" lowerBound="1" eType="#//UserRef"
+        containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FloatingLicenseRequisites" eSuperTypes="#//LicenseRequisites #//FloatingLicenseRequisitesDescriptor">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="company" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="company" lowerBound="1"
+        eType="#//CompanyRef" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ProductRef" eSuperTypes="#//ProductRefDescriptor">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="version" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="UserRef" eSuperTypes="#//UserRefDescriptor">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CompanyRef" eSuperTypes="#//CompanyRefDescriptor">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FloatingServer" eSuperTypes="#//FloatingServerDescriptor">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"

--- a/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
+++ b/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
@@ -132,6 +132,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="info" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FloatingServer" eSuperTypes="#//FloatingServerDescriptor">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="identifier" lowerBound="1"

--- a/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/CompanyRefDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/CompanyRefDescriptor.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.licenses;
+
+/**
+ * @since 2.0
+ */
+public interface CompanyRefDescriptor {
+
+	String getIdentifier();
+
+	String getName();
+
+	String getInfo();
+
+}

--- a/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/UserRefDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/UserRefDescriptor.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.licenses;
+
+/**
+ * @since 2.0
+ */
+public interface UserRefDescriptor {
+
+	String getIdentifier();
+
+	String getName();
+
+}

--- a/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeLicensePlanDescriptor.java
+++ b/tests/org.eclipse.passage.loc.report.core.tests/src/org/eclipse/passage/loc/report/internal/core/FakeLicensePlanDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at


### PR DESCRIPTION
Rearrange Personal License Pack with the use of reference and aggregating constructs. 

The following changes have been done: 
 - LicensePack -> PersonalLicensePack 
 - LicensePack.identifier -> PersonalLicensePack.license.identifier 
 - LicensePack.issueDate -> PersonalLicensePack.license.issueDate
 - LicensePack.planIdentifier ->  PersonalLicensePack.license.plan
 - LicensePack.productIdentifier -> PersonalLicensePack.license.product.identifier
 - LicensePack.productVersion -> PersonalLicensePack.license.product.version
 -  LicensePack.requestIdentifier -> [deleted as it doubles pack.identifier and practically is not used by its own]
 - LicensePack.userIdentifier -> PersonalLicensePack.license.user.identifier
 - LicensePack.userFullName -> PersonalLicensePack.license.user.name
 - LicensePack.licenseGrants -> PersonalLicensePack.grants

Model/Edit code regeneration with all the subsequent fixes are going to happen in the next PR.

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>