### PR TITLE
Import-Package instead of Require-Bundle for javax and log4j and remove trivial pom.xml files

### DIFF
--- a/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.base/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lbc.base
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lbc.base
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -14,13 +14,13 @@ Require-Bundle: org.eclipse.osgi;bundle-version="0.0.0",
  org.eclipse.emf.ecore.xmi;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1",
  org.eclipse.passage.lic.equinox;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lbc.internal.base;x-friends:="org.eclipse.passage.lbc.jetty,org.eclipse.passage.lbc.base.tests,org.eclipse.passage.lic.hc.tests",
  org.eclipse.passage.lbc.internal.base.acquire;x-friends:="org.eclipse.passage.lbc.base.tests,org.eclipse.passage.lic.hc.tests",
  org.eclipse.passage.lbc.internal.base.api;x-internal:=true,
  org.eclipse.passage.lbc.internal.base.interaction;x-friends:="org.eclipse.passage.lbc.jetty",
  org.eclipse.passage.lbc.internal.base.mine;x-friends:="org.eclipse.passage.lbc.base.tests,org.eclipse.passage.lic.hc.tests"
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy
 Provide-Capability: licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent";version="2.0.0";name="FLS: Concurrent access to a feature grant for several users";level="info";provider="Eclipse Passage",
  licensing.feature;licensing.feature="org.eclipse.passage.lbc.acquire.concurrent.full";version="2.0.0";name="FLS: Concurrent access to a feature grant for any amount of users";level="error";provider="Eclipse Passage"

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.passage.lic.api;bundle-version="2.6.0";visibility:=reexport,
- org.apache.logging.log4j;bundle-version="2.17.1"
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="2.6.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.base,
  org.eclipse.passage.lic.base.access,
  org.eclipse.passage.lic.base.acquire,
@@ -32,3 +31,5 @@ Export-Package: org.eclipse.passage.lic.base,
  org.eclipse.passage.lic.internal.base.observatory;x-internal:=true,
  org.eclipse.passage.lic.internal.base.requirements;x-internal:=true,
  org.eclipse.passage.lic.internal.base.time;x-friends:="org.eclipse.passage.lic.base.tests"
+Import-Package: org.apache.logging.log4j;version="2.17.1",
+ org.apache.logging.log4j.core.config;version="2.17.1"

--- a/bundles/org.eclipse.passage.lic.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.equinox/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Require-Bundle: org.eclipse.osgi;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.osgi.services;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.api;bundle-version="2.6.0";visibility:=reexport,
- org.eclipse.passage.lic.base;bundle-version="2.6.0";visibility:=reexport,
- org.apache.logging.log4j;bundle-version="2.17.1"
+ org.eclipse.passage.lic.base;bundle-version="2.6.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.equinox,
  org.eclipse.passage.lic.equinox.access;x-friends:="org.eclipse.passage.lic.jetty",
  org.eclipse.passage.lic.equinox.acquire,
@@ -27,6 +26,7 @@ Export-Package: org.eclipse.passage.lic.equinox,
    org.eclipse.passage.loc.licenses.core,
    org.eclipse.passage.loc.users.core",
  org.eclipse.passage.lic.internal.equinox.i18n;x-internal:=true
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy
 Provide-Capability: licensing.management;licensing.management="equinox";version="1.0.0"
 

--- a/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.apache.logging.log4j;bundle-version="2.17.1",
- org.eclipse.osgi.services;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.api;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0",
@@ -19,3 +18,4 @@ Require-Bundle: org.apache.logging.log4j;bundle-version="2.17.1",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.execute
+Import-Package: org.apache.logging.log4j

--- a/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jetty/META-INF/MANIFEST.MF
@@ -2,14 +2,12 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.jrtty
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.jetty;singleton:=true
-Bundle-Version: 0.1.300.qualifier
+Bundle-Version: 0.1.400.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: javax.servlet;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1",
- org.eclipse.core.runtime;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.jetty.http;bundle-version="0.0.0",
  org.eclipse.jetty.server;bundle-version="0.0.0",
  org.eclipse.jetty.util;bundle-version="0.0.0",
@@ -18,4 +16,7 @@ Require-Bundle: javax.servlet;bundle-version="0.0.0",
  org.eclipse.passage.lic.net;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.internal.jetty;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lbc.jetty,org.eclipse.passage.lac.jetty",
  org.eclipse.passage.lic.internal.jetty.interaction;x-friends:="org.eclipse.passage.lbc.jetty"
