### PR TITLE
Bug 574642 - [Passage] prepare releng for 2.0.1 service release

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/features/org.eclipse.passage.demo.feature/feature.xml
+++ b/features/org.eclipse.passage.demo.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.demo.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.lbc.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.execute.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lbc.execute.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.passage.ldc.feature/feature.xml
+++ b/features/org.eclipse.passage.ldc.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.ldc.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.ldc"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.lic.compile.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.compile.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.compile.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.compile.branding"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.lic.define.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.define.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.define.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.define.branding"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.lic.execute.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.execute.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.lic.execute.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.passage.lic.execute.branding"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.passage.loc.operator.feature/feature.xml
+++ b/features/org.eclipse.passage.loc.operator.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.passage.loc.operator.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>./releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/products/org.eclipse.passage.lac.server.product/org.eclipse.passage.lac.server.product
+++ b/products/org.eclipse.passage.lac.server.product/org.eclipse.passage.lac.server.product
@@ -13,7 +13,7 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<product name="Passage Licensing Agent" uid="org.eclipse.passage.lac.server.product" id="org.eclipse.passage.lac.server.product" application="org.eclipse.passage.lac.server.application" version="2.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Passage Licensing Agent" uid="org.eclipse.passage.lac.server.product" id="org.eclipse.passage.lac.server.product" application="org.eclipse.passage.lac.server.application" version="2.0.1.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/products/org.eclipse.passage.lac.server.product/pom.xml
+++ b/products/org.eclipse.passage.lac.server.product/pom.xml
@@ -23,7 +23,7 @@ xmlns="http://maven.apache.org/POM/4.0.0"
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/products/org.eclipse.passage.lbc.fls.product/org.eclipse.passage.lbc.fls.product
+++ b/products/org.eclipse.passage.lbc.fls.product/org.eclipse.passage.lbc.fls.product
@@ -13,7 +13,7 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<product name="Passage Licensing Floating License Server" uid="org.eclipse.passage.lbc.fls.product" id="org.eclipse.passage.lbc.fls.product" application="org.eclipse.passage.lbc.fls.application" version="2.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Passage Licensing Floating License Server" uid="org.eclipse.passage.lbc.fls.product" id="org.eclipse.passage.lbc.fls.product" application="org.eclipse.passage.lbc.fls.application" version="2.0.1.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/products/org.eclipse.passage.lbc.fls.product/pom.xml
+++ b/products/org.eclipse.passage.lbc.fls.product/pom.xml
@@ -23,7 +23,7 @@ xmlns="http://maven.apache.org/POM/4.0.0"
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/products/org.eclipse.passage.loc.operator.product/org.eclipse.passage.loc.operator.product.product
+++ b/products/org.eclipse.passage.loc.operator.product/org.eclipse.passage.loc.operator.product.product
@@ -13,7 +13,7 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<product name="Passage Licensing Operator Workbench" uid="org.eclipse.passage.loc.operator.product" id="org.eclipse.passage.loc.operator.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="2.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Passage Licensing Operator Workbench" uid="org.eclipse.passage.loc.operator.product" id="org.eclipse.passage.loc.operator.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="2.0.1.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/products/org.eclipse.passage.loc.operator.product/pom.xml
+++ b/products/org.eclipse.passage.loc.operator.product/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.demo.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.demo.aggregator/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.demo.repository/pom.xml
+++ b/releng/org.eclipse.passage.demo.repository/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.lac.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lac.aggregator/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	<modules>

--- a/releng/org.eclipse.passage.lac.repository/pom.xml
+++ b/releng/org.eclipse.passage.lac.repository/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.passage.lbc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lbc.aggregator/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	<modules>

--- a/releng/org.eclipse.passage.lbc.repository/pom.xml
+++ b/releng/org.eclipse.passage.lbc.repository/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.passage.ldc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.ldc.aggregator/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	<modules>

--- a/releng/org.eclipse.passage.ldc.repository/pom.xml
+++ b/releng/org.eclipse.passage.ldc.repository/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.passage.lic.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.lic.aggregator/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.lic.repository/pom.xml
+++ b/releng/org.eclipse.passage.lic.repository/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.loc.aggregator/pom.xml
+++ b/releng/org.eclipse.passage.loc.aggregator/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.loc.repository/pom.xml
+++ b/releng/org.eclipse.passage.loc.repository/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -41,7 +41,7 @@
 		<eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>
 		<cbi-snapshots-repo.url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</cbi-snapshots-repo.url>
 
-		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.19/R-4.19-202103031800/</eclipserun-repo>
+		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/</eclipserun-repo>
 		<released.baseline>https://download.eclipse.org/passage/updates/release/1.2.1/</released.baseline>
 		<staging.baseline>https://download.eclipse.org/passage/drops/integration/latest/</staging.baseline>
 

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -42,7 +42,7 @@
 		<cbi-snapshots-repo.url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</cbi-snapshots-repo.url>
 
 		<eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/</eclipserun-repo>
-		<released.baseline>https://download.eclipse.org/passage/updates/release/1.2.1/</released.baseline>
+		<released.baseline>https://download.eclipse.org/passage/updates/release/2.0.0/</released.baseline>
 		<staging.baseline>https://download.eclipse.org/passage/drops/integration/latest/</staging.baseline>
 
 		<compare-version-with-baselines.skip>true</compare-version-with-baselines.skip>

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>org.eclipse.passage</groupId>
 	<artifactId>org.eclipse.passage.parent</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<prerequisites>

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -34,8 +34,7 @@
 
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-passage/passage.git</tycho.scmUrl>
 		<tycho.version>2.3.0</tycho.version>
