### PR TITLE
Remove org.bouncycastle bundles from LIC BC feature #1156

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
@@ -41,6 +41,7 @@
       <plugin id="org.bouncycastle.bcpg"/>
       <plugin id="org.bouncycastle.bcpkix"/>
       <plugin id="org.bouncycastle.bcprov"/>
+      <plugin id="org.bouncycastle.bcutil"/>
       <plugin id="org.eclipse.core.commands"/>
       <plugin id="org.eclipse.core.contenttype"/>
       <plugin id="org.eclipse.core.databinding"/>

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4FullFeatherProduct/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4FullFeatherProduct/$pluginId$.product
@@ -41,6 +41,7 @@
       <plugin id="org.bouncycastle.bcpg"/>
       <plugin id="org.bouncycastle.bcpkix"/>
       <plugin id="org.bouncycastle.bcprov"/>
+      <plugin id="org.bouncycastle.bcutil"/>
       <plugin id="org.eclipse.core.commands"/>
       <plugin id="org.eclipse.core.contenttype"/>
       <plugin id="org.eclipse.core.databinding"/>

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
@@ -41,6 +41,7 @@
       <plugin id="org.bouncycastle.bcpg"/>
       <plugin id="org.bouncycastle.bcpkix"/>
       <plugin id="org.bouncycastle.bcprov"/>
+      <plugin id="org.bouncycastle.bcutil"/>
       <plugin id="org.eclipse.core.commands"/>
       <plugin id="org.eclipse.core.contenttype"/>
       <plugin id="org.eclipse.core.databinding"/>

--- a/bundles/org.eclipse.passage.lic.bc/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.bc/META-INF/MANIFEST.MF
@@ -8,9 +8,15 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.bouncycastle.bcpg;bundle-version="0.0.0",
- org.bouncycastle.bcpkix;bundle-version="0.0.0",
- org.bouncycastle.bcprov;bundle-version="0.0.0",
- org.eclipse.passage.lic.api;bundle-version="2.6.0",
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="2.6.0",
  org.eclipse.passage.lic.base;bundle-version="2.6.0"
 Export-Package: org.eclipse.passage.lic.bc
+Import-Package: org.bouncycastle.bcpg;version="1.72.0",
+ org.bouncycastle.crypto.digests;version="1.72.0",
+ org.bouncycastle.jce;version="1.72.0",
+ org.bouncycastle.jce.provider;version="1.72.0",
+ org.bouncycastle.openpgp;version="1.72.0",
+ org.bouncycastle.openpgp.bc;version="1.72.0",
+ org.bouncycastle.openpgp.jcajce;version="1.72.0",
+ org.bouncycastle.openpgp.operator;version="1.72.0",
+ org.bouncycastle.openpgp.operator.jcajce;version="1.72.0"

--- a/features/org.eclipse.passage.lic.bc.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.bc.feature/feature.xml
@@ -37,34 +37,6 @@
    </requires>
 
    <plugin
-         id="org.bouncycastle.bcpg"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.bouncycastle.bcpkix"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.bouncycastle.bcprov"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.bouncycastle.bcutil"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.passage.lic.bc"
          download-size="0"
          install-size="0"

--- a/releng/org.eclipse.passage.lic.repository/category.xml
+++ b/releng/org.eclipse.passage.lic.repository/category.xml
@@ -69,8 +69,16 @@
 		id="org.eclipse.passage.lic.jetty.feature.source">
 		<category name="org.eclipse.passage.lic.category.source" />
 	</feature>
-	<bundle id="org.slf4j.api"/>
-	<bundle id="org.slf4j.api.source"/>
 	<bundle id="org.apache.logging.log4j"/>
 	<bundle id="org.apache.logging.log4j.source"/>
+	<bundle id="org.bouncycastle.bcpg" />
+	<bundle id="org.bouncycastle.bcpg.source" />
+	<bundle id="org.bouncycastle.bcpkix" />
+	<bundle id="org.bouncycastle.bcpkix.source" />
+	<bundle id="org.bouncycastle.bcprov" />
+	<bundle id="org.bouncycastle.bcprov.source" />
+	<bundle id="org.bouncycastle.bcutil" />
+	<bundle id="org.bouncycastle.bcutil.source" />
+	<bundle id="org.slf4j.api"/>
+	<bundle id="org.slf4j.api.source"/>
 </site>


### PR DESCRIPTION
Remove from org.bouncycastle bundles from feature
Switch from required bundle to package import
Add bcutil to template product manifests

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>