### PR TITLE
Bug 573006 cover FLS functions with licensing requirements

### DIFF
--- a/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
@@ -22,5 +22,5 @@ Export-Package: org.eclipse.passage.lbc.internal.base;x-friends:="org.eclipse.pa
  org.eclipse.passage.lbc.internal.base.interaction;x-friends:="org.eclipse.passage.lbc.jetty",
  org.eclipse.passage.lbc.internal.base.mine;x-friends:="org.eclipse.passage.lbc.base.tests,org.eclipse.passage.lic.hc.tests"
 Bundle-ActivationPolicy: lazy
-Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent";version="2.0.0";name="FLS: Concurrent access to a feature grant for several users";level="warn";provider="Eclipse Passage",
+Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent";version="2.0.0";name="FLS: Concurrent access to a feature grant for several users";level="info";provider="Eclipse Passage",
  licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent.full";version="2.0.0";name="FLS: Concurrent access to a feature grant for any amount of users";level="error";provider="Eclipse Passage"

--- a/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
@@ -22,6 +22,5 @@ Export-Package: org.eclipse.passage.lbc.internal.base;x-friends:="org.eclipse.pa
  org.eclipse.passage.lbc.internal.base.interaction;x-friends:="org.eclipse.passage.lbc.jetty",
  org.eclipse.passage.lbc.internal.base.mine;x-friends:="org.eclipse.passage.lbc.base.tests,org.eclipse.passage.lic.hc.tests"
 Bundle-ActivationPolicy: lazy
-Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.lbc.concurrent";version="2.0.0";name="FLS: Concurrent access to a feature grant for several users";level="warn";provider="Eclipse Passage",
- licensing.feature;licensing.feature="org.eclipse.passage.lbc.concurrent.full";version="2.0.0";name="FLS: Concurrent access to a feature grant for any amount of users";level="error";provider="Eclipse Passage"
-
+Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent";version="2.0.0";name="FLS: Concurrent access to a feature grant for several users";level="warn";provider="Eclipse Passage",
+ licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent.full";version="2.0.0";name="FLS: Concurrent access to a feature grant for any amount of users";level="error";provider="Eclipse Passage"

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/AcquiredGrants.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/AcquiredGrants.java
@@ -32,7 +32,7 @@ public final class AcquiredGrants implements Grants {
 
 	public AcquiredGrants(Supplier<Path> base) {
 		this.base = base;
-		storage = new AcquiredGrantsStorage();
+		this.storage = new AcquiredGrantsStorage();
 	}
 
 	public AcquiredGrants() {

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/AcquiredGrantsStorage.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/AcquiredGrantsStorage.java
@@ -50,13 +50,16 @@ final class AcquiredGrantsStorage {
 		}
 	}
 
-	synchronized Optional<GrantAcqisition> acquire(LicensedProduct product, String user, FeatureGrant grant) {
-		Collection<GrantAcqisition> acquisitions = grantLocks(product, grant.getIdentifier());
-		if (acquisitions.size() < grant.getCapacity()) {
-			GrantAcqisition acquistion = acquistion(grant, user);
-			acquisitions.add(acquistion);
-			logAcquisition("acquire", acquistion, product); //$NON-NLS-1$
-			return Optional.of(acquistion);
+	Optional<GrantAcqisition> acquire(LicensedProduct product, String user, FeatureGrant grant) {
+		final int capacity = new ProtectedGrantCapacity(grant).get();
+		synchronized (this) {
+			Collection<GrantAcqisition> acquisitions = grantLocks(product, grant.getIdentifier());
+			if (acquisitions.size() < capacity) {
+				GrantAcqisition acquistion = acquistion(grant, user);
+				acquisitions.add(acquistion);
+				logAcquisition("acquire", acquistion, product); //$NON-NLS-1$
+				return Optional.of(acquistion);
+			}
 		}
 		return Optional.empty();
 	}

--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/ProtectedGrantCapacity.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/acquire/ProtectedGrantCapacity.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lbc.internal.base.acquire;
+
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
+import org.eclipse.passage.lic.licenses.model.api.FeatureGrant;
+
+final class ProtectedGrantCapacity implements Supplier<Integer> {
+
+	private final Logger log = LogManager.getLogger(getClass());
+	private final String feature = "org.eclipse.passage.lbc.acquire.concurrent.full"; //$NON-NLS-1$
+	private final FeatureGrant grant;
+	private final int unlicensed = 4;
+
+	ProtectedGrantCapacity(FeatureGrant grant) {
+		this.grant = grant;
+	}
+
+	@Override
+	public Integer get() {
+		if (grant.getCapacity() < unlicensed) {
+			return grant.getCapacity();
+		}
+		if (new EquinoxPassage().canUse(feature)) {
+			return grant.getCapacity();
+		}
+		reportDiminish();
+		return unlicensed;
+	}
+
+	private void reportDiminish() {
+		log.error(String.format("Due to insufficient license coverage capacity for grant [%s] decreased to %d", //$NON-NLS-1$
+				grant(), //
+				unlicensed));
+	}
+
+	private String grant() {
+		return String.format("feature=%s, license=%s, capacity=%d", //$NON-NLS-1$
+				grant.getFeature().getIdentifier(), //
+				grant.getPack().getLicense().getIdentifier(), //
+				grant.getCapacity());
+	}
+
+}

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/ExtensiveReleaseTest.java
@@ -47,6 +47,8 @@ public final class ExtensiveReleaseTest {
 	private final int noGrants = new NoGrantsAvailable(data.product(), data.feature()).error().code();
 
 	@Test
+	// TODO: add enough test grants to check capacity protection:
+	// TODO: min {grant.capacity, unlicensedCapacity}
 	public void concurrentAcquireAndRelease() throws InterruptedException, ExecutionException {
 		// having
 		int amount = 128;


### PR DESCRIPTION
diminish feature grant capacity to 'unlicensed' amount in case the license coverage does not cover 'aquire.concurrent.full' feature

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>