### PR TITLE
#1056 Access Cycle: error on a license reading

### DIFF
--- a/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/internal/bc/i18n/BcMessages.properties
+++ b/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/internal/bc/i18n/BcMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2020 ArSysOp and others
+# Copyright (c) 2019, 2022 ArSysOp
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@ BcStreamCodec_create_keys_error_private=Error writing private key
 BcStreamCodec_create_keys_error_public=Error writing public key
 BcStreamCodec_create_keys_error_ring=Error working with key ring
 BcStreamCodec_deconde_error=Decoding error for configuration %s
-BcStreamCodec_encode_error_data=Invalid compressed data for configuration %s
+BcStreamCodec_encode_error_data=License for [%s] does not contain encrypted data
 BcStreamCodec_encode_error_digest=Key ring digest does not match for configuration %s
 BcStreamCodec_encode_error_no_key=Unable to find signing key
 BcStreamCodec_encode_error_public_key=Public key invalid for configuration %s


### PR DESCRIPTION
As error is caused by license file corruption, make disorder description explanatory

Signed-off-by: eparovyshnaya <elena.parovyshnaya@gmail.com>