### PR TITLE
574598 Dialog-facilitated import of unreadable license fails without reporting

### DIFF
--- a/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.base.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.jface
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.1.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
@@ -21,7 +21,10 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.passage.lic.internal.api.PassageUI;
 import org.eclipse.passage.lic.internal.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.internal.api.access.GrantLockAttempt;
+import org.eclipse.passage.lic.internal.api.diagnostic.Trouble;
+import org.eclipse.passage.lic.internal.api.diagnostic.TroubleCode;
 import org.eclipse.passage.lic.internal.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.internal.base.BaseServiceInvocationResult;
 import org.eclipse.passage.lic.internal.base.restrictions.CertificateWorthAttention;
 import org.eclipse.passage.lic.internal.equinox.EquinoxPassage;
 import org.eclipse.passage.lic.internal.equinox.EquinoxPassageLicenseCoverage;
@@ -56,8 +59,15 @@ public final class EquinoxPassageUI implements PassageUI {
 			Function<T, ExaminationCertificate> certificate, //
 			Predicate<Optional<ExaminationCertificate>> ok) {
 		ServiceInvocationResult<T> result = service.get();
-		while (exposeAndMayBeEvenFix(result, certificate, ok)) {
-			result = service.get();
+		try {
+			while (exposeAndMayBeEvenFix(result, certificate, ok)) {
+				result = service.get();
+			}
+		} catch (Exception e) {
+			return new BaseServiceInvocationResult<>(new Trouble(//
+					new TroubleCode.Of(-1, "Unexpected error"), //$NON-NLS-1$
+					"One of supplied subservices failed", //$NON-NLS-1$
+					e));
 		}
 		return result;
 	}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/EquinoxPassageUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticColors.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticColors.java
@@ -15,6 +15,7 @@ package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
 import java.util.Arrays;
 
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Device;
 
 final class DiagnosticColors {
 
@@ -23,11 +24,11 @@ final class DiagnosticColors {
 	private final Color warning;
 	private final Color info;
 
-	DiagnosticColors() {
-		this.failure = new Color(222, 145, 145);
-		this.error = new Color(233, 175, 215);
-		this.warning = new Color(244, 228, 186);
-		this.info = new Color(178, 201, 166);
+	DiagnosticColors(Device device) {
+		this.failure = new Color(device, 222, 145, 145);
+		this.error = new Color(device, 233, 175, 215);
+		this.warning = new Color(device, 244, 228, 186);
+		this.info = new Color(device, 178, 201, 166);
 	}
 
 	Color get(boolean severe, boolean exception) {

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/DiagnosticDialog.java
@@ -34,7 +34,7 @@ public final class DiagnosticDialog extends NotificationDialog {
 	public DiagnosticDialog(Shell shell, Diagnostic diagnostic) {
 		super(shell);
 		this.diagnostic = diagnostic;
-		this.colors = new DiagnosticColors();
+		this.colors = new DiagnosticColors(shell.getDisplay());
 	}
 
 	@Override


### PR DESCRIPTION
- as first step: cover and properly expose any unexpected failure of any subservice
- use old-fashion `Color` construction