-		<cbi-plugins.version>1.1.8-SNAPSHOT</cbi-plugins.version>
-		<jarsigner.version>1.1.5</jarsigner.version>
+		<cbi-plugins.version>1.3.1</cbi-plugins.version>
 
 		<tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>
 		<cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
@@ -432,7 +431,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>${jarsigner.version}</version>
+						<version>${cbi-plugins.version}</version>
 						<executions>
 							<execution>
 								<id>sign</id>

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -211,11 +211,11 @@
           <repository
               url="https://download.eclipse.org/passage/updates/release/2.0.0/"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/releases/6.3.4/2020-09/"/>
+              url="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-09/"/>
           <repository
               url="https://download.eclipse.org/tools/gef/updates/legacy/releases/4.0.0_gef-master_1952/"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-09/"/>
+              url="https://download.eclipse.org/tools/orbit/downloads/2021-06"/>
         </repositoryList>
       </targlet>
     </setupTask>

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -187,7 +187,7 @@
         <repositoryList
             name="Passage Latest Released">
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.19/R-4.19-202103031800/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
           <repository
               url="https://download.eclipse.org/ecp/releases/releases_125/1250/"/>
           <repository
@@ -209,13 +209,13 @@
           <repository
               url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.24/"/>
           <repository
-              url="https://download.eclipse.org/passage/updates/release/1.2.1/"/>
+              url="https://download.eclipse.org/passage/updates/release/2.0.0/"/>
           <repository
               url="https://download.eclipse.org/sirius/updates/releases/6.3.4/2020-09/"/>
           <repository
               url="https://download.eclipse.org/tools/gef/updates/legacy/releases/4.0.0_gef-master_1952/"/>
           <repository
-              url="https://download.eclipse.org/tools/orbit/downloads/2021-03"/>
+              url="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-09/"/>
         </repositoryList>
       </targlet>
     </setupTask>
@@ -329,7 +329,7 @@
           <repository
               url="https://download.eclipse.org/cbi/updates/license/"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.20/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
           <repository
               url="https://download.eclipse.org/ecp/releases/releases_125/1250/"/>
           <repository

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
@@ -12,14 +12,15 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.baseline" sequenceNumber="90">
+<target name="org.eclipse.passage.baseline" sequenceNumber="91">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.19/R-4.19-202103031800/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>
@@ -61,14 +62,14 @@
 			<unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/passage/updates/release/1.2.1/"/>
+			<repository location="https://download.eclipse.org/passage/updates/release/2.0.0/"/>
 			<unit id="org.eclipse.passage.lbc.execute.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.passage.ldc.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.passage.lic.define.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.passage.loc.operator.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/sirius/updates/releases/6.3.4/2020-09/"/>
+			<repository location="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-09/"/>
 			<unit id="org.eclipse.sirius.runtime.aql.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sirius.runtime.feature.group" version="0.0.0"/>
 		</location>
@@ -77,32 +78,23 @@
 			<unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-03/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-06/"/>
 			<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
-			<unit id="com.fasterxml.jackson.core.jackson-annotations.source" version="0.0.0"/>
 			<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
-			<unit id="com.fasterxml.jackson.core.jackson-core.source" version="0.0.0"/>
 			<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
-			<unit id="com.fasterxml.jackson.core.jackson-databind.source" version="0.0.0"/>
 			<unit id="com.github.oshi.oshi-core" version="0.0.0"/>
-			<unit id="com.github.oshi.oshi-core.source" version="0.0.0"/>
-			<unit id="com.sun.jna" version="4.5.1.v20190425-1842"/>
-			<unit id="com.sun.jna.source" version="4.5.1.v20190425-1842"/>
+			<unit id="com.sun.jna" version="4.5.1.v20210503-0343"/>
 			<unit id="com.sun.jna.platform" version="4.5.1.v20190425-1842"/>
-			<unit id="com.sun.jna.platform.source" version="4.5.1.v20190425-1842"/>
 			<unit id="javax.activation" version="0.0.0"/>
 			<unit id="javax.mail" version="0.0.0"/>
+			<unit id="javax.servlet" version="0.0.0"/>
 			<unit id="org.apache.commons.csv" version="0.0.0"/>
 			<unit id="org.apache.logging.log4j" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcpg" version="0.0.0"/>
-			<unit id="org.bouncycastle.bcpg.source" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcpkix" version="0.0.0"/>
-			<unit id="org.bouncycastle.bcpkix.source" version="0.0.0"/>
 			<unit id="org.bouncycastle.bcprov" version="0.0.0"/>
-			<unit id="org.bouncycastle.bcprov.source" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.slf4j.api" version="0.0.0"/>
-			<unit id="org.slf4j.api.source" version="0.0.0"/>
 			<unit id="org.slf4j.apis.log4j" version="0.0.0"/>
 		</location>
 	</locations>

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -12,7 +12,7 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.target" sequenceNumber="96">
+<target name="org.eclipse.passage.target" sequenceNumber="95">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -12,7 +12,7 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.target" sequenceNumber="95">
+<target name="org.eclipse.passage.target" sequenceNumber="96">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>

--- a/releng/org.eclipse.passage.target/pom.xml
+++ b/releng/org.eclipse.passage.target/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 


### PR DESCRIPTION
Increment versions for pom manifests
Increment versions for product manifests
Increment versions for container features
Switch jarsigner to 1.3.1
Update baseline to Eclipse Passage 2.0.0