### PR TITLE
[Build] update to Tycho 2.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ hs_err_pid*
 releng/**/.settings/
 
 #tycho
-.polyglot.build.properties
+.polyglot.*
 .META-INF_MANIFEST.MF
-.polyglot..META-INF_MANIFEST.MF
+.tycho-consumer-pom.xml
 *.takari_issue_192

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -13,8 +13,8 @@
 -->
 <extensions>
 	<extension>
-		<groupId>org.eclipse.tycho.extras</groupId>
-		<artifactId>tycho-pomless</artifactId>
-		<version>2.3.0</version>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.1</version>
 	</extension>
 </extensions>

--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -33,7 +33,7 @@
 		<build.label>${unqualifiedVersion}.${buildQualifier}</build.label>
 
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-passage/passage.git</tycho.scmUrl>
-		<tycho.version>2.3.0</tycho.version>
+		<tycho.version>2.7.1</tycho.version>
 		<cbi-plugins.version>1.3.1</cbi-plugins.version>
 
 		<tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>


### PR DESCRIPTION
This update to Tycho's latest version 2.7.1.

Please consider that at the moment local execution of builds that use older versions of Tycho does not work after you have executed a build that uses Tycho 2.7.0 or later without manual changes.
If you really want to use mixed versions there is a workaround:
https://github.com/eclipse/tycho/discussions/651#discussioncomment-2223456