### PR TITLE
Build with Tycho 2.7.4

### DIFF
--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -33,7 +33,7 @@
 		<build.label>${unqualifiedVersion}.${buildQualifier}</build.label>
 
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-passage/passage.git</tycho.scmUrl>
-		<tycho.version>2.7.1</tycho.version>
+		<tycho.version>2.7.4</tycho.version>
 		<cbi-plugins.version>1.3.1</cbi-plugins.version>
 
 		<tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -86,12 +86,8 @@
         name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
     <requirement
         name="org.eclipse.sirius.specifier.feature.group"/>
-    <requirement
-        name="org.sonatype.tycho.m2e.feature.feature.group"/>
     <repository
         url="https://download.eclipse.org/releases/2022-03/"/>
-    <repository
-        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <stream name="master">


### PR DESCRIPTION
The today released version 2.7.4 of Tycho is shipped with embedded [M2E lifecycle-mapping-metadata](https://github.com/eclipse/tycho/blob/tycho-2.7.4/RELEASE_NOTES.md#eclipse-m2e-lifecycle-mapping-metadata-embedded).
This makes the `org.sonatype.tycho.m2e` M2E-connector obsolete and allows to remove it from Passage's Oomph setup. That connector is incompatible with the upcoming M2E 2.0 release (and likely won't be adjusted).