### PR TITLE
Bug 575166 License Agreement management: license issuing

### DIFF
--- a/bundles/org.eclipse.passage.loc.api/src/org/eclipse/passage/loc/internal/api/OperatorGear.java
+++ b/bundles/org.eclipse.passage.loc.api/src/org/eclipse/passage/loc/internal/api/OperatorGear.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.eclipse.passage.lic.api.Gear;
 import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.inspection.RuntimeEnvironmentRegistry;
+import org.eclipse.passage.lic.api.io.HashesRegistry;
 import org.eclipse.passage.lic.api.io.StreamCodec;
 import org.eclipse.passage.loc.internal.api.workspace.OperatorWorkspace;
 
@@ -25,6 +26,8 @@ public interface OperatorGear extends Gear {
 	Optional<StreamCodec> codec(LicensedProduct product);
 
 	RuntimeEnvironmentRegistry environments();
+
+	HashesRegistry hashes();
 
 	OperatorWorkspace workspace();
 

--- a/bundles/org.eclipse.passage.loc.operator.gear/src/org/eclipse/passage/loc/operator/internal/gear/DefaultGear.java
+++ b/bundles/org.eclipse.passage.loc.operator.gear/src/org/eclipse/passage/loc/operator/internal/gear/DefaultGear.java
@@ -20,8 +20,12 @@ import org.eclipse.passage.lic.api.EvaluationType;
 import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.inspection.RuntimeEnvironment;
 import org.eclipse.passage.lic.api.inspection.RuntimeEnvironmentRegistry;
+import org.eclipse.passage.lic.api.io.Hashes;
+import org.eclipse.passage.lic.api.io.HashesRegistry;
 import org.eclipse.passage.lic.api.io.StreamCodec;
 import org.eclipse.passage.lic.api.registry.Registry;
+import org.eclipse.passage.lic.api.registry.StringServiceId;
+import org.eclipse.passage.lic.base.io.MD5Hashes;
 import org.eclipse.passage.lic.base.registry.ReadOnlyRegistry;
 import org.eclipse.passage.lic.bc.BcStreamCodec;
 import org.eclipse.passage.lic.oshi.HardwareEnvironment;
@@ -35,12 +39,14 @@ final class DefaultGear implements OperatorGear {
 	final static DefaultGear gear = new DefaultGear();
 
 	private final Registry<EvaluationType, RuntimeEnvironment> environments;
+	private final Registry<StringServiceId, Hashes> hashes;
 	private final OperatorWorkspace workspace;
 
 	private DefaultGear() {
 		this.environments = new ReadOnlyRegistry<>(Arrays.asList(//
 				new HardwareEnvironment() //
 		));
+		this.hashes = new ReadOnlyRegistry<>(new MD5Hashes());
 		this.workspace = new CollectiveWorkspace();
 	}
 
@@ -58,6 +64,11 @@ final class DefaultGear implements OperatorGear {
 	@Override
 	public OperatorWorkspace workspace() {
 		return workspace;
+	}
+
+	@Override
+	public HashesRegistry hashes() {
+		return () -> hashes;
 	}
 
 }


### PR DESCRIPTION
Hash calculator service is needed for the agreements packing, supply those through `OperatorGear`

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>