### PR TITLE
Bug 575166 License Agreement management: license issuing

### DIFF
--- a/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
+++ b/bundles/org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore
@@ -296,6 +296,12 @@
         <details key="documentation" value="@since 2.0"/>
       </eAnnotations>
     </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="agreements" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="@since 2.1"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="LicenseRequisites" abstract="true" eSuperTypes="#//LicenseRequisitesDescriptor">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/bundles/org.eclipse.passage.lic.licenses.edit/plugin.properties
+++ b/bundles/org.eclipse.passage.lic.licenses.edit/plugin.properties
@@ -208,3 +208,4 @@ _UI_AgreementData_hash_feature = Hash
 _UI_AgreementData_content_feature = Content
 _UI_LicenseRequisites_agreements_feature = Agreements
 _UI_AgreementData_contentType_feature = Content Type
+_UI_LicensePlanFeature_agreements_feature = Agreements

--- a/bundles/org.eclipse.passage.lic.licenses.edit/src-gen/org/eclipse/passage/lic/licenses/edit/providers/LicensePlanFeatureItemProvider.java
+++ b/bundles/org.eclipse.passage.lic.licenses.edit/src-gen/org/eclipse/passage/lic/licenses/edit/providers/LicensePlanFeatureItemProvider.java
@@ -134,6 +134,7 @@ public class LicensePlanFeatureItemProvider extends ItemProviderAdapter implemen
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
 			childrenFeatures.add(LicensesPackage.eINSTANCE.getLicensePlanFeature_Feature());
+			childrenFeatures.add(LicensesPackage.eINSTANCE.getLicensePlanFeature_Agreements());
 		}
 		return childrenFeatures;
 	}
@@ -216,6 +217,7 @@ public class LicensePlanFeatureItemProvider extends ItemProviderAdapter implemen
 			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 			return;
 		case LicensesPackage.LICENSE_PLAN_FEATURE__FEATURE:
+		case LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS:
 			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
 			return;
 		default:
@@ -237,6 +239,8 @@ public class LicensePlanFeatureItemProvider extends ItemProviderAdapter implemen
 
 		newChildDescriptors.add(createChildParameter(LicensesPackage.eINSTANCE.getLicensePlanFeature_Feature(),
 				LicensesFactory.eINSTANCE.createFeatureRef()));
+
+		newChildDescriptors.add(createChildParameter(LicensesPackage.eINSTANCE.getLicensePlanFeature_Agreements(), "")); //$NON-NLS-1$
 	}
 
 	/**

--- a/bundles/org.eclipse.passage.lic.licenses.model/model/licenses.genmodel
+++ b/bundles/org.eclipse.passage.lic.licenses.model/model/licenses.genmodel
@@ -114,6 +114,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference ../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicensePlanFeature/plan"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicensePlanFeature/vivid"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicensePlanFeature/capacity"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference ../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicensePlanFeature/agreements"/>
     </genClasses>
     <genClasses image="false" ecoreClass="../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicenseRequisites">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../org.eclipse.passage.lic.licenses.ecore/model/licenses.ecore#//LicenseRequisites/identifier"/>

--- a/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/api/LicensePlanFeature.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/api/LicensePlanFeature.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.licenses.model.api;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 
 import org.eclipse.passage.lic.licenses.LicensePlanFeatureDescriptor;
@@ -29,6 +30,7 @@ import org.eclipse.passage.lic.licenses.LicensePlanFeatureDescriptor;
  *   <li>{@link org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getPlan <em>Plan</em>}</li>
  *   <li>{@link org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getVivid <em>Vivid</em>}</li>
  *   <li>{@link org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getCapacity <em>Capacity</em>}</li>
+ *   <li>{@link org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getAgreements <em>Agreements</em>}</li>
  * </ul>
  *
  * @see org.eclipse.passage.lic.licenses.model.meta.LicensesPackage#getLicensePlanFeature()
@@ -145,5 +147,21 @@ public interface LicensePlanFeature extends EObject, LicensePlanFeatureDescripto
 	 * @generated
 	 */
 	void setCapacity(int value);
