### PR TITLE
Harden KeyContent against different publicKey-file line-delimiters

### DIFF
--- a/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/KeyKeeperWithOppositeLineDelimiter.java
+++ b/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/KeyKeeperWithOppositeLineDelimiter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IILS mbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IILS mbH (Hannes Wellmann) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.net.tests.io;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.api.LicensingException;
+import org.eclipse.passage.lic.api.io.KeyKeeper;
+import org.eclipse.passage.lic.base.io.FileKeyKeeper;
+
+final class KeyKeeperWithOppositeLineDelimiter extends TestKeyKeeper {
+
+	@Override
+	public KeyKeeper get() throws LicensingException, IOException {
+		Path file = SafePayloadTest.folder.newFile("key.pub").toPath(); //$NON-NLS-1$
+		Files.write(file, content());
+		return new FileKeyKeeper(file);
+	}
+
+	private byte[] content() throws IOException {
+		return Files.lines(publicKey()) //
+				.collect(Collectors.joining(oppositeLineSeparator())) //
+				.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private String oppositeLineSeparator() {
+		return "\r\n".equals(System.lineSeparator()) //$NON-NLS-1$
+				? "\n" //$NON-NLS-1$
+				: "\r\n"; //$NON-NLS-1$
+	}
+}

--- a/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/SimpleKeyKeeper.java
+++ b/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/SimpleKeyKeeper.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IILS mbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IILS mbH (Hannes Wellmann) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.net.tests.io;
+
+import java.io.IOException;
+
+import org.eclipse.passage.lic.api.LicensingException;
+import org.eclipse.passage.lic.api.io.KeyKeeper;
+import org.eclipse.passage.lic.base.io.FileKeyKeeper;
+
+final class SimpleKeyKeeper extends TestKeyKeeper {
+
+	@Override
+	public KeyKeeper get() throws LicensingException, IOException {
+		return new FileKeyKeeper(publicKey());
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/TestKeyKeeper.java
+++ b/tests/org.eclipse.passage.lic.net.tests/src/org/eclipse/passage/lic/net/tests/io/TestKeyKeeper.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IILS mbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IILS mbH (Hannes Wellmann) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.net.tests.io;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.passage.lic.api.LicensingException;
+import org.eclipse.passage.lic.api.io.KeyKeeper;
+
+abstract class TestKeyKeeper {
+
+	protected abstract KeyKeeper get() throws LicensingException, IOException;
+
+	protected final Path publicKey() {
+		return Paths.get("resource").resolve("io").resolve("key.pub"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+}


### PR DESCRIPTION
The class `KeyContent` reads the entire content of a publicKey-file and returns its raw content as byte-array.
This is problematic if the publicKey-file on server- and client-site use different line endings.
This can happen for example if the file is under git version-control and git is configured to use platform-specific line-endings for text files.

This PR attempts to fix this issue by effectively ignoring line-feed and carriage-return characters when reading the file-content.
Using a `BufferedReader` makes the method even a bit more compact.

The additional test-case outlines the issue and only passes with the change in this PR.