### PR TITLE
574495 [Passage][FLS] supply 'request license' command 

### DIFF
--- a/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: javax.servlet;bundle-version="0.0.0",
  org.eclipse.jetty.server;bundle-version="0.0.0",
  org.eclipse.jetty.util;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",
- org.eclipse.passage.lic.net;bundle-version="1.0.100",
- org.eclipse.passage.lic.equinox;bundle-version="1.0.201"
+ org.eclipse.passage.lic.net;bundle-version="0.0.0",
+ org.eclipse.passage.lic.equinox;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.internal.jetty;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lbc.jetty,org.eclipse.passage.lac.jetty",
  org.eclipse.passage.lic.internal.jetty.interaction;x-friends:="org.eclipse.passage.lbc.jetty"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Commands.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/Commands.java
@@ -20,7 +20,7 @@ final class Commands {
 	private ServerHandles server;
 
 	void register(BundleContext context, JettyServer jetty, String name) {
-		registerSelfStatus(context);
+		registerSelfLicensingCommands(context);
 		registerServerHandles(context, jetty, name);
 	}
 
@@ -28,8 +28,9 @@ final class Commands {
 		return server;
 	}
 
-	private void registerSelfStatus(BundleContext context) {
+	private void registerSelfLicensingCommands(BundleContext context) {
 		new LicenseStatus().register(context);
+		new LicenseRequest().register(context);
 	}
 
 	private void registerServerHandles(BundleContext context, JettyServer jetty, String name) {

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicenseRequest.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicenseRequest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.jetty.interaction;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.internal.api.LicensingException;
+import org.eclipse.passage.lic.internal.api.inspection.RuntimeEnvironment;
+import org.eclipse.passage.lic.internal.equinox.Environments;
+
+@SuppressWarnings("restriction")
+final class LicenseRequest extends Command {
+
+	public LicenseRequest() {
+		super(new Scope.Self(), new String[] { "licrequest" });//$NON-NLS-1$
+	}
+
+	public void licrequest() {
+		Collection<RuntimeEnvironment> envs = new Environments().get();
+		reportEnvironmentsDiscovered(envs);
+		for (RuntimeEnvironment env : envs) {
+			try {
+				reportAssessment(env);
+			} catch (LicensingException e) {
+				System.err.printf("%s environment assessment failed\n", env.id().identifier()); //$NON-NLS-1$
+				e.printStackTrace();
+			}
+		}
+
+	}
+
+	private void reportEnvironmentsDiscovered(Collection<RuntimeEnvironment> envs) {
+		System.out.printf(
+				"\nTo request a license send demanded particles of these %d environments (%s) assessment to your licensing operator:\n", //$NON-NLS-1$
+				envs.size(), //
+				envs.stream().map(env -> env.id().identifier()).collect(Collectors.joining(", "))); //$NON-NLS-1$
+	}
+
+	private void reportAssessment(RuntimeEnvironment env) throws LicensingException {
+		System.out.printf("\n==== %s ====\n%s\n", env.id().identifier(), env.state()); //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicenseStatus.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicenseStatus.java
@@ -19,10 +19,10 @@ import org.eclipse.passage.lic.internal.equinox.EquinoxPassageLicenseCoverage;
 final class LicenseStatus extends Command {
 
 	public LicenseStatus() {
-		super(new Scope.Self(), new String[] { "status" });//$NON-NLS-1$
+		super(new Scope.Self(), new String[] { "licstatus" });//$NON-NLS-1$
 	}
 
-	public void status() {
+	public void licstatus() {
 		ServiceInvocationResult<ExaminationCertificate> response = new EquinoxPassageLicenseCoverage().assess();
 		if (response.data().isPresent()) {
 			reportCertificate(response.data().get());

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
@@ -32,7 +32,7 @@ final class ServerHandles extends Command {
 						"start", //$NON-NLS-1$
 						"stop", //$NON-NLS-1$
 						"restart", //$NON-NLS-1$
-						"licstatus" //$NON-NLS-1$
+						"state" //$NON-NLS-1$
 				});
 		this.server = server;
 		this.port = new Port(8090);
@@ -63,7 +63,7 @@ final class ServerHandles extends Command {
 		start();
 	}
 
-	public void licstatus() {
+	public void state() {
 		try {
 			System.out.println(server.state());
 		} catch (JettyException e) {

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/ServerHandles.java
@@ -32,7 +32,7 @@ final class ServerHandles extends Command {
 						"start", //$NON-NLS-1$
 						"stop", //$NON-NLS-1$
 						"restart", //$NON-NLS-1$
-						"state" //$NON-NLS-1$
+						"licstatus" //$NON-NLS-1$
 				});
 		this.server = server;
 		this.port = new Port(8090);
@@ -63,7 +63,7 @@ final class ServerHandles extends Command {
 		start();
 	}
 
-	public void state() {
+	public void licstatus() {
 		try {
 			System.out.println(server.state());
 		} catch (JettyException e) {

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -12,14 +12,14 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.target" sequenceNumber="94">
+<target name="org.eclipse.passage.target" sequenceNumber="95">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.20-I-builds/I20210603-0040/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
- `licrequest` command is added to `self` scope to expose all available runtme environments assessment
- `status` command of the `self` scope is renamed to `licstatus` to define a common ground for self licensing scenario commands