### PR TITLE
Bug 575007 - [Passage][Releng] pom-files for selected LIC bundles

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/pom.xml
+++ b/bundles/org.eclipse.passage.lic.api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.api</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.base/pom.xml
+++ b/bundles/org.eclipse.passage.lic.base/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.base</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.bc/pom.xml
+++ b/bundles/org.eclipse.passage.lic.bc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.bc</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.equinox/pom.xml
+++ b/bundles/org.eclipse.passage.lic.equinox/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.equinox</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.apache.logging.log4j;bundle-version="2.8.2",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
  org.eclipse.passage.lic.hc;bundle-version="0.0.0",
+ org.eclipse.passage.lic.licenses;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.execute

--- a/bundles/org.eclipse.passage.lic.execute/pom.xml
+++ b/bundles/org.eclipse.passage.lic.execute/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.execute</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.hc/pom.xml
+++ b/bundles/org.eclipse.passage.lic.hc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.hc</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.licenses.model/pom.xml
+++ b/bundles/org.eclipse.passage.lic.licenses.model/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.licenses.model</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.licenses/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.licenses/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.licenses
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.licenses
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.1.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.licenses/pom.xml
+++ b/bundles/org.eclipse.passage.lic.licenses/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.licenses</artifactId>
+	<version>2.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>

--- a/bundles/org.eclipse.passage.lic.oshi/pom.xml
+++ b/bundles/org.eclipse.passage.lic.oshi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2018, 2021 ArSysOp and others
+	Copyright (c) 2021 ArSysOp
 
 	This program and the accompanying materials are made available under the
 	terms of the Eclipse Public License 2.0 which is available at
@@ -18,14 +18,14 @@
 >
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>org.eclipse.passage.bundles</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>org.eclipse.passage.lic.oshi</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
-		<artifactId>org.eclipse.passage.parent</artifactId>
+		<artifactId>org.eclipse.passage.bundles</artifactId>
 		<version>2.1.0-SNAPSHOT</version>
-		<relativePath>../releng/org.eclipse.passage.parent</relativePath>
 	</parent>
 
 </project>


### PR DESCRIPTION
bundles/org.eclipse.passage.lic.api/pom.xml
bundles/org.eclipse.passage.lic.base/pom.xml
bundles/org.eclipse.passage.lic.bc/pom.xml
bundles/org.eclipse.passage.lic.equinox/pom.xml
bundles/org.eclipse.passage.lic.execute/pom.xml
bundles/org.eclipse.passage.lic.hc/pom.xml
bundles/org.eclipse.passage.lic.licenses/pom.xml
bundles/org.eclipse.passage.lic.licenses.model/pom.xml
bundles/org.eclipse.passage.lic.oshi/pom.xml

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>