### PR TITLE
[OSHI] Only read requested system properties

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/Cached.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/Cached.java
@@ -24,9 +24,22 @@ import java.util.function.Supplier;
  */
 public final class Cached<S, T> implements Supplier<T> {
 
-	private final S source;
-	private final Function<S, T> retrieve;
-	private final List<T> value = new ArrayList<T>(1);
+	private final Supplier<T> retrieve;
+	private final List<T> value = new ArrayList<>(1);
+
+	/**
+	 * To create a <i>late init</i> value, you should specify a a {@code way} to
+	 * perform it.
+	 * 
+	 * @param retrieve a supplier that builds <i>the late init value</i>. It is
+	 *                 guaranteed to be called ones and only when {@linkplain get}
+	 *                 method is called.
+	 * @since 2.3.0
+	 */
+	public Cached(Supplier<T> retrieve) {
+		Objects.requireNonNull(retrieve, "Retriever function cannot be null"); //$NON-NLS-1$
+		this.retrieve = retrieve;
+	}
 
 	/**
 	 * To create a <i>late init</i> value, you should specify a {@code source} for
@@ -42,8 +55,7 @@ public final class Cached<S, T> implements Supplier<T> {
 	public Cached(S source, Function<S, T> retrieve) {
 		Objects.requireNonNull(source, "Source cannot be null"); //$NON-NLS-1$
 		Objects.requireNonNull(retrieve, "Retriever function cannot be null"); //$NON-NLS-1$
-		this.source = source;
-		this.retrieve = retrieve;
+		this.retrieve = () -> retrieve.apply(source);
 	}
 
 	/**
@@ -55,7 +67,7 @@ public final class Cached<S, T> implements Supplier<T> {
 	@Override
 	public T get() {
 		if (value.isEmpty()) {
-			value.add(retrieve.apply(source));
+			value.add(retrieve.get());
 		}
 		return value.get(0);
 	}

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/EnvironmentProperties.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/EnvironmentProperties.java
@@ -23,8 +23,20 @@ import org.eclipse.passage.lic.api.inspection.EnvironmentProperty;
 final class EnvironmentProperties {
 
 	private final Map<EnvironmentProperty, String> properties = new HashMap<>();
+	private final EnvironmentProperty property;
+
+	public EnvironmentProperties() {
+		this(null);
+	}
+
+	public EnvironmentProperties(EnvironmentProperty property) {
+		this.property = property;
+	}
 
 	void store(Supplier<String> value, EnvironmentProperty key) {
+		if (property != null && !property.equals(key)) {
+			return;
+		}
 		Optional<String> read;
 		try {
 			read = Optional.ofNullable(value.get());
@@ -34,8 +46,8 @@ final class EnvironmentProperties {
 		read.ifPresent(valuable -> properties.put(key, valuable));
 	}
 
-	String get(EnvironmentProperty property) {
-		return properties.get(property);
+	String get(EnvironmentProperty prop) {
+		return properties.get(prop);
 	}
 
 	Set<EnvironmentProperty> all() {

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/FragileData.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/FragileData.java
@@ -28,21 +28,18 @@ import java.util.function.Supplier;
 final class FragileData<T> {
 
 	private final Supplier<T> aspect;
-	private final Consumer<T> read;
+	private final Consumer<Supplier<T>> read;
 
-	FragileData(Supplier<T> aspect, Consumer<T> read) {
+	FragileData(Supplier<T> aspect, Consumer<Supplier<T>> read) {
 		this.aspect = aspect;
 		this.read = read;
 	}
 
 	void supply() {
-		T descriptor;
 		try {
-			descriptor = aspect.get();
+			read.accept(aspect);
 		} catch (Throwable any) {
-			return; // legal; 'read' just isn't going to happen
+			// legal; 'read' just isn't going to happen
 		}
-		read.accept(descriptor);
 	}
-
 }

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/HardwareEnvironment.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/HardwareEnvironment.java
@@ -44,12 +44,12 @@ public final class HardwareEnvironment implements RuntimeEnvironment {
 	public boolean isAssuptionTrue(EnvironmentProperty property, String assumption) throws LicensingException {
 		Objects.requireNonNull(property, "HardwareEnvironment::isAssuptionTrue::property"); //$NON-NLS-1$
 		Objects.requireNonNull(assumption, "HardwareEnvironment::isAssuptionTrue::assumption"); //$NON-NLS-1$
-		return freshState().hasValue(property, assumption);
+		return freshState(property).hasValue(property, assumption);
 	}
 
 	@Override
 	public String state() throws LicensingException {
-		return new GlanceOfState(freshState()).get();
+		return new GlanceOfState(freshState(null)).get();
 	}
 
 	/**
@@ -64,10 +64,10 @@ public final class HardwareEnvironment implements RuntimeEnvironment {
 	 * class. Just beware, in case of any threading troubles revise.
 	 * </p>
 	 */
-	private State freshState() throws LicensingException {
+	private State freshState(EnvironmentProperty property) throws LicensingException {
 		State state;
 		synchronized (SystemInfo.class) {
-			state = new State();
+			state = new State(property);
 		}
 		return state;
 	}

--- a/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/Swath.java
+++ b/bundles/org.eclipse.passage.lic.oshi/src/org/eclipse/passage/lic/oshi/Swath.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.api.inspection.EnvironmentProperty;
 import org.eclipse.passage.lic.internal.base.inspection.hardware.Disk;
@@ -70,8 +71,8 @@ abstract class Swath<T> {
 		new FragileData<>(() -> source(system), this::readSource).supply();
 	}
 
-	private void readSource(T[] source) {
-		Arrays.stream(source).forEach(src -> properties.add(fillProperties(src, new EnvironmentProperties())));
+	private void readSource(Supplier<T[]> source) {
+		Arrays.stream(source.get()).forEach(src -> properties.add(fillProperties(src, new EnvironmentProperties())));
 	}
 
 	protected abstract T[] source(SystemInfo system);


### PR DESCRIPTION
Checking if a `HardwareEnvironment` meets a given assumptions (i.e. calling `HardwareEnvironment.isAssuptionTrue()`) is a relatively slow operation because all available information are always fully read form OSHI's `SystemInfo` in the `State` class.

With this PR I propose to only read those properties that are actually requested.

To get an impression about runtime improvements: On my computer this change reduced the runtime of `HardwareEnvironmentTest` from 45~50sec to ~4sec.
