### PR TITLE
Move to GEF 3.18.0M1

### DIFF
--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -67,7 +67,7 @@
 			<unit id="org.eclipse.sirius.runtime.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/gef/classic/releases/3.16.0/"/>
+			<repository location="https://download.eclipse.org/tools/gef/classic/releases/3.18.0M1/"/>
 			<unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
file:/home/jenkins/agent/workspace/passage-base/releng/org.eclipse.passage.target/org.eclipse.passage.target.target: Failed to load p2 metadata repository from location https://download.eclipse.org/tools/gef/classic/releases/3.16.0/: No repository found at
https://download.eclipse.org/tools/gef/classic/releases/3.16.0.

Move to GEF 3.18.0M1