### PR TITLE
fix minor ui discrepancies in Operator reporting tools

### DIFF
--- a/bundles/org.eclipse.passage.loc.report.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.report.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.report.ui
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.report.ui;singleton:=true
-Bundle-Version: 0.3.1.qualifier
+Bundle-Version: 0.3.100.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.passage.lic.users;bundle-version="0.0.0",
  org.eclipse.passage.loc.products.ui;bundle-version="0.0.0",
  org.eclipse.passage.loc.report.core;bundle-version="0.0.0",
- org.eclipse.passage.loc.yars.api;bundle-version="0.0.0";visibility:=reexport
+ org.eclipse.passage.loc.yars.api;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.loc.report.internal.ui.jface.license;x-friends:="org.eclipse.passage.loc.licenses.ui",
  org.eclipse.passage.loc.report.internal.ui.jface.user;x-friends:="org.eclipse.passage.loc.users.ui"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.java
@@ -21,6 +21,7 @@ public class ExportCustomersWizardMessages extends NLS {
 	public static String ExposedExportCustomersWizard_dialogTitle;
 	public static String PreviewPage_description;
 	public static String PreviewPage_title;
+	public static String PreviewPage_noinfo_company;
 	public static String ScopePage_columnProduct;
 	public static String ScopePage_columnSelect;
 	public static String ScopePage_description;

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.properties
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 ArSysOp
+# Copyright (c) 2020, 2021 ArSysOp
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.properties
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/i18n/ExportCustomersWizardMessages.properties
@@ -16,6 +16,7 @@ ExposedExportCustomersWizard_dialogTitle=Export Customers
 PreviewPage_description=Here are the final list of users to be exported \
 and the final location of the result
 PreviewPage_title=Users to be exported
+PreviewPage_noinfo_company = no information provided (not loaded)
 
 ScopePage_columnProduct=Product
 ScopePage_columnSelect=Select

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/license/IssuedLicensesReportWizard.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/license/IssuedLicensesReportWizard.java
@@ -22,6 +22,7 @@ import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.passage.loc.report.internal.core.license.LicensePlanReportParameters;
 import org.eclipse.passage.loc.report.internal.core.license.LicenseReportExportService;
 import org.eclipse.passage.loc.report.internal.core.license.LicenseStorage;
+import org.eclipse.passage.loc.report.internal.ui.i18n.ExportLicenseReportWizardMessages;
 import org.eclipse.passage.loc.report.internal.ui.i18n.ExportWizardMessages;
 import org.eclipse.passage.loc.report.internal.ui.jface.FileForExport;
 import org.eclipse.passage.loc.report.internal.ui.jface.TargetPage;
@@ -52,6 +53,7 @@ final class IssuedLicensesReportWizard extends Wizard {
 		this.scope = new PlansPage(new LicensePlans(storage), preview);
 		this.config = new ConfigPage(preview);
 		this.target = new TargetPage(preview);
+		setWindowTitle(ExportLicenseReportWizardMessages.ExposedIssuedLicensesReportWizard_dialogTitle);
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/license/IssuedLicensesReportWizard.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/license/IssuedLicensesReportWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2021 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/user/PreviewPage.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/user/PreviewPage.java
@@ -87,6 +87,9 @@ final class PreviewPage extends WizardPage implements PageObserver {
 	}
 
 	private String companyInfo(UserOriginDescriptor company) {
+		if (company == null) {
+			return "no information provided (not loaded)"; //$NON-NLS-1$
+		}
 		return NLS.bind("{0} ({1})", company.getName(), company.getIdentifier()); //$NON-NLS-1$
 	}
 

--- a/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/user/PreviewPage.java
+++ b/bundles/org.eclipse.passage.loc.report.ui/src/org/eclipse/passage/loc/report/internal/ui/jface/user/PreviewPage.java
@@ -88,7 +88,7 @@ final class PreviewPage extends WizardPage implements PageObserver {
 
 	private String companyInfo(UserOriginDescriptor company) {
 		if (company == null) {
-			return "no information provided (not loaded)"; //$NON-NLS-1$
+			return ExportCustomersWizardMessages.PreviewPage_noinfo_company;
 		}
 		return NLS.bind("{0} ({1})", company.getName(), company.getIdentifier()); //$NON-NLS-1$
 	}


### PR DESCRIPTION
 - Customers export wizard must not fail is loaded metainformation is
not consistent
  - Issued Licenses Report wizard must have a title



Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>