### PR TITLE
Use Import-Package to reference third-party dependencies

### DIFF
--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/META-INF/MANIFEST.MF
@@ -21,6 +21,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Copyright: %Bundle-Copyright
 Automatic-Module-Name: org.eclipse.passage.ldc.pde.ui.templates
-Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
- javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedProductSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/BaseLicensedProductSection.java
@@ -174,7 +174,6 @@ public abstract class BaseLicensedProductSection extends BaseLicensingSection {
 
 	protected List<String> getRCP4xDependencies() {
 		return Arrays.asList(//
-				"javax.inject", //$NON-NLS-1$
 				"org.eclipse.core.runtime", //$NON-NLS-1$
 				"org.eclipse.swt", //$NON-NLS-1$
 				"org.eclipse.jface", //$NON-NLS-1$
@@ -186,8 +185,7 @@ public abstract class BaseLicensedProductSection extends BaseLicensingSection {
 				"org.eclipse.e4.core.contexts", //$NON-NLS-1$
 				"org.eclipse.passage.lic.equinox", //$NON-NLS-1$
 				"org.eclipse.passage.lic.e4.ui", //$NON-NLS-1$
-				"org.eclipse.passage.seal.demo", //$NON-NLS-1$
-				"org.apache.logging.log4j"); //$NON-NLS-1$
+				"org.eclipse.passage.seal.demo"); //$NON-NLS-1$
 	}
 
 	protected Requirement createProductRequirement(String product) {

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/e4/LicensedE4ProductContentWizard.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/e4/LicensedE4ProductContentWizard.java
@@ -24,4 +24,9 @@ public class LicensedE4ProductContentWizard extends NewPluginTemplateWizard {
 				new LicensedE4ProductTemplateSection(), //
 		};
 	}
+
+	@Override
+	public String[] getImportPackages() {
+		return new String[] { "javax.inject;version=\"[1.0.0,2.0.0)\"" }; //$NON-NLS-1$
+	}
 }

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/LicensedE4FullFeatherProductContentWizard.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/LicensedE4FullFeatherProductContentWizard.java
@@ -23,4 +23,9 @@ public final class LicensedE4FullFeatherProductContentWizard extends NewPluginTe
 				new LicensedE4FullFeatherProductTemplateSection(), //
 		};
 	}
