### PR TITLE
Support multiple required values for evaluation expressions

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/BerlinProtocolExpressionParseService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/BerlinProtocolExpressionParseService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.base.conditions.evaluation;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,7 +45,7 @@ public final class BerlinProtocolExpressionParseService implements ExpressionPar
 	@Override
 	public ParsedExpression parsed(String expression) throws ExpressionParsingException {
 		Objects.requireNonNull(expression);
-		Map<String, String> couples = new HashMap<>();
+		Map<String, List<String>> couples = new HashMap<>();
 		for (String segment : expression.split(separator)) {
 			addCouple(segment, couples);
 		}
@@ -55,14 +57,14 @@ public final class BerlinProtocolExpressionParseService implements ExpressionPar
 		return new SimpleMapExpression(protocol, couples);
 	}
 
-	private void addCouple(String segment, Map<String, String> couples) throws ExpressionParsingException {
+	private void addCouple(String segment, Map<String, List<String>> couples) throws ExpressionParsingException {
 		String[] couple = segment.split(mediator);
 		if (coupleIsInvalid(couple)) {
 			throw new ExpressionParsingException(String.format(//
 					ConditionsEvaluationMessages.getString("BerlinProtocolExpressionParseService.invalid_format"), //$NON-NLS-1$
 					segment));
 		}
-		couples.put(couple[0].trim(), couple[1].trim());
+		couples.computeIfAbsent(couple[0].trim(), k -> new ArrayList<>()).add(couple[1].trim());
 	}
 
 	private boolean coupleIsInvalid(String[] couple) {

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/SimpleMapExpression.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/SimpleMapExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.passage.lic.base.conditions.evaluation;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,10 +26,10 @@ import org.eclipse.passage.lic.api.conditions.evaluation.ParsedExpression;
  */
 public final class SimpleMapExpression implements ParsedExpression {
 
-	private final Map<String, String> checks;
+	private final Map<String, List<String>> checks;
 	private final ExpressionProtocol protocol;
 
-	public SimpleMapExpression(ExpressionProtocol protocol, Map<String, String> checks) {
+	public SimpleMapExpression(ExpressionProtocol protocol, Map<String, List<String>> checks) {
 		Objects.requireNonNull(protocol);
 		Objects.requireNonNull(checks);
 		this.protocol = protocol;
@@ -45,6 +46,14 @@ public final class SimpleMapExpression implements ParsedExpression {
 	}
 
 	public String expected(String key) {
+		List<String> list = checks.get(key);
+		return list != null ? list.get(0) : null;
+	}
+
+	/**
+	 * @since 2.5
+	 */
+	public List<String> expecteds(String key) {
 		return checks.get(key);
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/evaluation/SimpleMapExpressionEvaluationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,11 +41,13 @@ public final class SimpleMapExpressionEvaluationService implements ExpressionEva
 		verifyProtocol(expression);
 		SimpleMapExpression map = map(expression);
 		for (String key : map.keys()) {
-			boolean passed = equal(key, map.expected(key), assessor);
-			if (!passed) {
-				throw new ExpressionEvaluationException(String.format(ConditionsEvaluationMessages.getString(//
-						"SimpleMapExpressionEvaluationService.segment_fails_evaluation"), //$NON-NLS-1$
-						assessor.id().identifier(), key, map.expected(key)));
+			for (String expected : map.expecteds(key)) {
+				boolean passed = equal(key, expected, assessor);
+				if (!passed) {
+					throw new ExpressionEvaluationException(String.format(ConditionsEvaluationMessages.getString(//
+							"SimpleMapExpressionEvaluationService.segment_fails_evaluation"), //$NON-NLS-1$
+							assessor.id().identifier(), key, map.expected(key)));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In some cases it can be useful to require multiple different values for the same key in a hardware evaluation expression.
For example if one wants to require that multiple network-interfaces with different MAC-addresses are present.

This PR is a suggestion how this could be achieved. If you think this is a good approach, I can add some test-cases.
Furthermore it sometimes wanted to require that the specified list of values is exactly equals to actual values encountered in the system. For example one wants to ensure that exactly those network-interfaces with the MAC-addresses  specified in the license are present in the running system. But I think this will require some more work to implement.