### PR TITLE
Revert "Build with Tycho 2.7.4"

### DIFF
--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -33,7 +33,7 @@
 		<build.label>${unqualifiedVersion}.${buildQualifier}</build.label>
 
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-passage/passage.git</tycho.scmUrl>
-		<tycho.version>2.7.4</tycho.version>
+		<tycho.version>2.7.1</tycho.version>
 		<cbi-plugins.version>1.3.1</cbi-plugins.version>
 
 		<tycho-snapshot-repo.url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</tycho-snapshot-repo.url>

--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -86,8 +86,12 @@
         name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
     <requirement
         name="org.eclipse.sirius.specifier.feature.group"/>
+    <requirement
+        name="org.sonatype.tycho.m2e.feature.feature.group"/>
     <repository
         url="https://download.eclipse.org/releases/2022-03/"/>
+    <repository
+        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <stream name="master">


### PR DESCRIPTION
Reverts eclipse-passage/passage#1113

Passage 250 m1  fails on Jenkins

https://ci.eclipse.org/passage/job/passage-base/1424/console
```
[ERROR] Plugin org.eclipse.tycho.extras:tycho-pack200a-plugin:2.7.4 or one of its dependencies could not be resolved: org.eclipse.tycho.extras:tycho-pack200a-plugin:jar:2.7.4 was not found in https://repo.eclipse.org/content/repositories/tycho-snapshots/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of tycho-snapshots has elapsed or updates are forced
```
Let's try again later (for M2 probably), currently we have no resources for this. 