### PR TITLE
Maintain collection-order in FeatureFilter and FeatureConditionPack

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/FeatureFilter.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/FeatureFilter.java
@@ -14,6 +14,7 @@ package org.eclipse.passage.lic.base;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -56,7 +57,7 @@ public final class FeatureFilter<T>
 				.map(target -> map.apply(target, feature))//
 				.filter(Optional::isPresent) //
 				.map(Optional::get) //
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/FeatureConditionPack.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/FeatureConditionPack.java
@@ -13,6 +13,7 @@
 package org.eclipse.passage.lic.base.conditions;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -49,7 +50,7 @@ public final class FeatureConditionPack implements ConditionPack {
 		// FIXME: work for CachingFunction
 		return parent.conditions().stream()//
 				.filter(condition -> condition.feature().equals(feature))//
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	@Override


### PR DESCRIPTION
This ensure the order implied by the order of services in the registry is maintained throughout the mining-process, as described in:
https://github.com/eclipse-passage/passage/issues/1105

@eparovyshnaya please have a look. I think it does not have a negative impact for Passage in general, but it would help me in my use-case. The documentation states nothing about if the element order is retained during filtering, therefore I think it is OK to change it from 'shuffling' to 'order-maintaining'. If you want, I can also add documentation that states that the order is now maintained.