### PR TITLE
[LIC-Base] simplify stream-pipeline and avoid use of Stream.peek()

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/Swath.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/Swath.java
@@ -15,7 +15,7 @@ package org.eclipse.passage.lic.oshi;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.passage.lic.api.inspection.EnvironmentProperty;
@@ -61,9 +61,8 @@ abstract class Swath<T> {
 
 	final boolean hasValue(EnvironmentProperty property, String regexp) {
 		return properties.stream()//
-				.map(props -> Optional.ofNullable(props.get(property)))//
-				.filter(Optional::isPresent)//
-				.map(Optional::get)//
+				.map(props -> props.get(property))//
+				.filter(Objects::nonNull)//
 				.anyMatch(value -> value.matches(regexp));
 	}
 


### PR DESCRIPTION
With this PR I want to propose to simplify some stream pipelines by avoiding to collect their content into intermediate Lists.
This improves the performance (but I have to admit that I did not encounter performance problems) and readability (due to shorter pipelines) of the code.

Furthermore this PR avoids the use of `Stream.peek()`, which is only intended for debugging according to the JavaDoc and not for production code: `"This method exists mainly to support debugging, where you want to see the elements as they flow past a certain point in a pipeline".
I wonder if it is intended to collect only the first satisfying permission or all of them in `BasePermissionsExaminationService.notCovered()`.