### PR TITLE
1054  LIC: library-licensed-separately: support license import

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/agreements/AgreementToAccept.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/agreements/AgreementToAccept.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,19 @@ import org.eclipse.passage.lic.api.requirements.Requirement;
 
 public interface AgreementToAccept {
 
+	/**
+	 * <p>
+	 * Agreement can be demanded for acceptance right where a licensing Requirement
+	 * for a feature is declared Thus agreement is bound to a physical Requirement.
+	 * </p>
+	 * <p>
+	 * It if also possible to demand an agreement acceptance in the body of a
+	 * license. In this case an instance of {@linkplain AgreementAcceptanceDemand}
+	 * is instantiated to represent a requirement under this demand. It references a
+	 * product-representing-feature (it's id and name correspond to the ones of the
+	 * product).
+	 * </p>
+	 */
 	Requirement origin();
 
 	ResolvedAgreement definition();

--- a/bundles/org.eclipse.passage.lic.base/schema/library.exsd
+++ b/bundles/org.eclipse.passage.lic.base/schema/library.exsd
@@ -67,7 +67,7 @@
                   
                </documentation>
                <appinfo>
-                  <meta.attribute kind="java" basedOn=":org.eclipse.passage.lic.internal.base.access.DelegatedLicensingService"/>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.passage.lic.internal.base.access.Library"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/Restrictions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/Restrictions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/Restrictions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/access/Restrictions.java
@@ -94,7 +94,7 @@ public final class Restrictions implements Supplier<ServiceInvocationResult<Exam
 	private AgreementToAccept agreementToAccept(GlobalAgreement agreement) {
 		ResolvedAgreement definition = new MinedAgreement(agreement);
 		return new BaseAgreementToAccept(//
-				new AgreementAcceptanceDemand(definition), //
+				new AgreementAcceptanceDemand(definition, product), //
 				definition, //
 				acceptanceState(agreement));
 	}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/AgreementAcceptanceDemand.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/AgreementAcceptanceDemand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.passage.lic.base.agreements;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.agreements.ResolvedAgreement;
 import org.eclipse.passage.lic.api.requirements.Feature;
 import org.eclipse.passage.lic.api.requirements.Requirement;
@@ -25,8 +26,8 @@ public final class AgreementAcceptanceDemand implements Requirement {
 	private final Feature feature;
 	private final List<ResolvedAgreement> agreement;
 
-	public AgreementAcceptanceDemand(ResolvedAgreement agreement) {
-		this.feature = new GlobalAgreementSupportFeature().get();
+	public AgreementAcceptanceDemand(ResolvedAgreement agreement, LicensedProduct product) {
+		this.feature = new GlobalAgreementSupportFeature(product).get();
 		this.agreement = Collections.singletonList(agreement);
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/GlobalAgreementSupportFeature.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/agreements/GlobalAgreementSupportFeature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,16 +14,23 @@ package org.eclipse.passage.lic.base.agreements;
 
 import java.util.function.Supplier;
 
+import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.requirements.Feature;
 import org.eclipse.passage.lic.base.requirements.BaseFeature;
 
 public final class GlobalAgreementSupportFeature implements Supplier<Feature> {
 
+	private final LicensedProduct product;
+
+	public GlobalAgreementSupportFeature(LicensedProduct product) {
+		this.product = product;
+	}
+
 	@Override
 	public Feature get() {
 		return new BaseFeature(//
-				"passage.global-agreement-support.feature", //$NON-NLS-1$
-				"1.0.0", //$NON-NLS-1$
+				product.identifier(), //
+				product.version(), //
 				"Global Agreements Support by Passage", //$NON-NLS-1$
 				"Eclipse Passage Runtime" //$NON-NLS-1$
 		);

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/diagnostic/code/ForeignLicense.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/diagnostic/code/ForeignLicense.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.base.diagnostic.code;
+
+import org.eclipse.passage.lic.api.diagnostic.TroubleCode;
+import org.eclipse.passage.lic.internal.base.i18n.DiagnosticCodeMessages;
+
+/**
+ * 
+ * @since 2.3
+ */
+public final class ForeignLicense extends TroubleCode {
+
+	public ForeignLicense() {
+		super(413, DiagnosticCodeMessages.getString("ForeignLicense.explanation")); //$NON-NLS-1$
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/diagnostic/code/package-info.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/diagnostic/code/package-info.java
@@ -65,6 +65,8 @@
  * <li>411 - no data of a particular type found (info)</li>
  * <li>412 - a licensing agreement has not been actively accepted by the product
  * user</li>
+ * <li>413 - foreign license: suggested license file cannot be read with the
+ * product/library key (bearable)
  * </ul>
  * </li>
  * <li>5xx - reserved</li>

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/PassageFileExtension.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/PassageFileExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.base.io;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.function.Supplier;
 
@@ -22,6 +23,13 @@ public abstract class PassageFileExtension implements Supplier<String> {
 
 	public final boolean ends(Path path) {
 		return path.getFileName().toString().endsWith(get());
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public final boolean ends(File file) {
+		return file.getName().endsWith(get());
 	}
 
 	public static final class LicenseEncrypted extends PassageFileExtension {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/DelegatedLicensingService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/DelegatedLicensingService.java
@@ -21,9 +21,13 @@ import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.PassageLicenseCoverage;
 import org.eclipse.passage.lic.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.api.agreements.AgreementAcceptanceService;
+import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
 
+/**
+ * Implementation must be stateless.
+ */
 public interface DelegatedLicensingService extends PassageLicenseCoverage {
 
 	LicensedProduct product();
@@ -31,7 +35,12 @@ public interface DelegatedLicensingService extends PassageLicenseCoverage {
 	@Override
 	ServiceInvocationResult<ExaminationCertificate> assess();
 
-	Optional<AgreementAcceptanceService> agreementsService();
+	/**
+	 * For a given {@code agreement} a library should perform an analysis if this
+	 * agreement is demanded by it, and in this case supply an instance and
+	 * {@linkplain AgreementAcceptanceService} for acceptance.
+	 */
+	Optional<AgreementAcceptanceService> agreementsService(AgreementToAccept agreement);
 
 	Collection<Condition> conditions(Path license);
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/DelegatedLicensingService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/DelegatedLicensingService.java
@@ -89,6 +89,11 @@ public interface DelegatedLicensingService extends PassageLicenseCoverage {
 	 */
 	ServiceInvocationResult<LicenseReadingService> licenseReadingService();
 
+	/**
+	 * If the given {@code license} relates to the library, it should install to the
+	 * license residence, configured for this library's
+	 * {@code access cycle configuration}
+	 */
 	void installLicense(Path license) throws IOException;
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Libraries.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Libraries.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.access;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.LicensedProduct;
+import org.eclipse.passage.lic.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.api.agreements.AgreementAcceptanceService;
+import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
+import org.eclipse.passage.lic.api.conditions.Condition;
+import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.base.access.SumOfCertificates;
+
+public final class Libraries {
+
+	private final List<DelegatedLicensingService> libraries;
+	private final Supplier<LicensedProduct> owner;
+
+	public Libraries(Supplier<List<DelegatedLicensingService>> libraries, Supplier<LicensedProduct> owner) {
+		this(libraries.get(), owner);
+	}
+
+	public Libraries(List<DelegatedLicensingService> libraries, Supplier<LicensedProduct> owner) {
+		this.libraries = libraries;
+		this.owner = owner;
+	}
+
+	public boolean empty() {
+		return libraries.isEmpty();
+	}
+
+	public LicensedProduct product() {
+		return owner.get();
+	}
+
+	public Optional<ServiceInvocationResult<ExaminationCertificate>> assess() {
+		return libraries.stream()//
+				.map(DelegatedLicensingService::assess)
+				.reduce(new BaseServiceInvocationResult.Sum<>(new SumOfCertificates()));
+	}
+
+	public Optional<AgreementAcceptanceService> agreementsService(AgreementToAccept agreement) {
+		if (empty()) {
+			return Optional.empty();
+		}
+		return libraries.stream()//
+				.map(library -> library.agreementsService(agreement))//
+				.filter(Optional::isPresent)//
+				.map(Optional::get)//
+				.findAny();
+	}
+
+	public Collection<Condition> conditions(Path license) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	public void installLicense(Path license) throws IOException {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Library.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/Library.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.access;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 import org.eclipse.passage.lic.api.LicensedProduct;
@@ -22,8 +21,12 @@ import org.eclipse.passage.lic.api.agreements.AgreementAcceptanceService;
 import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
 import org.eclipse.passage.lic.api.conditions.mining.LicenseReadingService;
 import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.base.diagnostic.code.ForeignLicense;
 
 /**
+ * <p>
+ * Represent a library's licensing aspect for an owning product.
+ * </p>
  * <p>
  * Implementation must be stateless: service is to be instantiated as many times
  * as it is appealed to, no caching to perform for scanned extensions.
@@ -52,27 +55,33 @@ import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
  * 
  * <ul>
  * 
- * <li>1.1. supply it's own assessment results when asked:
- * {@code implementing access()}</li>
+ * <li>1.1. supply it's own assessment results when asked: {@code access()}</li>
  * 
  * <li>1.2. facilitate acceptance of a license agreement, in case it demands
  * some for acceptance:
  * {@code agreementsService(AgreementToAccept agreement)}</li>
  * 
  * <li>2.1. supply a {@linkplain LicenseReadingService} that will read licensing
- * {@linkplain Condition}s from a given file, in case it can be treated a this
+ * {@linkplain Condition}s from a license file, in case it can be treated a this
  * library's license</li>
  * 
- * <li>2.2. provide a way to install a license to path configured for the
- * library as license residence.</li>
+ * <li>2.2. provide a way to install a license (it defined to be this library's
+ * license) to path configured for the library as <i>license residence</i>:
+ * {@code installLicense(Path license)}.</li>
  * 
  * </ul>
  * 
  */
-public interface DelegatedLicensingService extends PassageLicenseCoverage {
+public interface Library extends PassageLicenseCoverage {
 
+	/**
+	 * Library represents its own <i>product</i>.
+	 */
 	LicensedProduct product();
 
+	/**
+	 * Request a library to perform full license coverage assessment.
+	 */
 	@Override
 	ServiceInvocationResult<ExaminationCertificate> assess();
 
@@ -90,10 +99,28 @@ public interface DelegatedLicensingService extends PassageLicenseCoverage {
 	ServiceInvocationResult<LicenseReadingService> licenseReadingService();
 
 	/**
+	 * <p>
 	 * If the given {@code license} relates to the library, it should install to the
 	 * license residence, configured for this library's
 	 * {@code access cycle configuration}
+	 * </p>
+	 * 
+	 * <p>
+	 * If the {@code license} file does not belong to the library, report negative
+	 * result with bearable diagnostic of {@linkplain ForeignLicense} trouble code.
+	 * </p>
+	 * <p>
+	 * If the {@code license} file can be read, but was not imported for some
+	 * reason, report negative result with severe trouble in diagnostic.
+	 * </p>
+	 * <p>
+	 * In case the {@code license} has been actually installed, report positive
+	 * result, optionally with whatever informative diagnostic.
+	 * </p>
+	 * 
+	 * @return diagnosed result of installation: whether installation of the
+	 *         {@code license} has been actually performed or not
 	 */
-	void installLicense(Path license) throws IOException;
+	ServiceInvocationResult<Boolean> installLicense(Path license);
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/LicenseConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/LicenseConditions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/LicenseConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/conditions/LicenseConditions.java
@@ -14,30 +14,73 @@ package org.eclipse.passage.lic.internal.base.conditions;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.api.conditions.ConditionPack;
 import org.eclipse.passage.lic.api.conditions.mining.LicenseReadingService;
 import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.base.BaseServiceInvocationResult.Sum;
+import org.eclipse.passage.lic.base.SumOfCollections;
+import org.eclipse.passage.lic.internal.base.access.Libraries;
 
+/**
+ * <p>
+ * Reads all licensing {@linkplain Condition}s from given license file.
+ * </p>
+ * <p>
+ * A license file can belong either to a product under licensing, or to any
+ * library it exploits. Only appropriate component can read it's licenses.
+ * </p>
+ */
 public final class LicenseConditions implements Supplier<ServiceInvocationResult<Collection<ConditionPack>>> {
 
 	private final Path file;
-	private final Supplier<ServiceInvocationResult<LicenseReadingService>> provider;
+	private final Supplier<ServiceInvocationResult<LicenseReadingService>> owner;
+	private final Libraries libraries;
 
-	public LicenseConditions(Path file, Supplier<ServiceInvocationResult<LicenseReadingService>> provider) {
+	public LicenseConditions(//
+			Path file, //
+			Supplier<ServiceInvocationResult<LicenseReadingService>> provider, //
+			Libraries libraries) {
 		this.file = file;
-		this.provider = provider;
+		this.owner = provider;
+		this.libraries = libraries;
 	}
 
 	@Override
 	public ServiceInvocationResult<Collection<ConditionPack>> get() {
-		ServiceInvocationResult<LicenseReadingService> reader = provider.get();
+		return sum().apply(fromProduct(), fromLibraries());
+	}
+
+	private ServiceInvocationResult<Collection<ConditionPack>> fromProduct() {
+		ServiceInvocationResult<LicenseReadingService> reader = owner.get();
 		if (!reader.data().isPresent()) {
 			return new BaseServiceInvocationResult<>(reader.diagnostic());
 		}
 		return reader.data().get().read(file);
+	}
+
+	private ServiceInvocationResult<Collection<ConditionPack>> fromLibraries() {
+		Optional<ServiceInvocationResult<List<LicenseReadingService>>> request = libraries.licenseReadingServices();
+		if (!request.isPresent()) {
+			return new BaseServiceInvocationResult<>(Collections.emptyList());
+		}
+		ServiceInvocationResult<List<LicenseReadingService>> services = request.get();
+		if (!services.data().isPresent()) {
+			return new BaseServiceInvocationResult<>(services.diagnostic());
+		}
+		return services.data().get().stream()//
+				.map(service -> service.read(file))//
+				.reduce(sum())//
+				.get(); // no library case is checked
+	}
+
+	private Sum<Collection<ConditionPack>> sum() {
+		return new Sum<Collection<ConditionPack>>(new SumOfCollections<>());
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/DiagnosticCodeMessages.properties
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/i18n/DiagnosticCodeMessages.properties
@@ -29,3 +29,4 @@ InvalidLicenseAttendantFile.license_expired=Invalid content of a license attenda
 AbsentLicenseAttendantFile.license_expired=Expected license attendant file is not found
 TentativeAccess.explanation=Feature is not covered by a license, but in the same time it's usage is not severely restricted; thus tentative access can be granted.
 NoDataOfType.explanation=No data of type found
+ForeignLicense.explanation=License file does not belong to the product/library

--- a/bundles/org.eclipse.passage.lic.equinox/.settings/.api_filters
+++ b/bundles/org.eclipse.passage.lic.equinox/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.passage.lic.equinox" version="2">
+    <resource path="src/org/eclipse/passage/lic/equinox/LicenseReadingServiceRequest.java" type="org.eclipse.passage.lic.equinox.LicenseReadingServiceRequest">
+        <filter id="338722907">
+            <message_arguments>
+                <message_argument value="org.eclipse.passage.lic.equinox.LicenseReadingServiceRequest"/>
+                <message_argument value="LicenseReadingServiceRequest(EquinoxFrameworkAware&lt;?&gt;)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/passage/lic/equinox/requirements/BundleResidentAgreement.java" type="org.eclipse.passage.lic.equinox.requirements.BundleResidentAgreement">
         <filter id="576725006">
             <message_arguments>

--- a/bundles/org.eclipse.passage.lic.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.equinox/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Export-Package: org.eclipse.passage.lic.equinox,
  org.eclipse.passage.lic.equinox.io,
  org.eclipse.passage.lic.equinox.requirements,
  org.eclipse.passage.lic.internal.equinox;x-friends:="org.eclipse.passage.loc.licenses.core,org.eclipse.passage.lic.jetty",
+ org.eclipse.passage.lic.internal.equinox.access;x-internal:=true,
  org.eclipse.passage.lic.internal.equinox.events;
   x-friends:="org.eclipse.passage.loc.features.core,
    org.eclipse.passage.loc.products.core,

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/EquinoxPassageLicenseCoverage.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/EquinoxPassageLicenseCoverage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/EquinoxPassageLicenseCoverage.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/EquinoxPassageLicenseCoverage.java
@@ -12,14 +12,25 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox;
 
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.Framework;
+import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.PassageLicenseCoverage;
 import org.eclipse.passage.lic.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.api.diagnostic.Trouble;
 import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
 import org.eclipse.passage.lic.base.access.Access;
+import org.eclipse.passage.lic.base.access.SumOfCertificates;
+import org.eclipse.passage.lic.base.diagnostic.code.NoDataOfType;
+import org.eclipse.passage.lic.internal.base.access.Libraries;
+import org.eclipse.passage.lic.internal.equinox.access.RegisteredLibraries;
 
 /**
  * @since 2.1
  */
+@SuppressWarnings("restriction")
 public final class EquinoxPassageLicenseCoverage implements PassageLicenseCoverage {
 
 	private final EquinoxFrameworkAware<?> delegate;
@@ -34,7 +45,34 @@ public final class EquinoxPassageLicenseCoverage implements PassageLicenseCovera
 
 	@Override
 	public ServiceInvocationResult<ExaminationCertificate> assess() {
+		return both(owner(), libraries());
+	}
+
+	private ServiceInvocationResult<ExaminationCertificate> both(//
+			ServiceInvocationResult<ExaminationCertificate> owner, //
+			Optional<ServiceInvocationResult<ExaminationCertificate>> libraries) {
+		if (!libraries.isPresent()) {
+			return owner;
+		}
+		return new BaseServiceInvocationResult.Sum<>(new SumOfCertificates())//
+				.apply(owner, libraries.get());
+	}
+
+	private Optional<ServiceInvocationResult<ExaminationCertificate>> libraries() {
+		Optional<LicensedProduct> product = delegate.withFramework(Framework::product);
+		if (!product.isPresent()) {
+			return noOwningProduct();
+		}
+		return new Libraries(new RegisteredLibraries(), product::get).assess();
+	}
+
+	private ServiceInvocationResult<ExaminationCertificate> owner() {
 		return delegate.withFrameworkService(framework -> new Access(framework).assess());
+	}
+
+	private Optional<ServiceInvocationResult<ExaminationCertificate>> noOwningProduct() {
+		return Optional.of(new BaseServiceInvocationResult<>(
+				new Trouble(new NoDataOfType(), "License Product definition is absent"))); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicenseReadingServiceRequest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicenseReadingServiceRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicenseReadingServiceRequest.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/LicenseReadingServiceRequest.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import org.eclipse.passage.lic.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.api.conditions.mining.LicenseReadingService;
 import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.base.FrameworkAware;
 import org.eclipse.passage.lic.base.conditions.mining.BaseLicenseReadingService;
 
 /**
@@ -24,13 +25,16 @@ import org.eclipse.passage.lic.base.conditions.mining.BaseLicenseReadingService;
  */
 public final class LicenseReadingServiceRequest implements Supplier<ServiceInvocationResult<LicenseReadingService>> {
 
-	private final EquinoxFrameworkAware<?> delegate;
+	private final FrameworkAware delegate;
 
 	public LicenseReadingServiceRequest() {
 		this(new SuppliedFrameworkAware());
 	}
 
-	public LicenseReadingServiceRequest(EquinoxFrameworkAware<?> delegate) {
+	/**
+	 * @since 2.3
+	 */
+	public LicenseReadingServiceRequest(FrameworkAware delegate) {
 		this.delegate = delegate;
 	}
 

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/LicenseCoverageCheck.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/LicenseCoverageCheck.java
@@ -65,7 +65,8 @@ public final class LicenseCoverageCheck {
 		if (new CertificateIsRestrictive().test(assessment.data())) {
 			options.add(new OptionImport(interaction, product));
 			options.add(new OptionRequest(interaction));
-			agreements(assessment).ifPresent(agreements -> options.add(new OptionAccept(interaction, agreements)));
+			agreements(assessment)
+					.ifPresent(agreements -> options.add(new OptionAccept(interaction, agreements, product)));
 			options.add(new OptionDiagnostic(interaction, assessment.diagnostic()));
 			options.add(new OptionQuit(interaction));
 			options.add(new OptionProceed(interaction));

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/LicenseCoverageCheck.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/LicenseCoverageCheck.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/OptionAccept.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/OptionAccept.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/ServiceExtensions.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/ServiceExtensions.java
@@ -32,8 +32,8 @@ import org.eclipse.core.runtime.Platform;
  * extensions of sequence<service<class>> structure.
  * </p>
  * <p>
- * In case there is a trouble with any single library, logs details and proceeds
- * with the rest of them.
+ * In case there is a trouble with any single extension, logs details and
+ * proceeds with the rest of them.
  * </p>
  */
 public final class ServiceExtensions<S> implements Supplier<List<S>> {
@@ -57,7 +57,7 @@ public final class ServiceExtensions<S> implements Supplier<List<S>> {
 		return Arrays.stream(extensions())//
 				.map(IExtension::getConfigurationElements)//
 				.flatMap(Arrays::stream)//
-				.map(this::oneService)//
+				.map(this::service)//
 				.filter(Optional::isPresent) //
 				.map(Optional::get) //
 				.collect(Collectors.toList());
@@ -67,7 +67,7 @@ public final class ServiceExtensions<S> implements Supplier<List<S>> {
 		return Platform.getExtensionRegistry().getExtensionPoint(namespace, point).getExtensions();
 	}
 
-	private Optional<S> oneService(IConfigurationElement config) {
+	private Optional<S> service(IConfigurationElement config) {
 		try {
 			Object executable = config.createExecutableExtension("class"); //$NON-NLS-1$
 			return Optional.of(service.cast(executable));

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/AgreementAcceptanceDelegate.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/AgreementAcceptanceDelegate.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.access;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.agreements.AgreementAcceptanceService;
+import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
+import org.eclipse.passage.lic.internal.base.access.Libraries;
+
+/**
+ * <p>
+ * Licensing agreement can be demanded for acceptance by product itself as well
+ * as by ant library it employs.
+ * </p>
+ * <p>
+ * Here we survey all registered libraries whether they are eligible to perform
+ * acceptance of a given agreement, and use product own acceptance service if
+ * none of the libraries step in.
+ * </p>
+ */
+@SuppressWarnings("restriction")
+public final class AgreementAcceptanceDelegate {
+
+	private final AgreementAcceptanceService root;
+	private final Libraries libraries;
+
+	public AgreementAcceptanceDelegate(AgreementAcceptanceService root, Libraries libraries) {
+		this.root = root;
+		this.libraries = libraries;
+	}
+
+	public void accept(AgreementToAccept agreement) throws Exception {
+		AgreementAcceptanceService service = root;
+		Optional<AgreementAcceptanceService> library = libraries.agreementsService(agreement);
+		if (library.isPresent()) {
+			service = library.get();
+		}
+		service.accept(() -> agreement.acceptance().content());
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/AgreementAcceptanceDelegate.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/AgreementAcceptanceDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.equinox.access;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.internal.base.access.DelegatedLicensingService;
+import org.eclipse.passage.lic.internal.equinox.ServiceExtensions;
+
+@SuppressWarnings("restriction")
+public final class RegisteredLibraries implements Supplier<List<DelegatedLicensingService>> {
+
+	@Override
+	public List<DelegatedLicensingService> get() {
+		return new ServiceExtensions<DelegatedLicensingService>(//
+				"org.eclipse.passage.lic.base", //$NON-NLS-1$
+				"library", //$NON-NLS-1$
+				DelegatedLicensingService.class)//
+						.get();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/internal/equinox/access/RegisteredLibraries.java
@@ -15,18 +15,18 @@ package org.eclipse.passage.lic.internal.equinox.access;
 import java.util.List;
 import java.util.function.Supplier;
 
-import org.eclipse.passage.lic.internal.base.access.DelegatedLicensingService;
+import org.eclipse.passage.lic.internal.base.access.Library;
 import org.eclipse.passage.lic.internal.equinox.ServiceExtensions;
 
 @SuppressWarnings("restriction")
-public final class RegisteredLibraries implements Supplier<List<DelegatedLicensingService>> {
+public final class RegisteredLibraries implements Supplier<List<Library>> {
 
 	@Override
-	public List<DelegatedLicensingService> get() {
-		return new ServiceExtensions<DelegatedLicensingService>(//
+	public List<Library> get() {
+		return new ServiceExtensions<Library>(//
 				"org.eclipse.passage.lic.base", //$NON-NLS-1$
 				"library", //$NON-NLS-1$
-				DelegatedLicensingService.class)//
+				Library.class)//
 						.get();
 	}
 

--- a/bundles/org.eclipse.passage.lic.jface/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.jface/OSGI-INF/l10n/bundle.properties
@@ -1,6 +1,6 @@
 #Properties file for org.eclipse.passage.lic.jface
 ###############################################################################
-# Copyright (c) 2018, 2021 ArSysOp and others
+# Copyright (c) 2018, 2022 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@
 
 Bundle-Name = Passage LIC JFace
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018, 2021 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2022 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AgreementsWizard.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AgreementsWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AllConditionsFromLicenses.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AllConditionsFromLicenses.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.eclipse.passage.lic.api.ServiceInvocationResult;
+import org.eclipse.passage.lic.api.conditions.ConditionPack;
+import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
+import org.eclipse.passage.lic.base.SumOfCollections;
+import org.eclipse.passage.lic.equinox.LicenseReadingServiceRequest;
+import org.eclipse.passage.lic.internal.base.access.Libraries;
+import org.eclipse.passage.lic.internal.base.conditions.LicenseConditions;
+
+@SuppressWarnings("restriction")
+final class AllConditionsFromLicenses implements Supplier<ServiceInvocationResult<Collection<ConditionPack>>> {
+
+	private final List<Path> licenses;
+	private final Libraries libraries;
+	private final LicenseReadingServiceRequest product;
+
+	AllConditionsFromLicenses(List<Path> licenses, Libraries libraries) {
+		this.licenses = licenses;
+		this.libraries = libraries;
+		this.product = new LicenseReadingServiceRequest();
+	}
+
+	@Override
+	public ServiceInvocationResult<Collection<ConditionPack>> get() {
+		return licenses.stream()//
+				.map(this::fromLicense)//
+				.reduce(new BaseServiceInvocationResult.Sum<>(new SumOfCollections<>()))//
+				.orElse(new BaseServiceInvocationResult<>(Collections.emptyList()));
+	}
+
+	private ServiceInvocationResult<Collection<ConditionPack>> fromLicense(Path file) {
+		return new LicenseConditions(file, product, libraries).get();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AllLicensesFromFolder.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/AllLicensesFromFolder.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.jface.dialogs.licensing;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.base.io.PassageFileExtension;
+
+final class AllLicensesFromFolder implements Supplier<List<Path>> {
+
+	private final Optional<String> folder;
+
+	AllLicensesFromFolder(String folder) {
+		this(Optional.ofNullable(folder));
+	}
+
+	AllLicensesFromFolder(Optional<String> folder) {
+		this.folder = folder;
+	}
+
+	@Override
+	public List<Path> get() {
+		if (!folder.isPresent()) {
+			return Collections.emptyList();
+		}
+		return Arrays.stream(licenses())//
+				.map(File::toPath)//
+				.collect(Collectors.toList());
+	}
+
+	private File[] licenses() {
+		File host = new File(folder.get());
+		if (!host.isDirectory()) {
+			return new File[0];
+		}
+		return host.listFiles(licen());
+	}
+
+	private FileFilter licen() {
+		return new FileFilter() {
+			private final PassageFileExtension licen = new PassageFileExtension.LicenseEncrypted();
+
+			@Override
+			public boolean accept(File file) {
+				return licen.ends(file);
+			}
+		};
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/dialogs/licensing/ImportLicenseDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/internal/jface/i18n/ImportLicenseDialogMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2021 ArSysOp and others
+# Copyright (c) 2020, 2022 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,14 +10,14 @@
 # Contributors:
 #     ArSysOp - initial API and implementation
 ###############################################################################
-ImportLicenseDialog_browse_dialog_title=Import from File
+ImportLicenseDialog_browse_dialog_title=Import all licenses from folder
 ImportLicenseDialog_column_evaluation=Evaluation
 ImportLicenseDialog_column_feature=Feature
 ImportLicenseDialog_column_period=Valid
 ImportLicenseDialog_import_title=&Import
-ImportLicenseDialog_import_tooltip=Copy this license file to a dedicated directory 
+ImportLicenseDialog_import_tooltip=Copy found license files to dedicated directories
 ImportLicenseDialog_io_error=License import failed due to I/O error: %s
-ImportLicenseDialog_lic_read_failed=Failed to read the license pointed
+ImportLicenseDialog_lic_read_failed=Failed to read the license from the pointed folder
 ImportLicenseDialog_path_label=From license file:
-ImportLicenseDialog_prelude=Point license file to see what's inside
-ImportLicenseDialog_title=Import License
+ImportLicenseDialog_prelude=Point a folder with license files to see what's inside them
+ImportLicenseDialog_title=Import Licenses


### PR DESCRIPTION
delegate external licensing activities to a library used by project
 - license status assessment: assemble library licensing status assessment results when assessing product license coverage
 - license import: ask a library to decompose proepr license for conditions for exposure
 - license import: delegate actual license import to a library (it can be configured to reside its licenses in a very much specific destination)
 - regarget `ImportLicenseDialog` from a single file to a directory