### PR TITLE
[LIC-Base] Simplify IO operations

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/FileContent.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/FileContent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,11 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     Hannes Wellmann (IILS mbH) - Simplify IO operations(#1071)
  *******************************************************************************/
 package org.eclipse.passage.lic.base.io;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -32,10 +31,6 @@ public final class FileContent {
 	}
 
 	public byte[] get() throws IOException {
-		byte[] content = new byte[(int) Files.size(file)];
-		try (InputStream stream = new FileInputStream(file.toFile())) {
-			stream.read(content);
-		}
-		return content;
+		return Files.readAllBytes(file);
 	}
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/FileKeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/FileKeyKeeper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.base.io;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,7 +43,7 @@ public final class FileKeyKeeper implements KeyKeeper {
 	@Override
 	public InputStream productPublicKey() throws LicensingException {
 		try {
-			return new FileInputStream(key.toFile());
+			return Files.newInputStream(key);
 		} catch (Exception e) {
 			throw new LicensingException(e);
 		}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/PathKeyKeeper.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/io/PathKeyKeeper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.base.io;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -47,7 +47,7 @@ public final class PathKeyKeeper implements KeyKeeper {
 	public InputStream productPublicKey() throws LicensingException {
 		Path path = base.get().resolve(keyFile());
 		try {
-			return new FileInputStream(path.toFile());
+			return Files.newInputStream(path);
 		} catch (Exception e) {
 			throw new LicensingException(//
 					String.format(//


### PR DESCRIPTION
This PR simplifies the IO operations in the package `org.eclipse.passage.lic.base.io` by better leveraging Java's NIO Path API.

Some of the changes require Java-11. But since some other Plug-ins already use Java-11 as their lower bound (just like Eclipse-Platform) I assume this is OK.