### PR TITLE
Remove SLF4J Plugin from o.e.passage.lic.oshi feature

### DIFF
--- a/features/org.eclipse.passage.lbc.target.feature/feature.xml
+++ b/features/org.eclipse.passage.lbc.target.feature/feature.xml
@@ -66,4 +66,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.slf4j.api"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.eclipse.passage.lic.equinox.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.equinox.feature/feature.xml
@@ -53,11 +53,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.apache.logging.log4j"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/features/org.eclipse.passage.lic.oshi.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.oshi.feature/feature.xml
@@ -37,13 +37,6 @@
    </requires>
 
    <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.sun.jna"
          download-size="0"
          install-size="0"

--- a/releng/org.eclipse.passage.ldc.repository/category.xml
+++ b/releng/org.eclipse.passage.ldc.repository/category.xml
@@ -35,4 +35,6 @@
 		id="org.eclipse.passage.ldc.feature.source">
 		<category name="org.eclipse.passage.ldc.category.source" />
 	</feature>
+	<bundle id="org.slf4j.api"/>
+	<bundle id="org.slf4j.api.source"/>
 </site>

--- a/releng/org.eclipse.passage.ldc.repository/category.xml
+++ b/releng/org.eclipse.passage.ldc.repository/category.xml
@@ -37,4 +37,6 @@
 	</feature>
 	<bundle id="org.slf4j.api"/>
 	<bundle id="org.slf4j.api.source"/>
+	<bundle id="org.apache.logging.log4j"/>
+	<bundle id="org.apache.logging.log4j.source"/>
 </site>

--- a/releng/org.eclipse.passage.lic.repository/category.xml
+++ b/releng/org.eclipse.passage.lic.repository/category.xml
@@ -69,4 +69,6 @@
 		id="org.eclipse.passage.lic.jetty.feature.source">
 		<category name="org.eclipse.passage.lic.category.source" />
 	</feature>
+	<bundle id="org.slf4j.api"/>
+	<bundle id="org.slf4j.api.source"/>
 </site>

--- a/releng/org.eclipse.passage.lic.repository/category.xml
+++ b/releng/org.eclipse.passage.lic.repository/category.xml
@@ -71,4 +71,6 @@
 	</feature>
 	<bundle id="org.slf4j.api"/>
 	<bundle id="org.slf4j.api.source"/>
+	<bundle id="org.apache.logging.log4j"/>
+	<bundle id="org.apache.logging.log4j.source"/>
 </site>


### PR DESCRIPTION
If a Feature includes a Plugin, it usually includes it with a specific name and the version that was in the TP when the feature was build. This prevents consumers from using a slf4j bundle with different symbolic-name or different version in their TP or product.

This is part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588