### PR TITLE
Remove unused Require-Bundle: org.slf4j.api

### DIFF
--- a/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Require-Bundle: com.sun.jna;bundle-version="[4.5.1,5.0.0)",
  org.eclipse.osgi;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.api;bundle-version="2.4.0",
- org.eclipse.passage.lic.base;bundle-version="2.4.0",
- org.slf4j.api;bundle-version="1.7.2"
+ org.eclipse.passage.lic.base;bundle-version="2.4.0"
 Export-Package: org.eclipse.passage.lic.oshi
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.slf4j.api;bundle-version="0.0.0",
  com.github.oshi.oshi-core;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.api;bundle-version="1.0.0",


### PR DESCRIPTION
It looks like `org.eclipse.passage.lic.oshi` and its tests do not use the slf4j API and the requirement to it can therefore be removed.

If there is another reason, that I oversaw, to wire to a slf4j bundle I suggest to use Import-Package instead. That allows consumers to use another slf4j bundle than the one provided at Eclipse-Orbit.