### PR TITLE
Fix FLS console input on Linux: #1081

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/ConsoleInteraction.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/access/ConsoleInteraction.java
@@ -26,7 +26,7 @@ public final class ConsoleInteraction implements Interaction {
 		byte[] bytes = new byte[1024];
 		int length = 0;
 		try {
-			for (int symbol = System.in.read(); symbol != 13; symbol = System.in.read()) {
+			for (int symbol = System.in.read(); (symbol != 10) && (symbol != 13); symbol = System.in.read()) {
 				bytes[length++] = (byte) symbol;
 			}
 		} catch (IOException e) {


### PR DESCRIPTION
ConsoleInteraction.java waits for the carriage return character (ASCII 13) before accepting input. Linux indicates input with the line feed character (ASCII 10). Checking for either ASCII 10 or ASCII 13 allows input to be accepted on Unix, Windows, and Mac