+Import-Package: javax.servlet,
+ javax.servlet.http,
+ org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Require-Bundle: org.eclipse.osgi;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.jface;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.api;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.base;bundle-version="0.0.0";visibility:=reexport,
- org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1"
+ org.eclipse.passage.lic.equinox;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.internal.jface.dialogs.licensing;x-friends:="org.eclipse.passage.lic.e4.ui,org.eclipse.passage.loc.dashboard.ui,org.eclipse.passage.loc.licenses.ui",
  org.eclipse.passage.lic.internal.jface.i18n;x-internal:=true,
  org.eclipse.passage.lic.jface;x-friends:="org.eclipse.passage.loc.workbench",
@@ -34,4 +33,5 @@ Export-Package: org.eclipse.passage.lic.internal.jface.dialogs.licensing;x-frien
    org.eclipse.passage.loc.edit.ui,
    org.eclipse.passage.lic.agreements.e4.ui",
  org.eclipse.passage.lic.jface.widgets;x-friends:="org.eclipse.passage.loc.workbench"
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.lic.mail/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.mail/META-INF/MANIFEST.MF
@@ -2,15 +2,16 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.lic.mail
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.mail
-Bundle-Version: 0.2.200.qualifier
+Bundle-Version: 0.2.300.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: javax.activation;bundle-version="0.0.0",
- javax.mail;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.email;bundle-version="0.0.0";visibility:=reexport
 Export-Package: org.eclipse.passage.lic.internal.mail;x-internal=true
+Import-Package: javax.activation;version="1.0.0",
+ javax.mail,
+ javax.mail.internet
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.net/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.apache.logging.log4j;bundle-version="2.17.1",
- org.eclipse.emf.ecore.xmi;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="2.6.0";visibility:=reexport,
  org.eclipse.passage.lic.emf;bundle-version="2.6.0",
  org.eclipse.passage.lic.equinox;bundle-version="2.6.0"
@@ -36,4 +35,5 @@ Export-Package: org.eclipse.passage.lic.internal.net;
    org.eclipse.passage.lbc.jetty,
    org.eclipse.passage.lic.jetty",
  org.eclipse.passage.lic.internal.net.io;x-friends:="org.eclipse.passage.lbc.base,org.eclipse.passage.lic.hc"
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.loc.licenses.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.licenses.core/META-INF/MANIFEST.MF
@@ -2,13 +2,12 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.licenses.core
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.licenses.core;singleton:=true
-Bundle-Version: 2.0.102.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.apache.logging.log4j;bundle-version="2.17.1",
- org.eclipse.osgi;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.osgi;bundle-version="0.0.0",
  org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.email;bundle-version="0.0.0",
@@ -30,5 +29,6 @@ Export-Package: org.eclipse.passage.loc.internal.licenses;
  org.eclipse.passage.loc.internal.licenses.core;x-friends:="org.eclipse.passage.loc.dashboard.ui",
  org.eclipse.passage.loc.internal.licenses.core.i18n;x-internal:=true,
  org.eclipse.passage.loc.internal.licenses.core.request;x-friends:="org.eclipse.passage.loc.dashboard.ui,org.eclipse.passage.loc.licenses.ui"
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.passage.loc.licenses.emfforms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.licenses.emfforms/META-INF/MANIFEST.MF
@@ -2,13 +2,12 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.licenses.emfforms
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.licenses.emfforms;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.9.100.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: javax.inject;bundle-version="0.0.0",
- org.eclipse.core.databinding;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.core.databinding;bundle-version="0.0.0",
  org.eclipse.e4.core.contexts;bundle-version="0.0.0",
  org.eclipse.e4.core.di;bundle-version="0.0.0",
  org.eclipse.e4.ui.di;bundle-version="0.0.0",
@@ -43,4 +42,5 @@ Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.passage.loc.licenses.emfforms.parts;x-internal:=true,
  org.eclipse.passage.loc.licenses.emfforms.renderers;x-internal:=true
+Import-Package: javax.inject
 

--- a/bundles/org.eclipse.passage.loc.operator.seal/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.operator.seal/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0",
  org.eclipse.passage.lic.execute;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
