### PR TITLE
[FLS] Provide mean to obtain the remote address that send a request

### DIFF
--- a/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/StatedRequest.java
+++ b/bundles/org.eclipse.passage.lbc.jetty/src/org/eclipse/passage/lbc/internal/jetty/StatedRequest.java
@@ -35,6 +35,11 @@ final class StatedRequest implements RawRequest {
 	}
 
 	@Override
+	public String remoteAddress() {
+		return delegate.remoteAddress();
+	}
+
+	@Override
 	public byte[] content() throws IOException {
 		return delegate.content();
 	}

--- a/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyRequest.java
+++ b/bundles/org.eclipse.passage.lic.jetty/src/org/eclipse/passage/lic/internal/jetty/JettyRequest.java
@@ -37,6 +37,11 @@ public final class JettyRequest implements NetRequest {
 	}
 
 	@Override
+	public String remoteAddress() {
+		return Request.getRemoteAddr(origin);
+	}
+
+	@Override
 	public byte[] content() throws IOException {
 		//FIXME: AF: field can be null
 		HttpField field = origin.getHeaders().getField(HttpHeader.CONTENT_LENGTH);

--- a/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequest.java
+++ b/bundles/org.eclipse.passage.lic.net/src/org/eclipse/passage/lic/internal/net/api/handle/NetRequest.java
@@ -18,6 +18,15 @@ public interface NetRequest {
 
 	String parameter(String name);
 
+	/**
+	 * Returns the address of the remote that send this request.
+	 * <p>
+	 * By default, this is the first hop of the underlying network connection, but
+	 * it may be wrapped to represent a more remote end point.
+	 * </p>
+	 */
+	String remoteAddress();
+
 	byte[] content() throws IOException;
 
 }

--- a/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/RequestConstructed.java
+++ b/tests/org.eclipse.passage.lbc.base.tests/src/org/eclipse/passage/lbc/base/tests/RequestConstructed.java
@@ -121,6 +121,11 @@ final class RequestConstructed {
 		}
 
 		@Override
+		public String remoteAddress() {
+			return null;
+		}
+
+		@Override
 		public byte[] content() throws IOException {
 			return content;
 		}

--- a/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/RawRequestFromConnection.java
+++ b/tests/org.eclipse.passage.lic.hc.tests/src/org/eclipse/passage/lic/internal/hc/tests/remote/RawRequestFromConnection.java
@@ -34,6 +34,11 @@ final class RawRequestFromConnection implements RawRequest {
 	}
 
 	@Override
+	public String remoteAddress() {
+		return null;
+	}
+
+	@Override
 	public byte[] content() throws IOException {
 		return connection.requestPayload();
 	}


### PR DESCRIPTION
Within the FLS it can be of interest to know the sender of a request, e.g. to log it somewhere.

This adds a corresponding `remoteAddress()` method to `NetRequest` to obtain it.

Alternatively `JettyRequest` could grant access to the `origin` Jetty `Request`, but this would add parts of Jetty's API to the API of Passage (but personally I would be perfectly fine with that too).