### PR TITLE
Bug 574822 - [Passage] prepare releng for 2.1.0 minor release

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -329,9 +329,9 @@
           <repository
               url="https://download.eclipse.org/cbi/updates/license/"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.21-I-builds/I20210709-0030/"/>
           <repository
-              url="https://download.eclipse.org/ecp/rt/1260a"/>
+              url="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1/"/>
           <repository
               url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.25/"/>
           <repository

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -331,7 +331,7 @@
           <repository
               url="https://download.eclipse.org/eclipse/updates/4.21-I-builds/I20210709-0030/"/>
           <repository
-              url="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1/"/>
+              url="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1a/"/>
           <repository
               url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.25/"/>
           <repository

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -12,20 +12,20 @@
 	Contributors:
 		ArSysOp - initial API and implementation
 -->
-<target name="org.eclipse.passage.target" sequenceNumber="96">
+<target name="org.eclipse.passage.target" sequenceNumber="97">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.20/R-4.20-202106111600/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.21-I-builds/I20210709-0030/"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/ecp/rt/1260a"/>
+			<repository location="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1/"/>
 			<unit id="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emfforms.setup.base" version="0.0.0"/>
 		</location>

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1/"/>
+			<repository location="https://download.eclipse.org/ecp/releases/releases_126/1261_RC1a/"/>
 			<unit id="org.eclipse.emf.ecp.emfforms.runtime.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emfforms.setup.base" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
Try https://download.eclipse.org/ecp/releases/releases_126/1261_RC1/
with Eclipse Platform 4.21 M1

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>