### PR TITLE
Don't require log4j-core for o.e.passage.lic.base #1131

### DIFF
--- a/bundles/org.eclipse.passage.lbc.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lbc.jetty/META-INF/MANIFEST.MF
@@ -7,11 +7,12 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.passage.lic.net;bundle-version="0.0.0",
- org.eclipse.passage.lic.jetty;bundle-version="0.0.0",
- org.eclipse.core.runtime;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
+ org.eclipse.passage.lbc.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
- org.eclipse.passage.lbc.base;bundle-version="0.0.0"
+ org.eclipse.passage.lic.execute;bundle-version="0.0.0",
+ org.eclipse.passage.lic.jetty;bundle-version="0.0.0",
+ org.eclipse.passage.lic.net;bundle-version="0.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.passage.lbc.internal.jetty.FlsJettyActivator
 Export-Package: org.eclipse.passage.lbc.jetty

--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsJettyActivator.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/FlsJettyActivator.java
@@ -19,6 +19,7 @@ import org.eclipse.passage.lbc.internal.base.api.FloatingState;
 import org.eclipse.passage.lbc.internal.base.api.FloatingStateFromGear;
 import org.eclipse.passage.lbc.jetty.FlsCommandScope;
 import org.eclipse.passage.lic.equinox.io.FileFromBundle;
+import org.eclipse.passage.lic.internal.execute.Logging;
 import org.eclipse.passage.lic.internal.jetty.JettyHandler;
 import org.eclipse.passage.lic.internal.jetty.interaction.LicensedJettyActivator;
 import org.eclipse.passage.lic.internal.net.connect.Storage;
@@ -47,7 +48,11 @@ public final class FlsJettyActivator extends LicensedJettyActivator {
 	}
 
 	@Override
-	protected InputStream logConfig() throws Exception {
+	protected void configureLogging() {
+		new Logging(this::logConfig).configure();
+	}
+
+	private InputStream logConfig() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 		return new FileFromBundle(bundle, "config/log4j2.xml").get(); //$NON-NLS-1$
 	}

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -27,7 +27,6 @@ Export-Package: org.eclipse.passage.lic.base,
  org.eclipse.passage.lic.internal.base.access;x-internal:=true,
  org.eclipse.passage.lic.internal.base.conditions;x-internal:=true,
  org.eclipse.passage.lic.internal.base.inspection.hardware;x-friends:="org.eclipse.passage.loc.licenses.core,org.eclipse.passage.lic.oshi",
- org.eclipse.passage.lic.internal.base.logging;x-friends:="org.eclipse.passage.lic.jetty",
  org.eclipse.passage.lic.internal.base.observatory;x-internal:=true,
  org.eclipse.passage.lic.internal.base.requirements;x-internal:=true,
  org.eclipse.passage.lic.internal.base.time;x-friends:="org.eclipse.passage.lic.base.tests"

--- a/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.base/META-INF/MANIFEST.MF
@@ -30,5 +30,4 @@ Export-Package: org.eclipse.passage.lic.base,
  org.eclipse.passage.lic.internal.base.observatory;x-internal:=true,
  org.eclipse.passage.lic.internal.base.requirements;x-internal:=true,
  org.eclipse.passage.lic.internal.base.time;x-friends:="org.eclipse.passage.lic.base.tests"
-Import-Package: org.apache.logging.log4j;version="2.17.1",
- org.apache.logging.log4j.core.config;version="2.17.1"
+Import-Package: org.apache.logging.log4j;version="2.17.1"

--- a/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.execute/META-INF/MANIFEST.MF
@@ -16,5 +16,7 @@ Require-Bundle: org.eclipse.passage.lic.api;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="0.0.0"
-Export-Package: org.eclipse.passage.lic.execute
-Import-Package: org.apache.logging.log4j
+Export-Package: org.eclipse.passage.lic.execute,
+ org.eclipse.passage.lic.internal.execute;x-internal:=true
+Import-Package: org.apache.logging.log4j;version="2.17.1",
+ org.apache.logging.log4j.core.config;version="2.17.1"