+
+	/**
+	 * Returns the value of the '<em><b>Agreements</b></em>' attribute list.
+	 * The list contents are of type {@link java.lang.String}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * @since 2.1
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Agreements</em>' attribute list.
+	 * @see org.eclipse.passage.lic.licenses.model.meta.LicensesPackage#getLicensePlanFeature_Agreements()
+	 * @model
+	 * @generated
+	 */
+	@Override
+	EList<String> getAgreements();
 
 } // LicensePlanFeature

--- a/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/impl/LicensePlanFeatureImpl.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/impl/LicensePlanFeatureImpl.java
@@ -12,15 +12,18 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.licenses.model.impl;
 
+import java.util.Collection;
 import org.eclipse.emf.common.notify.Notification;
 
 import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.passage.lic.licenses.model.api.FeatureRef;
 import org.eclipse.passage.lic.licenses.model.api.LicensePlan;
@@ -40,6 +43,7 @@ import org.eclipse.passage.lic.licenses.model.meta.LicensesPackage;
  *   <li>{@link org.eclipse.passage.lic.licenses.model.impl.LicensePlanFeatureImpl#getPlan <em>Plan</em>}</li>
  *   <li>{@link org.eclipse.passage.lic.licenses.model.impl.LicensePlanFeatureImpl#getVivid <em>Vivid</em>}</li>
  *   <li>{@link org.eclipse.passage.lic.licenses.model.impl.LicensePlanFeatureImpl#getCapacity <em>Capacity</em>}</li>
+ *   <li>{@link org.eclipse.passage.lic.licenses.model.impl.LicensePlanFeatureImpl#getAgreements <em>Agreements</em>}</li>
  * </ul>
  *
  * @generated
@@ -96,6 +100,17 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 	 * @ordered
 	 */
 	private int capacity = CAPACITY_EDEFAULT;
+
+	/**
+	 * The cached value of the '{@link #getAgreements() <em>Agreements</em>}' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAgreements()
+	 * @since 2.1
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<String> agreements;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -283,6 +298,21 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @since 2.1
+	 * @generated
+	 */
+	@Override
+	public EList<String> getAgreements() {
+		if (agreements == null) {
+			agreements = new EDataTypeUniqueEList<String>(String.class, this,
+					LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS);
+		}
+		return agreements;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -347,6 +377,8 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 			return getVivid();
 		case LicensesPackage.LICENSE_PLAN_FEATURE__CAPACITY:
 			return getCapacity();
+		case LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS:
+			return getAgreements();
 		default:
 			return super.eGet(featureID, resolve, coreType);
 		}
@@ -357,6 +389,7 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
@@ -371,6 +404,10 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 			return;
 		case LicensesPackage.LICENSE_PLAN_FEATURE__CAPACITY:
 			setCapacity((Integer) newValue);
+			return;
+		case LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS:
+			getAgreements().clear();
+			getAgreements().addAll((Collection<? extends String>) newValue);
 			return;
 		default:
 			super.eSet(featureID, newValue);
@@ -398,6 +435,9 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 		case LicensesPackage.LICENSE_PLAN_FEATURE__CAPACITY:
 			setCapacity(CAPACITY_EDEFAULT);
 			return;
+		case LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS:
+			getAgreements().clear();
+			return;
 		default:
 			super.eUnset(featureID);
 			return;
@@ -420,6 +460,8 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 			return vivid != VIVID_EDEFAULT;
 		case LicensesPackage.LICENSE_PLAN_FEATURE__CAPACITY:
 			return capacity != CAPACITY_EDEFAULT;
+		case LicensesPackage.LICENSE_PLAN_FEATURE__AGREEMENTS:
+			return agreements != null && !agreements.isEmpty();
 		default:
 			return super.eIsSet(featureID);
 		}
@@ -440,6 +482,8 @@ public class LicensePlanFeatureImpl extends MinimalEObjectImpl.Container impleme
 		result.append(vivid);
 		result.append(", capacity: "); //$NON-NLS-1$
 		result.append(capacity);
+		result.append(", agreements: "); //$NON-NLS-1$
+		result.append(agreements);
 		result.append(')');
 		return result.toString();
 	}

--- a/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/impl/LicensesPackageImpl.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/impl/LicensesPackageImpl.java
@@ -972,6 +972,17 @@ public class LicensesPackageImpl extends EPackageImpl implements LicensesPackage
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @since 2.1
+	 * @generated
+	 */
+	@Override
+	public EAttribute getLicensePlanFeature_Agreements() {
+		return (EAttribute) licensePlanFeatureEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @since 2.0
 	 * @generated
 	 */
@@ -2052,6 +2063,7 @@ public class LicensesPackageImpl extends EPackageImpl implements LicensesPackage
 		createEReference(licensePlanFeatureEClass, LICENSE_PLAN_FEATURE__PLAN);
 		createEAttribute(licensePlanFeatureEClass, LICENSE_PLAN_FEATURE__VIVID);
 		createEAttribute(licensePlanFeatureEClass, LICENSE_PLAN_FEATURE__CAPACITY);
+		createEAttribute(licensePlanFeatureEClass, LICENSE_PLAN_FEATURE__AGREEMENTS);
 
 		licenseRequisitesEClass = createEClass(LICENSE_REQUISITES);
 		createEAttribute(licenseRequisitesEClass, LICENSE_REQUISITES__IDENTIFIER);
@@ -2407,6 +2419,9 @@ public class LicensesPackageImpl extends EPackageImpl implements LicensesPackage
 				LicensePlanFeature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
 		initEAttribute(getLicensePlanFeature_Capacity(), ecorePackage.getEInt(), "capacity", null, 1, 1, //$NON-NLS-1$
+				LicensePlanFeature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+				!IS_DERIVED, IS_ORDERED);
+		initEAttribute(getLicensePlanFeature_Agreements(), ecorePackage.getEString(), "agreements", null, 0, -1, //$NON-NLS-1$
 				LicensePlanFeature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
 

--- a/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/meta/LicensesPackage.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src-gen/org/eclipse/passage/lic/licenses/model/meta/LicensesPackage.java
@@ -1780,13 +1780,23 @@ public interface LicensesPackage extends EPackage {
 	int LICENSE_PLAN_FEATURE__CAPACITY = LICENSE_PLAN_FEATURE_DESCRIPTOR_FEATURE_COUNT + 3;
 
 	/**
+	 * The feature id for the '<em><b>Agreements</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.1
+	 * @generated
+	 * @ordered
+	 */
+	int LICENSE_PLAN_FEATURE__AGREEMENTS = LICENSE_PLAN_FEATURE_DESCRIPTOR_FEATURE_COUNT + 4;
+
+	/**
 	 * The number of structural features of the '<em>License Plan Feature</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int LICENSE_PLAN_FEATURE_FEATURE_COUNT = LICENSE_PLAN_FEATURE_DESCRIPTOR_FEATURE_COUNT + 4;
+	int LICENSE_PLAN_FEATURE_FEATURE_COUNT = LICENSE_PLAN_FEATURE_DESCRIPTOR_FEATURE_COUNT + 5;
 
 	/**
 	 * The number of operations of the '<em>License Plan Feature</em>' class.
@@ -3435,6 +3445,18 @@ public interface LicensesPackage extends EPackage {
 	 * @generated
 	 */
 	EAttribute getLicensePlanFeature_Capacity();
+
+	/**
+	 * Returns the meta object for the attribute list '{@link org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getAgreements <em>Agreements</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute list '<em>Agreements</em>'.
+	 * @see org.eclipse.passage.lic.licenses.model.api.LicensePlanFeature#getAgreements()
+	 * @see #getLicensePlanFeature()
+	 * @since 2.1
+	 * @generated
+	 */
+	EAttribute getLicensePlanFeature_Agreements();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.passage.lic.licenses.model.api.PersonalFeatureGrant <em>Personal Feature Grant</em>}'.

--- a/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/LicensePlanFeatureDescriptor.java
+++ b/bundles/org.eclipse.passage.lic.licenses/src/org/eclipse/passage/lic/licenses/LicensePlanFeatureDescriptor.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.licenses;
 
+import java.util.List;
+
 /**
  * <p>
  * A <code>"License Pack Feature"</code> is a unit inside a
@@ -28,6 +30,11 @@ public interface LicensePlanFeatureDescriptor {
 	 * @since 2.0
 	 */
 	FeatureRefDescriptor getFeature();
+
+	/**
+	 * @since 2.1
+	 */
+	List<String> getAgreements();
 
 	/**
 	 * @since 2.0


### PR DESCRIPTION
`LicensePlanFeature` gets list of `agreements` identifiers: despite it is made of a FeatureVersion, it keeps niether a reference to it not a precise version. 

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>