### PR TITLE
Adapt Passage's Oomph-setup to 2.4.0 release and perform minor version bump

### DIFF
--- a/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.net
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.net
-Bundle-Version: 2.4.0.qualifier
+Bundle-Version: 2.5.0.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/bundles/org.eclipse.passage.lic.net/pom.xml
+++ b/bundles/org.eclipse.passage.lic.net/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.eclipse.passage</groupId>
 		<artifactId>org.eclipse.passage.bundles</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -192,7 +192,7 @@
           <repository
               url="https://download.eclipse.org/ecp/rt/1261/"/>
           <repository
-              url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.29/"/>
+              url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.30/"/>
           <repository
               url="https://download.eclipse.org/modeling/emf/query/updates/releases/R201805030653/"/>
           <repository
@@ -208,7 +208,7 @@
           <repository
               url="https://download.eclipse.org/modeling/mdt/uml2/updates/5.5/"/>
           <repository
-              url="https://download.eclipse.org/passage/updates/release/2.3.0/"/>
+              url="https://download.eclipse.org/passage/updates/release/2.4.0/"/>
           <repository
               url="https://download.eclipse.org/sirius/updates/releases/6.5.1/2020-09/"/>
           <repository
@@ -329,8 +329,6 @@
             name="">
           <repository
               url="https://download.eclipse.org/cbi/updates/license/"/>
-          <repository
-              url="https://download.eclipse.org/eclipse/updates/4.24-I-builds/I20220601-1800/"/>
           <repository
               url="https://download.eclipse.org/ecp/rt/1261/"/>
           <repository


### PR DESCRIPTION
This PR adapts Passage's Oomph-setup to the 2.4.0 release and performs the minor version bump, which is required by PDE's API tools due to https://github.com/eclipse-passage/passage/pull/1102.