--- a/bundles/org.eclipse.passage.lic.execute/src/org/eclipse/passage/lic/execute/DefaultFramework.java
+++ b/bundles/org.eclipse.passage.lic.execute/src/org/eclipse/passage/lic/execute/DefaultFramework.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
 package org.eclipse.passage.lic.execute;
 
@@ -24,11 +24,10 @@ import org.eclipse.passage.lic.base.BaseFramework;
 import org.eclipse.passage.lic.base.InvalidLicensedProduct;
 import org.eclipse.passage.lic.equinox.LicensedApplication;
 import org.eclipse.passage.lic.equinox.io.FileFromBundle;
-import org.eclipse.passage.lic.internal.base.logging.Logging;
+import org.eclipse.passage.lic.internal.execute.Logging;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
-@SuppressWarnings("restriction")
 public final class DefaultFramework extends BaseFramework {
 
 	private final Logger log;
@@ -65,7 +64,7 @@ public final class DefaultFramework extends BaseFramework {
 		return new FileFromBundle(//
 				FrameworkUtil.getBundle(getClass()), //
 				"config/log4j2.xml")//$NON-NLS-1$
-						.get();
+				.get();
 	}
 
 	private void logConfiguration() {

--- a/bundles/org.eclipse.passage.lic.execute/src/org/eclipse/passage/lic/internal/execute/Logging.java
+++ b/bundles/org.eclipse.passage.lic.execute/src/org/eclipse/passage/lic/internal/execute/Logging.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
-package org.eclipse.passage.lic.internal.base.logging;
+package org.eclipse.passage.lic.internal.execute;
 
 import java.io.InputStream;
 

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/interaction/LicensedJettyActivator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,13 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.jetty.interaction;
 
-import java.io.InputStream;
-
-import org.eclipse.passage.lic.internal.base.logging.Logging;
 import org.eclipse.passage.lic.internal.jetty.JettyHandler;
 import org.eclipse.passage.lic.internal.jetty.JettyServer;
 import org.osgi.framework.BundleActivator;
@@ -41,9 +38,7 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 		server.stop();
 	}
 
-	private void configureLogging() {
-		new Logging(this::logConfig).configure();
-	}
+	protected abstract void configureLogging();
 
 	private void registerCommands(BundleContext context) {
 		Commands commands = new Commands();
@@ -55,8 +50,6 @@ public abstract class LicensedJettyActivator implements BundleActivator {
 	protected abstract String name();
 
 	protected abstract JettyHandler handler();
-
-	protected abstract InputStream logConfig() throws Exception;
 
 	protected abstract void registerCustomCommands(BundleContext context);
 

--- a/bundles/org.eclipse.passage.loc.operator.seal/src/org/eclipse/passage/loc/operator/seal/OperatorFramework.java
+++ b/bundles/org.eclipse.passage.loc.operator.seal/src/org/eclipse/passage/loc/operator/seal/OperatorFramework.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2022 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
 package org.eclipse.passage.loc.operator.seal;
 
@@ -25,7 +25,7 @@ import org.eclipse.passage.lic.base.InvalidLicensedProduct;
 import org.eclipse.passage.lic.equinox.LicensedApplication;
 import org.eclipse.passage.lic.equinox.io.FileFromBundle;
 import org.eclipse.passage.lic.execute.FocusedAccessCycleConfiguration;
-import org.eclipse.passage.lic.internal.base.logging.Logging;
+import org.eclipse.passage.lic.internal.execute.Logging;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 


### PR DESCRIPTION
Inspired by #1132 
Move Logging class from LIC Base to LIC Execute
Rework LIC Jetty internal API to postpone log configuration 
Add (temporary until better solution) dependency from LBC Jetty to LIC Execute

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>