### PR TITLE
Add command line option -server.bindaddress

### DIFF
--- a/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.jrtty
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.jetty;singleton:=true
-Bundle-Version: 0.1.200.qualifier
+Bundle-Version: 0.1.300.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyServer.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyServer.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jetty;
 
+import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -21,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.passage.lic.internal.jetty.i18n.Messages;
 import org.eclipse.passage.lic.internal.net.connect.Port;
+import org.eclipse.passage.lic.internal.net.connect.BindAddress;
 
 public final class JettyServer {
 
@@ -33,12 +35,14 @@ public final class JettyServer {
 		this.handler = handler;
 	}
 
-	public void launch(Port port) throws JettyException {
+	public void launch(BindAddress listen, Port port) throws JettyException {
 		try {
-			server = Optional.of(new Server(port.get().get()));
+			InetSocketAddress address = InetSocketAddress.createUnresolved(listen.get().get(),
+					port.get().get());
+			server = Optional.of(new Server(address));
 			server.get().setHandler(handler.get());
 			server.get().start();
-			log.info(String.format(Messages.started, port.get().get()));
+			log.info(String.format(Messages.started, address));
 		} catch (Exception e) {
 			logAndRethrow(e, Messages.error_onstart);
 		}

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.properties
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/i18n/Messages.properties
@@ -11,7 +11,7 @@
 #     ArSysOp - initial API and implementation
 ###############################################################################
 
-server_started=Server started on port %s \n
+server_started=Server started on address:port %s \n
 server_stopped=Server stopped \n
 server_already_running=Server is already running \n
 server_not_running=No running server found \n

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/connect/BindAddress.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/connect/BindAddress.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IILS mbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IILS mbH - implementation to specify server listen address
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.net.connect;
+
+import java.util.Optional;
+
+/**
+ * @since 2.5
+ */
+public final class BindAddress extends CliParameter<String> {
+
+	/**
+	 * @since 2.5
+	 */
+	public BindAddress() {
+		super("0.0.0.0"); //$NON-NLS-1$
+	}
+
+	public BindAddress(String lazy) {
+		super(lazy);
+	}
+
+	public BindAddress(String[] sources, String lazy) {
+		super(sources, lazy);
+	}
+
+	@Override
+	public String key() {
+		return "server.bindaddress"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected Optional<String> parse(String value) {
+		return Optional.of(value);
+	}
+
+}


### PR DESCRIPTION
This allows to specify the binding address of the fls in addition to the port.
If nothing is specified the wildcard 0.0.0.0 is used, that assumes to listen
on all available addresses.

Usage:
-server.bindaddress=192.168.123.123

This should also work with ipv6 addresses, however I cannot test this at the
moment.

The API Versions in ServerBindAdress.java have to be correct to the actual value.