### PR TITLE
Bug 574492 - [Passage][FLS] 2.0.0 release fails on startup

### DIFF
--- a/products/org.eclipse.passage.lbc.fls.product/org.eclipse.passage.lbc.fls.product
+++ b/products/org.eclipse.passage.lbc.fls.product/org.eclipse.passage.lbc.fls.product
@@ -44,13 +44,8 @@
    <features>
       <feature id="org.eclipse.equinox.server.core"/>
       <feature id="org.eclipse.equinox.server.jetty"/>
-      <feature id="org.eclipse.equinox.server.p2"/>
       <feature id="org.eclipse.equinox.core.feature"/>
       <feature id="org.eclipse.equinox.executable"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
-      <feature id="org.eclipse.ecf.core.feature"/>
-      <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.passage.lbc.target.feature" installMode="root"/>
       <feature id="org.eclipse.passage.lbc.execute.feature" installMode="root"/>
       <feature id="org.eclipse.passage.lbc.fls.feature"/>


### PR DESCRIPTION
Remove ECF and P2 from FLS since we don't plan to use it at the moment

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>