### PR TITLE
Bug 575182 protect condition mining with Agreements consistency check

### DIFF
--- a/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/ReassemblingMiningTool.java
+++ b/bundles/org.eclipse.passage.lbc.base/src/org/eclipse/passage/lbc/internal/base/mine/ReassemblingMiningTool.java
@@ -39,11 +39,13 @@ import org.eclipse.passage.lic.base.conditions.mining.ArmedMiningTool;
 import org.eclipse.passage.lic.base.diagnostic.BaseDiagnostic;
 import org.eclipse.passage.lic.base.diagnostic.code.ServiceFailedOnMorsel;
 import org.eclipse.passage.lic.internal.emf.EObjectFromBytes;
+import org.eclipse.passage.lic.internal.licenses.convert.PAgreements;
 import org.eclipse.passage.lic.licenses.model.api.FloatingLicensePack;
 import org.eclipse.passage.lic.licenses.model.api.ProductRef;
 import org.eclipse.passage.lic.licenses.model.meta.LicensesPackage;
 import org.eclipse.passage.lic.licenses.model.util.LicensesResourceImpl;
 
+@SuppressWarnings("restriction")
 final class ReassemblingMiningTool extends ArmedMiningTool {
 
 	private final String user;
@@ -83,7 +85,8 @@ final class ReassemblingMiningTool extends ArmedMiningTool {
 			return noConditions(license);
 		}
 		Collection<Condition> conditions = new AssembledConditions(pack).forUser(user);
-		return new BaseConditionPack(origin(license), conditions);
+		return new BaseConditionPack(origin(license), conditions,
+				new PAgreements(pack.getLicense().getAgreements()).get());
 	}
 
 	private boolean productFits(ProductRef ref) {
@@ -102,6 +105,7 @@ final class ReassemblingMiningTool extends ArmedMiningTool {
 	private BaseConditionPack noConditions(Path license) {
 		return new BaseConditionPack(//
 				origin(license), //
+				Collections.emptyList(), //
 				Collections.emptyList());
 	}
 

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/agreements/GlobalAgreement.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/agreements/GlobalAgreement.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.agreements;
+
+public interface GlobalAgreement {
+
+	String identifier();
+
+	String name();
+
+	String file();
+
+	String hashAlgo();
+
+	byte[] hash();
+
+	byte[] content();
+}

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionPack.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/ConditionPack.java
@@ -14,6 +14,8 @@ package org.eclipse.passage.lic.api.conditions;
 
 import java.util.Collection;
 
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
+
 /**
  * <p>
  * Set of conditions of a common origin.
@@ -32,5 +34,7 @@ public interface ConditionPack {
 	ConditionOrigin origin();
 
 	Collection<Condition> conditions();
+
+	Collection<GlobalAgreement> agreements();
 
 }

--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/mining/ConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/mining/ConditionTransport.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.IssuerSignature;
 import org.eclipse.passage.lic.api.registry.Service;
@@ -39,23 +40,30 @@ public interface ConditionTransport extends Service<ContentType> {
 	public static final class Data {
 
 		private final Collection<Condition> conditions;
+		private final Collection<GlobalAgreement> agreements;
 		private final Optional<IssuerSignature> signature;
 
 		public Data() {
-			this(Collections.emptyList(), Optional.empty());
+			this(Collections.emptyList(), Collections.emptyList(), Optional.empty());
 		}
 
 		public Data(Collection<Condition> conditions) {
-			this(conditions, Optional.empty());
+			this(conditions, Collections.emptyList(), Optional.empty());
 		}
 
-		public Data(Collection<Condition> conditions, Optional<IssuerSignature> signature) {
+		public Data(Collection<Condition> conditions, Collection<GlobalAgreement> agreements,
+				Optional<IssuerSignature> signature) {
 			this.conditions = conditions;
 			this.signature = signature;
+			this.agreements = agreements;
 		}
 
 		public Collection<Condition> conditions() {
 			return conditions;
+		}
+
+		public Collection<GlobalAgreement> agreements() {
+			return agreements;
 		}
 
 		public Optional<IssuerSignature> signature() {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/BaseGlobalAgreement.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/BaseGlobalAgreement.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.base.agreements;
+
+import java.util.Objects;
+
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
+
+public final class BaseGlobalAgreement implements GlobalAgreement {
+	private final String identifier;
+	private final String name;
+	private final String file;
+	private final String hashAlgo;
+	private final byte[] hash;
+	private final byte[] content;
+
+	public BaseGlobalAgreement(String identifier, String name, String file, String hashAlgo, byte[] hash,
+			byte[] content) {
+		Objects.requireNonNull(identifier, "BaseGlobalAgreement::identifier"); //$NON-NLS-1$
+		Objects.requireNonNull(name, "BaseGlobalAgreement::name"); //$NON-NLS-1$
+		Objects.requireNonNull(file, "BaseGlobalAgreement::file"); //$NON-NLS-1$
+		Objects.requireNonNull(hashAlgo, "BaseGlobalAgreement::hashAlgo"); //$NON-NLS-1$
+		Objects.requireNonNull(hash, "BaseGlobalAgreement::hash"); //$NON-NLS-1$
+		Objects.requireNonNull(content, "BaseGlobalAgreement::content"); //$NON-NLS-1$
+		this.identifier = identifier;
+		this.name = name;
+		this.file = file;
+		this.hashAlgo = hashAlgo;
+		this.hash = hash;
+		this.content = content;
+	}
+
+	@Override
+	public String identifier() {
+		return identifier;
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public String file() {
+		return file;
+	}
+
+	@Override
+	public String hashAlgo() {
+		return hashAlgo;
+	}
+
+	@Override
+	public byte[] hash() {
+		return hash;
+	}
+
+	@Override
+	public byte[] content() {
+		return content;
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/BaseConditionPack.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/BaseConditionPack.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.ConditionOrigin;
 import org.eclipse.passage.lic.api.conditions.ConditionPack;
@@ -27,12 +28,16 @@ public final class BaseConditionPack implements ConditionPack {
 
 	private final ConditionOrigin origin;
 	private final Collection<Condition> conditions;
+	private final Collection<GlobalAgreement> agreements;
 
-	public BaseConditionPack(ConditionOrigin origin, Collection<Condition> conditions) {
+	public BaseConditionPack(ConditionOrigin origin, Collection<Condition> conditions,
+			Collection<GlobalAgreement> agreements) {
 		Objects.requireNonNull(origin, "BaseConditionPack::origin"); //$NON-NLS-1$
 		Objects.requireNonNull(conditions, "BaseConditionPack::conditions"); //$NON-NLS-1$
+		Objects.requireNonNull(agreements, "BaseConditionPack::agreements"); //$NON-NLS-1$
 		this.origin = origin;
 		this.conditions = new ArrayList<>(conditions);
+		this.agreements = new ArrayList<>(agreements);
 	}
 
 	@Override
@@ -43,6 +48,11 @@ public final class BaseConditionPack implements ConditionPack {
 	@Override
 	public Collection<Condition> conditions() {
 		return conditions;
+	}
+
+	@Override
+	public Collection<GlobalAgreement> agreements() {
+		return agreements;
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/FeatureConditionPack.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/FeatureConditionPack.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.ConditionOrigin;
 import org.eclipse.passage.lic.api.conditions.ConditionPack;
@@ -49,6 +50,11 @@ public final class FeatureConditionPack implements ConditionPack {
 		return parent.conditions().stream()//
 				.filter(condition -> condition.feature().equals(feature))//
 				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public Collection<GlobalAgreement> agreements() {
+		return parent.agreements(); // these are global (external for the product) and mandatory for each feature
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/PersonalLicenseMiningTool.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/PersonalLicenseMiningTool.java
@@ -61,7 +61,8 @@ final class PersonalLicenseMiningTool extends ArmedMiningTool {
 					Collections.singleton(//
 							new BaseConditionPack(//
 									new BaseConditionOrigin(miner, source(source), data.signature()), //
-									data.conditions())//
+									data.conditions(), //
+									data.agreements())//
 					));
 		} catch (IOException | LicensingException e) {
 			return new BaseServiceInvocationResult<>(//

--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/remote/impl/mine/DecryptedConditions.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/remote/impl/mine/DecryptedConditions.java
@@ -56,7 +56,8 @@ final class DecryptedConditions implements ResponseHandler<Collection<ConditionP
 			return Collections.singleton(//
 					new BaseConditionPack(//
 							new BaseConditionOrigin(target, source(), data.signature()), //
-							data.conditions() //
+							data.conditions(), //
+							data.agreements()//
 					));
 		} catch (IOException e) {
 			throw new LicensingException(MineMessages.DecryptedConditions_reading_error, e);

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PAgreement.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PAgreement.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.licenses.convert;
+
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
+import org.eclipse.passage.lic.base.agreements.BaseGlobalAgreement;
+import org.eclipse.passage.lic.licenses.model.api.AgreementData;
+
+@SuppressWarnings("restriction")
+public final class PAgreement implements Supplier<GlobalAgreement> {
+
+	private final AgreementData agreement;
+
+	public PAgreement(AgreementData agreement) {
+		this.agreement = agreement;
+	}
+
+	@Override
+	public GlobalAgreement get() {
+		return new BaseGlobalAgreement(//
+				agreement.getIdentifier(), //
+				agreement.getName(), //
+				agreement.getFile(), //
+				agreement.getHashAlgo(), //
+				agreement.getHash(), //
+				agreement.getContent());
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PAgreements.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PAgreements.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.licenses.convert;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
+import org.eclipse.passage.lic.licenses.model.api.AgreementData;
+
+@SuppressWarnings("restriction")
+public final class PAgreements implements Supplier<Collection<GlobalAgreement>> {
+
+	private final Collection<AgreementData> agreements;
+
+	public PAgreements(Collection<AgreementData> agreements) {
+		this.agreements = agreements;
+	}
+
+	@Override
+	public Collection<GlobalAgreement> get() {
+		return agreements.stream()//
+				.map(PAgreement::new)//
+				.map(PAgreement::get)//
+				.collect(Collectors.toList());
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/toberemoved/BaseXmiConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/toberemoved/BaseXmiConditionTransport.java
@@ -27,10 +27,12 @@ import java.util.stream.Collectors;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.passage.lic.api.EvaluationType;
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.IssuerSignature;
 import org.eclipse.passage.lic.api.conditions.mining.ConditionTransport;
 import org.eclipse.passage.lic.api.conditions.mining.ContentType;
+import org.eclipse.passage.lic.base.agreements.BaseGlobalAgreement;
 import org.eclipse.passage.lic.base.conditions.BaseCondition;
 import org.eclipse.passage.lic.base.conditions.BaseEvaluationInstructions;
 import org.eclipse.passage.lic.base.conditions.BaseValidityPeriodClosed;
@@ -38,11 +40,13 @@ import org.eclipse.passage.lic.internal.licenses.convert.PIssuerSignature;
 import org.eclipse.passage.lic.internal.licenses.convert.PVersionMatch;
 import org.eclipse.passage.lic.internal.licenses.model.migration.LicensesResourceHandler;
 import org.eclipse.passage.lic.licenses.ValidityPeriodClosedDescriptor;
+import org.eclipse.passage.lic.licenses.model.api.AgreementData;
 import org.eclipse.passage.lic.licenses.model.api.PersonalFeatureGrant;
 import org.eclipse.passage.lic.licenses.model.api.PersonalLicensePack;
 import org.eclipse.passage.lic.licenses.model.meta.LicensesPackage;
 import org.eclipse.passage.lic.licenses.model.util.LicensesResourceImpl;
 
+@SuppressWarnings("restriction")
 abstract class BaseXmiConditionTransport implements ConditionTransport {
 
 	private final ContentType type = new ContentType.Xml();
@@ -74,7 +78,23 @@ abstract class BaseXmiConditionTransport implements ConditionTransport {
 		if (!license.isPresent()) {
 			return new Data();
 		}
-		return new Data(conditions(license.get()), signature(license.get()));
+		return new Data(conditions(license.get()), agreements(license.get()), signature(license.get()));
+	}
+
+	private Collection<GlobalAgreement> agreements(PersonalLicensePack pack) {
+		return pack.getLicense().getAgreements().stream()//
+				.map(this::agreement)//
+				.collect(Collectors.toList());
+	}
+
+	private GlobalAgreement agreement(AgreementData agreement) {
+		return new BaseGlobalAgreement(//
+				agreement.getIdentifier(), //
+				agreement.getName(), //
+				agreement.getFile(), //
+				agreement.getHashAlgo(), //
+				agreement.getHash(), //
+				agreement.getContent());
 	}
 
 	private Optional<IssuerSignature> signature(PersonalLicensePack pack) {

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/toberemoved/BaseXmiConditionTransport.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/toberemoved/BaseXmiConditionTransport.java
@@ -32,15 +32,14 @@ import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.IssuerSignature;
 import org.eclipse.passage.lic.api.conditions.mining.ConditionTransport;
 import org.eclipse.passage.lic.api.conditions.mining.ContentType;
-import org.eclipse.passage.lic.base.agreements.BaseGlobalAgreement;
 import org.eclipse.passage.lic.base.conditions.BaseCondition;
 import org.eclipse.passage.lic.base.conditions.BaseEvaluationInstructions;
 import org.eclipse.passage.lic.base.conditions.BaseValidityPeriodClosed;
+import org.eclipse.passage.lic.internal.licenses.convert.PAgreements;
 import org.eclipse.passage.lic.internal.licenses.convert.PIssuerSignature;
 import org.eclipse.passage.lic.internal.licenses.convert.PVersionMatch;
 import org.eclipse.passage.lic.internal.licenses.model.migration.LicensesResourceHandler;
 import org.eclipse.passage.lic.licenses.ValidityPeriodClosedDescriptor;
-import org.eclipse.passage.lic.licenses.model.api.AgreementData;
 import org.eclipse.passage.lic.licenses.model.api.PersonalFeatureGrant;
 import org.eclipse.passage.lic.licenses.model.api.PersonalLicensePack;
 import org.eclipse.passage.lic.licenses.model.meta.LicensesPackage;
@@ -82,19 +81,7 @@ abstract class BaseXmiConditionTransport implements ConditionTransport {
 	}
 
 	private Collection<GlobalAgreement> agreements(PersonalLicensePack pack) {
-		return pack.getLicense().getAgreements().stream()//
-				.map(this::agreement)//
-				.collect(Collectors.toList());
-	}
-
-	private GlobalAgreement agreement(AgreementData agreement) {
-		return new BaseGlobalAgreement(//
-				agreement.getIdentifier(), //
-				agreement.getName(), //
-				agreement.getFile(), //
-				agreement.getHashAlgo(), //
-				agreement.getHash(), //
-				agreement.getContent());
+		return new PAgreements(pack.getLicense().getAgreements()).get();
 	}
 
 	private Optional<IssuerSignature> signature(PersonalLicensePack pack) {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/FakeConditionPack.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/conditions/FakeConditionPack.java
@@ -14,11 +14,18 @@ package org.eclipse.passage.lic.api.tests.fakes.conditions;
 
 import java.util.Collection;
 
+import org.eclipse.passage.lic.api.agreements.GlobalAgreement;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.ConditionOrigin;
 import org.eclipse.passage.lic.api.conditions.ConditionPack;
 
+@SuppressWarnings("restriction")
 public final class FakeConditionPack implements ConditionPack {
+
+	@Override
+	public Collection<GlobalAgreement> agreements() {
+		throw new UnsupportedOperationException();
+	}
 
 	@Override
 	public ConditionOrigin origin() {

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionEmittingServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/conditions/evaluation/BasePermissionEmittingServiceTest.java
@@ -208,6 +208,6 @@ public final class BasePermissionEmittingServiceTest {
 	private Collection<ConditionPack> packOf(Condition... conditions) {
 		return Collections.singleton(//
 				new BaseConditionPack(//
-						new UnknownConditionOrigin(), Arrays.asList(conditions)));
+						new UnknownConditionOrigin(), Arrays.asList(conditions), Collections.emptyList()));
 	}
 }


### PR DESCRIPTION
Support Global Agreenets - the ones defined for a license plan outside of the product under licensing:
 - extend `condition pack` with agreements, under which these conditions are supplied

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>