- org.eclipse.passage.lic.oshi;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1"
+ org.eclipse.passage.lic.oshi;bundle-version="0.0.0"
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Service-Component: OSGI-INF/*.xml
 

--- a/bundles/org.eclipse.passage.loc.products.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.products.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.products.core
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.products.core
-Bundle-Version: 0.7.103.qualifier
+Bundle-Version: 0.7.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -15,8 +15,7 @@ Require-Bundle: org.eclipse.e4.core.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.products.edit;bundle-version="0.0.0",
  org.eclipse.passage.lic.products.model;bundle-version="0.0.0",
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
- org.eclipse.passage.lic.keys.model;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1"
+ org.eclipse.passage.lic.keys.model;bundle-version="0.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.passage.loc.internal.products;
   x-friends:="org.eclipse.passage.loc.products.emfforms,
@@ -28,4 +27,5 @@ Export-Package: org.eclipse.passage.loc.internal.products;
    org.eclipse.passage.loc.licenses.ui",
  org.eclipse.passage.loc.internal.products.core;x-internal:=true,
  org.eclipse.passage.loc.internal.products.core.i18n;x-internal:=true
+Import-Package: org.apache.logging.log4j;version="2.17.1"
 Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.passage.loc.users.emfforms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.users.emfforms/META-INF/MANIFEST.MF
@@ -2,13 +2,12 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.users.emfforms
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.users.emfforms;singleton:=true
-Bundle-Version: 0.7.1.qualifier
+Bundle-Version: 0.7.100.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: javax.inject;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.equinox.common;bundle-version="0.0.0",
  org.eclipse.core.databinding;bundle-version="0.0.0",
  org.eclipse.jface.databinding;bundle-version="0.0.0",
@@ -37,6 +36,7 @@ Require-Bundle: javax.inject;bundle-version="0.0.0",
  org.eclipse.passage.loc.users.ui;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.loc.users.emfforms.parts;x-internal:=true,
  org.eclipse.passage.loc.users.emfforms.renderers;x-internal:=true
+Import-Package: javax.inject
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml
 

--- a/bundles/org.eclipse.passage.loc.workbench.emfforms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.workbench.emfforms/META-INF/MANIFEST.MF
@@ -2,11 +2,12 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.workbench.emfforms
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.workbench.emfforms;singleton:=true
-Bundle-Version: 2.0.102.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Import-Package: javax.inject,
- javax.annotation;version="1.2.0"
+Import-Package: javax.annotation;version="1.2.0",
+ javax.inject,
+ org.apache.logging.log4j;version="2.17.1"
 Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.core.databinding;bundle-version="0.0.0",
  org.eclipse.jface;bundle-version="0.0.0";visibility:=reexport,
@@ -34,8 +35,7 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
  org.eclipse.passage.loc.workbench;bundle-version="0.0.0";visibility:=reexport,
- org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1"
+ org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.passage.loc.internal.workbench.emfforms;x-internal:=true,
  org.eclipse.passage.loc.internal.workbench.emfforms.i18n;x-internal:=true,

--- a/bundles/org.eclipse.passage.loc.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.passage.loc.workbench
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.workbench;singleton:=true
-Bundle-Version: 2.0.103.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
@@ -27,10 +27,10 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="0.0.0",
  org.eclipse.passage.lic.jface;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.products.model;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.loc.api;bundle-version="0.0.0",
- org.apache.logging.log4j;bundle-version="2.17.1",
  org.eclipse.passage.lic.e4.ui;bundle-version="0.0.0"
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
-  javax.inject;version="1.0.0"
+ javax.inject;version="1.0.0",
+ org.apache.logging.log4j;version="2.17.1"
 Export-Package: org.eclipse.passage.loc.internal.workbench;
   x-friends:="org.eclipse.passage.loc.licenses.ui,
    org.eclipse.passage.loc.users.ui,


### PR DESCRIPTION
Using Import-Package instead of Require-Bundle to specify dependencies in a Manifest.Mf is a general recommendation for OSGi.
It is especially useful for packages like javax.* or log4j that can have multiple provides (e.g. the traditional javax vs jakarta or other bundles that repackage them) from different sources (for example Eclipse-Orbit vs. Maven-Central).

Therefore this PR replaces all Require-Bundle directives for javax and log4j bundles by corresponding Package-Imports.

Additionally remove trivial pom.xml files.