### PR TITLE
1096 Computer.Model and Cpu.Model EnvironmentProperty share family and name

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/inspection/BaseEnvironmentProperty.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/inspection/BaseEnvironmentProperty.java
@@ -54,8 +54,8 @@ public abstract class BaseEnvironmentProperty implements EnvironmentProperty {
 		if (!EnvironmentProperty.class.isInstance(object)) {
 			return false;
 		}
-		EnvironmentProperty os = (EnvironmentProperty) object;
-		return family.equals(os.family()) && name.equals(os.name());
+		EnvironmentProperty property = (EnvironmentProperty) object;
+		return family.equals(property.family()) && name.equals(property.name());
 	}
 
 	@Override

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Computer.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Computer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further development
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.inspection.hardware;
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Computer.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Computer.java
@@ -17,7 +17,7 @@ import org.eclipse.passage.lic.base.inspection.BaseEnvironmentProperty;
 public abstract class Computer extends BaseEnvironmentProperty {
 
 	protected Computer(String name) {
-		super("system", name); //$NON-NLS-1$
+		super("computer", name); //$NON-NLS-1$
 	}
 
 	public static final class Manufacturer extends Computer {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Cpu.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Cpu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 ArSysOp
+ * Copyright (c) 2020 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation, further development
+ *     ArSysOp - initial API and implementation
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.inspection.hardware;
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Cpu.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/inspection/hardware/Cpu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further development
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.inspection.hardware;
 

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/inspection/hardware/OshiPropertiesTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/inspection/hardware/OshiPropertiesTest.java
@@ -1,0 +1,69 @@
+package org.eclipse.passage.lic.internal.base.tests.inspection.hardware;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.eclipse.passage.lic.api.inspection.EnvironmentProperty;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.BaseBoard;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.Computer;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.Cpu;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.Disk;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.Firmware;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.NetworkInterface;
+import org.eclipse.passage.lic.internal.base.inspection.hardware.OS;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public final class OshiPropertiesTest {
+
+	@Test
+	public void allDifferent() {
+		// having
+		AtomicInteger additions = new AtomicInteger(0);
+		// when
+		Set<EnvironmentProperty> all = eachAndEveryProperty(additions);
+		// then
+		assertEquals(additions.get(), all.size());
+	}
+
+	private Set<EnvironmentProperty> eachAndEveryProperty(AtomicInteger additions) {
+		return Arrays.asList(//
+				new BaseBoard.Manufacturer(), //
+				new BaseBoard.Model(), //
+				new BaseBoard.Serial(), //
+				new BaseBoard.Version(), //
+				new Computer.Manufacturer(), //
+				new Computer.Model(), //
+				new Computer.Serial(), //
+				new Cpu.Identifier(), //
+				new Cpu.Family(), //
+				new Cpu.Model(), //
+				new Cpu.Name(), //
+				new Cpu.ProcessorId(), //
+				new Cpu.Vendor(), //
+				new Disk.Model(), //
+				new Disk.Name(), //
+				new Disk.Serial(), //
+				new Firmware.Description(), //
+				new Firmware.Manufacturer(), //
+				new Firmware.Name(), //
+				new Firmware.ReleaseDate(), //
+				new Firmware.Version(), //
+				new NetworkInterface.DisplayName(), //
+				new NetworkInterface.HwAddress(), //
+				new NetworkInterface.MacAddress(), //
+				new NetworkInterface.Name(), //
+				new OS.BuildNumber(), //
+				new OS.Family(), //
+				new OS.Manufacturer(), //
+				new OS.Version()//
+		).stream()//
+				.peek(property -> additions.incrementAndGet())//
+				.collect(Collectors.toSet());
+
+	}
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/inspection/hardware/OshiPropertiesTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/inspection/hardware/OshiPropertiesTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.tests.inspection.hardware;
 
 import static org.junit.Assert.assertEquals;
@@ -23,11 +35,11 @@ public final class OshiPropertiesTest {
 	@Test
 	public void allDifferent() {
 		// having
-		AtomicInteger additions = new AtomicInteger(0);
+		AtomicInteger amount = new AtomicInteger(0);
 		// when
-		Set<EnvironmentProperty> all = eachAndEveryProperty(additions);
+		Set<EnvironmentProperty> all = eachAndEveryProperty(amount);
 		// then
-		assertEquals(additions.get(), all.size());
+		assertEquals(amount.get(), all.size());
 	}
 
 	private Set<EnvironmentProperty> eachAndEveryProperty(AtomicInteger additions) {


### PR DESCRIPTION
`computer` properties belong to dedicated family

Closes #1096 