### PR TITLE
Bug 553630 - invent a way to publish general purpose passage bundles

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/requirements/RequirementsToBundle.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/requirements/RequirementsToBundle.java
@@ -30,8 +30,6 @@ import org.eclipse.passage.lic.base.NamedData;
  * <span> new NamedData.Writable&lt;List&lt;Requirement&gt;&gt;(new
  * RequirementsToBundle(requirements)).write(target); </span>
  * 
- * Á
- * 
  * @see NamedData.Writable
  * @since 2.1
  */


### PR DESCRIPTION
fix JavaDoc: remove `unmappable character for encoding UTF8`

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>