### PR TITLE
Temporary switch baseline to stage

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -211,7 +211,7 @@
           <repository
               url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.24/"/>
           <repository
-              url="https://download.eclipse.org/passage/updates/release/2.1.0/"/>
+              url="https://download.eclipse.org/passage/drops/release/stage/"/>
           <repository
               url="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-09/"/>
           <repository

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.baseline.target
@@ -62,7 +62,7 @@
 			<unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/passage/updates/release/2.1.0/"/>
+			<repository location="https://download.eclipse.org/passage/drops/release/stage/"/>
 			<unit id="org.eclipse.passage.lbc.execute.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.passage.ldc.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.passage.lic.define.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
We need this until 2.1.1 is not published
Then it should be switched to
https://download.eclipse.org/passage/updates/release/2.1.1/

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>