+
+	@Override
+	public String[] getImportPackages() {
+		return new String[] { "javax.annotation;version=\"[1.3.0,2.0.0)\"" }; //$NON-NLS-1$
+	}
 }

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/LicensedE4FullFeatherProductTemplateSection.java
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/src/org/eclipse/passage/ldc/internal/pde/ui/templates/fullfeather/LicensedE4FullFeatherProductTemplateSection.java
@@ -137,7 +137,6 @@ public final class LicensedE4FullFeatherProductTemplateSection extends BaseLicen
 	@Override
 	protected List<String> getRCP4xDependencies() {
 		List<String> result = new ArrayList<>();
-		result.add("javax.annotation"); //$NON-NLS-1$
 		result.addAll(super.getRCP4xDependencies());
 		result.add("org.eclipse.passage.lic.execute"); //$NON-NLS-1$
 		result.remove("org.eclipse.passage.seal.demo"); //$NON-NLS-1$

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE3Product/$pluginId$.product
@@ -21,11 +21,6 @@
       <plugin id="com.fasterxml.jackson.core.jackson-core"/>
       <plugin id="com.fasterxml.jackson.core.jackson-databind"/>
       <plugin id="com.github.oshi.oshi-core"/>
-      <plugin id="com.ibm.icu"/>
-      <plugin id="com.sun.jna"/>
-      <plugin id="com.sun.jna.platform"/>
-      <plugin id="javax.annotation"/>
-      <plugin id="javax.inject"/>
       <plugin id="org.apache.batik.constants"/>
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.i18n"/>

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4FullFeatherProduct/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4FullFeatherProduct/$pluginId$.product
@@ -21,11 +21,6 @@
       <plugin id="com.fasterxml.jackson.core.jackson-core"/>
       <plugin id="com.fasterxml.jackson.core.jackson-databind"/>
       <plugin id="com.github.oshi.oshi-core"/>
-      <plugin id="com.ibm.icu"/>
-      <plugin id="com.sun.jna"/>
-      <plugin id="com.sun.jna.platform"/>
-      <plugin id="javax.annotation"/>
-      <plugin id="javax.inject"/>
       <plugin id="org.apache.batik.constants"/>
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.i18n"/>

--- a/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
+++ b/bundles/org.eclipse.passage.ldc.pde.ui.templates/templates/LicensedE4Product/$pluginId$.product
@@ -21,11 +21,6 @@
       <plugin id="com.fasterxml.jackson.core.jackson-core"/>
       <plugin id="com.fasterxml.jackson.core.jackson-databind"/>
       <plugin id="com.github.oshi.oshi-core"/>
-      <plugin id="com.ibm.icu"/>
-      <plugin id="com.sun.jna"/>
-      <plugin id="com.sun.jna.platform"/>
-      <plugin id="javax.annotation"/>
-      <plugin id="javax.inject"/>
       <plugin id="org.apache.batik.constants"/>
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.i18n"/>

--- a/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.jface/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="0.0.0";visibility:=re
  org.eclipse.jface;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.api;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.passage.lic.base;bundle-version="0.0.0";visibility:=reexport,
- org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
- slf4j.api;bundle-version="1.7.36"
+ org.eclipse.passage.lic.equinox;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.internal.jface.dialogs.licensing;x-friends:="org.eclipse.passage.lic.e4.ui,org.eclipse.passage.loc.dashboard.ui,org.eclipse.passage.loc.licenses.ui",
  org.eclipse.passage.lic.internal.jface.i18n;x-internal:=true,
  org.eclipse.passage.lic.jface;x-friends:="org.eclipse.passage.loc.workbench",
@@ -33,4 +32,5 @@ Export-Package: org.eclipse.passage.lic.internal.jface.dialogs.licensing;x-frien
    org.eclipse.passage.loc.edit.ui,
    org.eclipse.passage.lic.agreements.e4.ui",
  org.eclipse.passage.lic.jface.widgets;x-friends:="org.eclipse.passage.loc.workbench"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.lic.oshi/META-INF/MANIFEST.MF
@@ -7,11 +7,11 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: com.sun.jna;bundle-version="5.12.0",
- com.sun.jna.platform;bundle-version="5.12.0",
- com.github.oshi.oshi-core;bundle-version="6.2.2",
- org.eclipse.passage.lic.api;bundle-version="2.8.0",
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="2.8.0",
  org.eclipse.passage.lic.base;bundle-version="2.8.0"
 Export-Package: org.eclipse.passage.lic.oshi
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.osgi.util;version="1.0.0"
+Import-Package: org.eclipse.osgi.util;version="1.0.0",
+ oshi;version="[6.2.2,7.0.0)",
+ oshi.hardware;version="[6.2.2,7.0.0)",
+ oshi.software.os;version="[6.2.2,7.0.0)"

--- a/bundles/org.eclipse.passage.loc.report.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.passage.loc.report.core/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.apache.commons.csv;bundle-version="1.4.0",
- org.eclipse.passage.lic.licenses;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.passage.lic.licenses;bundle-version="0.0.0",
  org.eclipse.passage.lic.users;bundle-version="0.0.0",
  org.eclipse.passage.loc.licenses.core;bundle-version="0.0.0",
  org.eclipse.passage.loc.products.core;bundle-version="0.0.0",
@@ -20,5 +19,6 @@ Export-Package: org.eclipse.passage.loc.report.internal.core.license;x-friends:=
    org.eclipse.passage.loc.report.ui,
    org.eclipse.passage.loc.users.ui,
    org.eclipse.passage.loc.licenses.ui"
+Import-Package: org.apache.commons.csv;version="[1.8.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/tests/org.eclipse.passage.lbc.base.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lbc.base.tests/META-INF/MANIFEST.MF
@@ -10,9 +10,9 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0",
  org.eclipse.passage.lic.licenses.model;bundle-version="0.0.0",
- org.junit;bundle-version="4.12.0",
  org.eclipse.passage.lbc.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.net;bundle-version="0.0.0",
  org.eclipse.passage.lic.emf;bundle-version="0.0.0",
  org.eclipse.passage.lbc.fls.gear;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lbc.base.tests;x-friends:="org.eclipse.passage.lic.hc.tests"
+Import-Package: org.junit

--- a/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lic.api;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="1.0.0"
 Export-Package: org.eclipse.passage.lic.api.tests;x-friends:="org.eclipse.passage.seal.demo.tests",
  org.eclipse.passage.lic.api.tests.conditions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.conditions.evaluation;x-internal:=true,
@@ -24,3 +23,4 @@ Export-Package: org.eclipse.passage.lic.api.tests;x-friends:="org.eclipse.passag
  org.eclipse.passage.lic.api.tests.registry;x-internal:=true,
  org.eclipse.passage.lic.api.tests.resrictions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.version;x-internal:=true
+Import-Package: org.junit

--- a/tests/org.eclipse.passage.lic.base.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.base.tests/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.passage.lic.api.tests;bundle-version="1.0.0",
- org.eclipse.passage.lic.base;bundle-version="1.0.0",
- org.junit;bundle-version="4.12.0"
+ org.eclipse.passage.lic.base;bundle-version="1.0.0"
 Export-Package: org.eclipse.passage.lic.internal.base.tests.requirements;x-internal:=true
+Import-Package: org.junit,
+ org.junit.rules

--- a/tests/org.eclipse.passage.lic.bc.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.bc.tests/META-INF/MANIFEST.MF
@@ -3,11 +3,12 @@ Automatic-Module-Name: org.eclipse.passage.lic.bc.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.bc.tests
 Bundle-Version: 2.8.0.qualifier
+Import-Package: org.junit,
+ org.junit.rules
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lic.api;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0"

--- a/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.emf
-Require-Bundle: org.junit;bundle-version="0.0.0"
+Import-Package: org.junit
 Export-Package: org.eclipse.passage.lic.emf.meta

--- a/tests/org.eclipse.passage.lic.equinox.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.equinox.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Fragment-Host: org.eclipse.passage.lic.equinox
-Require-Bundle: org.junit;bundle-version="0.0.0",
- org.eclipse.equinox.event;bundle-version="0.0.0",
+Import-Package: org.junit
+Require-Bundle: org.eclipse.equinox.event;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox.tests.data.requirements;bundle-version="0.1.0",
  org.eclipse.passage.lic.base.tests;bundle-version="1.0.0",

--- a/tests/org.eclipse.passage.lic.features.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.features.model.tests/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.features.model
-Require-Bundle: org.junit;bundle-version="4.12.0"
+Import-Package: org.junit

--- a/tests/org.eclipse.passage.lic.hc.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.hc.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.hc
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lbc.base;bundle-version="1.0.0",
+Import-Package: org.junit,
+ org.junit.rules
+Require-Bundle: org.eclipse.passage.lbc.base;bundle-version="1.0.0",
  org.eclipse.passage.lbc.base.tests;bundle-version="1.0.100",
  org.eclipse.passage.lic.bc;bundle-version="1.0.100"

--- a/tests/org.eclipse.passage.lic.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.jface.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="0.0.0",
- org.eclipse.equinox.preferences;bundle-version="0.0.0"
+Require-Bundle: org.eclipse.equinox.preferences;bundle-version="0.0.0"
 Export-Package: org.eclipse.passage.lic.jface.tests
 Fragment-Host: org.eclipse.passage.lic.jface
+Import-Package: org.junit

--- a/tests/org.eclipse.passage.lic.json.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.json.tests/META-INF/MANIFEST.MF
@@ -8,6 +8,6 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.json
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lic.api.tests;bundle-version="0.1.0"
+Import-Package: org.junit
+Require-Bundle: org.eclipse.passage.lic.api.tests;bundle-version="0.1.0"
 Export-Package: org.eclipse.passage.lic.json.tests;x-internal:=true

--- a/tests/org.eclipse.passage.lic.licenses.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.licenses.model.tests/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Fragment-Host: org.eclipse.passage.lic.licenses.model
+Import-Package: org.junit,
+ org.junit.rules
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lic.api.tests;bundle-version="1.0.1"
+Require-Bundle: org.eclipse.passage.lic.api.tests;bundle-version="1.0.1"

--- a/tests/org.eclipse.passage.lic.net.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.net.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.net
-Require-Bundle: org.junit;bundle-version="4.12.0"
-
+Import-Package: org.junit,
+ org.junit.rules,
+ org.junit.runner,
+ org.junit.runners

--- a/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
@@ -3,13 +3,12 @@ Automatic-Module-Name: org.eclipse.passage.lic.oshi.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.oshi.tests
 Bundle-Version: 2.8.0.qualifier
+Import-Package: org.junit
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- com.github.oshi.oshi-core;bundle-version="0.0.0",
- org.eclipse.passage.lic.api;bundle-version="1.0.0",
+Require-Bundle: org.eclipse.passage.lic.api;bundle-version="1.0.0",
  org.eclipse.passage.lic.base;bundle-version="1.0.0",
  org.eclipse.passage.lic.oshi;bundle-version="1.0.0",
  org.eclipse.passage.lic.api.tests;bundle-version="1.0.0"

--- a/tests/org.eclipse.passage.lic.products.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.products.model.tests/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Fragment-Host: org.eclipse.passage.lic.products.model
+Import-Package: org.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/tests/org.eclipse.passage.lic.users.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.users.model.tests/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.lic.users.model
-Require-Bundle: org.junit;bundle-version="4.12.0"
+Import-Package: org.junit

--- a/tests/org.eclipse.passage.loc.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.api.tests/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Fragment-Host: org.eclipse.passage.loc.api
+Import-Package: org.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/tests/org.eclipse.passage.loc.billing.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.billing.core.tests/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Automatic-Module-Name: org.eclipse.passage.loc.billing.core.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.billing.core.tests
 Bundle-Version: 2.8.0.qualifier
+Import-Package: org.junit
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.loc.billing.core;bundle-version="0.1.0",
+Require-Bundle: org.eclipse.passage.loc.billing.core;bundle-version="0.1.0",
  org.eclipse.passage.lic.users;bundle-version="1.0.0"

--- a/tests/org.eclipse.passage.loc.features.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.features.core.tests/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Automatic-Module-Name: org.eclipse.passage.loc.features.core.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.features.core.tests
 Bundle-Version: 2.8.0.qualifier
+Import-Package: org.junit
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.passage.loc.features.core;bundle-version="0.5.0",
- org.junit;bundle-version="4.12.0"
+Require-Bundle: org.eclipse.passage.loc.features.core;bundle-version="0.5.0"

--- a/tests/org.eclipse.passage.loc.report.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.report.core.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.passage.loc.licenses.core;bundle-version="0.6.0",
  org.eclipse.passage.loc.users.core;bundle-version="1.0.0",
- org.junit;bundle-version="4.12.0",
  org.eclipse.passage.lic.base;bundle-version="1.0.202"
 Fragment-Host: org.eclipse.passage.loc.report.core
+Import-Package: org.junit
 

--- a/tests/org.eclipse.passage.loc.workbench.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.workbench.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.loc.workbench
-Require-Bundle: org.eclipse.emf.ecore.edit;bundle-version="0.0.0",
- org.junit;bundle-version="4.12.0"
+Import-Package: org.junit
+Require-Bundle: org.eclipse.emf.ecore.edit;bundle-version="0.0.0"

--- a/tests/org.eclipse.passage.loc.yars.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.loc.yars.api.tests/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Automatic-Module-Name: org.eclipse.passage.loc.yars.api.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.loc.yars.api.tests
 Bundle-Version: 2.8.0.qualifier
+Import-Package: org.junit
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.loc.yars.api;bundle-version="0.1.0"
+Require-Bundle: org.eclipse.passage.loc.yars.api;bundle-version="0.1.0"

--- a/tests/org.eclipse.passage.seal.demo.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.seal.demo.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,9 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.passage.seal.demo
-Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.passage.lic.api.tests;bundle-version="0.0.0",
+Import-Package: org.junit,
+ org.junit.rules
+Require-Bundle: org.eclipse.passage.lic.api.tests;bundle-version="0.0.0",
  org.eclipse.passage.lic.api;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox;bundle-version="0.0.0",
  org.eclipse.passage.lic.bc;bundle-version="0.0.0",


### PR DESCRIPTION
Use Import-Package to reference third-party dependencies in passage's Plugins and templates. 
Additionally remove unnecessary dependencies Plugins and Templates.

Also remove them as explicitly content from template-products (they are included implicitly if necessary).

In contrast to production Plug-ins  don't use a version range for dependencies of Test-Plugins because the Target-Platform defines and controls a closed environment in which the tests run. Because a version range is therefore not necessary for Test-Plugins, the version range can be omitted in order to simplify version updates.

Fixes https://github.com/eclipse-passage/passage/issues/1224