### PR TITLE
[#1272] Extend license assessment with context

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.base.restrictions;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
+import org.eclipse.passage.lic.api.requirements.Requirement;
+import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.api.restrictions.Restriction;
+
+/**
+ * 
+ * @since 2.11
+ */
+public final class CertificateIsSufficient implements Predicate<Optional<ExaminationCertificate>> {
+
+	private final String feature;
+
+	public CertificateIsSufficient(String feature) {
+		this.feature = Objects.requireNonNull(feature);
+	}
+
+	@Override
+	public boolean test(Optional<ExaminationCertificate> certificate) {
+		if (!certificate.isPresent()) {
+			return false;
+		}
+		if (anyRestrictionForFeature(certificate.get())) {
+			return false;
+		}
+		if (anyUnacceptedAgreementsForFeature(certificate.get())) {
+			return false;
+		}
+		return true;
+	}
+
+	private boolean anyRestrictionForFeature(ExaminationCertificate certificate) {
+		return certificate.restrictions().stream()//
+				.filter(this::notBearable)//
+				.anyMatch(this::relatesToFeature);
+	}
+
+	private boolean anyUnacceptedAgreementsForFeature(ExaminationCertificate certificate) {
+		return certificate.agreements().stream()//
+				.filter(this::notAccepted)//
+				.anyMatch(this::relatesToFeature);
+	}
+
+	private boolean notBearable(Restriction restriction) {
+		return new RequirementDemandsExecutionStop().test(restriction.unsatisfiedRequirement());
+	}
+
+	private boolean relatesToFeature(Restriction restriction) {
+		return relatesToFeature(restriction.unsatisfiedRequirement());
+	}
+
+	private boolean relatesToFeature(AgreementToAccept agreement) {
+		return relatesToFeature(agreement.origin());
+	}
+
+	private boolean relatesToFeature(Requirement reqirement) {
+		return feature.equals(reqirement.feature().identifier());
+	}
+
+	private boolean notAccepted(AgreementToAccept agreement) {
+		return !agreement.acceptance().accepted();
+	}
+
+}

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
@@ -41,7 +41,7 @@ public final class CertificateIsSufficient implements Predicate<Optional<Examina
 		if (anyRestrictionForFeature(certificate.get())) {
 			return false;
 		}
-		if (anyUnacceptedAgreementsForFeature(certificate.get())) {
+		if (anyAgreementForFeatureIsNotAccepted(certificate.get())) {
 			return false;
 		}
 		return true;
@@ -53,7 +53,7 @@ public final class CertificateIsSufficient implements Predicate<Optional<Examina
 				.anyMatch(this::relatesToFeature);
 	}
 
-	private boolean anyUnacceptedAgreementsForFeature(ExaminationCertificate certificate) {
+	private boolean anyAgreementForFeatureIsNotAccepted(ExaminationCertificate certificate) {
 		return certificate.agreements().stream()//
 				.filter(this::notAccepted)//
 				.anyMatch(this::relatesToFeature);

--- a/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/e4/ui/addons/E4LicensingAddon.java
+++ b/bundles/org.eclipse.passage.lic.e4.ui/src/org/eclipse/passage/lic/e4/ui/addons/E4LicensingAddon.java
@@ -36,6 +36,7 @@ import org.osgi.service.event.Event;
 /**
  * @since 2.1
  */
+@SuppressWarnings("restriction")
 public final class E4LicensingAddon {
 
 	private final IApplicationContext application;

--- a/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/jface/EquinoxPassageUI.java
+++ b/bundles/org.eclipse.passage.lic.jface/src/org/eclipse/passage/lic/jface/EquinoxPassageUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 ArSysOp
+ * Copyright (c) 2020, 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support
  *******************************************************************************/
 package org.eclipse.passage.lic.jface;
 
@@ -25,7 +26,7 @@ import org.eclipse.passage.lic.api.diagnostic.Trouble;
 import org.eclipse.passage.lic.api.diagnostic.TroubleCode;
 import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
 import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
-import org.eclipse.passage.lic.base.restrictions.CertificateWorthAttention;
+import org.eclipse.passage.lic.base.restrictions.CertificateIsSufficient;
 import org.eclipse.passage.lic.equinox.EquinoxPassage;
 import org.eclipse.passage.lic.equinox.EquinoxPassageLicenseCoverage;
 import org.eclipse.passage.lic.internal.jface.dialogs.licensing.DiagnosticDialog;
@@ -45,7 +46,7 @@ public final class EquinoxPassageUI implements PassageUI {
 		return investigate(//
 				() -> acquire(feature), //
 				GrantLockAttempt::certificate, //
-				new CertificateWorthAttention().negate());
+				new CertificateIsSufficient(feature));
 	}
 
 	@Override

--- a/tests/org.eclipse.passage.lic.api.tests/.settings/.api_filters
+++ b/tests/org.eclipse.passage.lic.api.tests/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.passage.lic.api.tests" version="2">
+    <resource path="src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeAgreementState.java" type="org.eclipse.passage.lic.api.tests.fakes.agreements.FakeAgreementState">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="AgreementState"/>
+                <message_argument value="FakeAgreementState"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeResolvedAgreement.java" type="org.eclipse.passage.lic.api.tests.fakes.agreements.FakeResolvedAgreement">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="ResolvedAgreement"/>
+                <message_argument value="FakeResolvedAgreement"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Export-Package: org.eclipse.passage.lic.api.tests;x-friends:="org.eclipse.passag
  org.eclipse.passage.lic.api.tests.conditions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.conditions.evaluation;x-internal:=true,
  org.eclipse.passage.lic.api.tests.conditions.mining;x-friends:="org.eclipse.passage.lic.json.tests",
+ org.eclipse.passage.lic.api.tests.fakes.agreements,
  org.eclipse.passage.lic.api.tests.fakes.conditions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation;x-internal:=true,
  org.eclipse.passage.lic.api.tests.fakes.conditions.mining;x-internal:=true,

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeAgreementState.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeAgreementState.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.fakes.agreements;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.agreements.AgreementState;
+import org.eclipse.passage.lic.api.diagnostic.Trouble;
+
+@SuppressWarnings("restriction")
+public final class FakeAgreementState implements AgreementState {
+
+	private final boolean accepted;
+
+	public FakeAgreementState(boolean accepted) {
+		this.accepted = accepted;
+	}
+
+	public FakeAgreementState() {
+		this(true);
+	}
+
+	@Override
+	public String name() {
+		return "fake"; //$NON-NLS-1$
+	}
+
+	@Override
+	public boolean accepted() {
+		return accepted;
+	}
+
+	@Override
+	public byte[] content() {
+		return new byte[0];
+	}
+
+	@Override
+	public Optional<Trouble> error() {
+		return Optional.empty();
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeResolvedAgreement.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/agreements/FakeResolvedAgreement.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.api.tests.fakes.agreements;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.passage.lic.api.agreements.ResolvedAgreement;
+
+@SuppressWarnings("restriction")
+public final class FakeResolvedAgreement implements ResolvedAgreement {
+
+	@Override
+	public InputStream content() throws IOException {
+		return new ByteArrayInputStream(new byte[0]);
+	}
+
+	@Override
+	public String path() {
+		return "not very much real path"; //$NON-NLS-1$
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/requirements/FakeRequirement.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/fakes/requirements/FakeRequirement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.fakes.requirements;
 
@@ -20,6 +21,7 @@ import org.eclipse.passage.lic.api.requirements.Feature;
 import org.eclipse.passage.lic.api.requirements.Requirement;
 import org.eclipse.passage.lic.api.restrictions.RestrictionLevel;
 
+@SuppressWarnings("restriction")
 public final class FakeRequirement implements Requirement {
 
 	private final Feature feature;

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/BasePermissionsExaminationServiceTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/BasePermissionsExaminationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support 
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.tests.restrictions;
 
@@ -81,20 +82,16 @@ public final class BasePermissionsExaminationServiceTest extends PermissionsExam
 		assertPermissionHasDoneItsWork(state.permissionSecond(), certificate);
 	}
 
-	private void assertPermissionHasDoneItsWork(Permission permission, ExaminationCertificate certificate) {
-		Collection<Requirement> satisfied = certificate.satisfied();
-		assertEquals(1, satisfied.size());
-		Permission satisfaction = certificate.satisfaction(satisfied.iterator().next());
-		assertEquals(permission, satisfaction);
-	}
-
 	@Test
 	public void detectsRequirementUnsatisfactionOnObsoleteCondition() {
+		// given:
 		TestState state = new TestState();
+		// when:
 		Collection<Restriction> restrictions = examiner(state::product).examine(//
 				Arrays.asList(state.requirementSecond()), //
 				Arrays.asList(state.permissionSecondObsolete()))//
 				.restrictions();
+		// then:
 		assertNotNull(restrictions);
 		assertEquals(1, restrictions.size());
 		Restriction restriction = restrictions.iterator().next();
@@ -122,6 +119,13 @@ public final class BasePermissionsExaminationServiceTest extends PermissionsExam
 		return new BasePermissionsExaminationService(//
 				new BaseAgreementAcceptanceService(() -> new ReadOnlyRegistry<>(new MD5Hashes()), product), //
 				product);
+	}
+
+	private void assertPermissionHasDoneItsWork(Permission permission, ExaminationCertificate certificate) {
+		Collection<Requirement> satisfied = certificate.satisfied();
+		assertEquals(1, satisfied.size());
+		Permission satisfaction = certificate.satisfaction(satisfied.iterator().next());
+		assertEquals(permission, satisfaction);
 	}
 
 	private void testSuccess(//

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsRestrictiveTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsRestrictiveTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.restrictions;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.base.restrictions.CertificateIsRestrictive;
+import org.junit.Test;
+
+public final class CertificateIsRestrictiveTest {
+
+	@Test
+	public void noCertificateMeansNoRestriction() {
+		assertTrue(new CertificateIsRestrictive().test(Optional.empty()));
+	}
+
+	@Test
+	public void onlyBearableRestrictions() {
+		assertFalse(new CertificateIsRestrictive().test(Optional.of(bearable())));
+	}
+
+	@Test
+	public void withSevereRestrictions() {
+		assertTrue(new CertificateIsRestrictive().test(Optional.of(severe())));
+	}
+
+	@Test
+	public void withAgreementRestrictions() {
+		assertTrue(new CertificateIsRestrictive().test(Optional.of(agreementNotAccepted())));
+	}
+
+	@Test
+	public void noRestrictions() {
+		assertFalse(new CertificateIsRestrictive().test(Optional.of(agreementAccepted())));
+	}
+
+	private ExaminationCertificate bearable() {
+		return new TestCertificates().onlyBearableRestrictions();
+	}
+
+	private ExaminationCertificate severe() {
+		return new TestCertificates().withSevereRestrictions();
+	}
+
+	private ExaminationCertificate agreementNotAccepted() {
+		return new TestCertificates().withAgreementRestrictions();
+	}
+
+	private ExaminationCertificate agreementAccepted() {
+		return new TestCertificates().agreementAccepted();
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsSufficientTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsSufficientTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.restrictions;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.base.restrictions.CertificateIsSufficient;
+import org.junit.Test;
+
+public final class CertificateIsSufficientTest {
+
+	@Test
+	public void absentCertificateIsNotSufficient() {
+		assertFalse(new CertificateIsSufficient("any").test(Optional.empty())); //$NON-NLS-1$
+	}
+
+	@Test
+	public void assessedFeatureIsRestricted() {
+		String feature = feature();
+		assertFalse(new CertificateIsSufficient(feature).test(Optional.of(severe(feature))));
+	}
+
+	@Test
+	public void notAssessedFeatureIsRestricted() {
+		String feature = feature();
+		assertTrue(new CertificateIsSufficient(feature).test(Optional.of(severe())));
+	}
+
+	@Test
+	public void assessedFeatureDemandsAgreementNotAccepted() {
+		String feature = feature();
+		Optional<ExaminationCertificate> certificate = Optional.of(agreementNotAccepted(feature));
+		assertFalse(new CertificateIsSufficient(feature).test(certificate));
+	}
+
+	@Test
+	public void notAssessedFeatureDemandsAgreementNotAccepted() {
+		String feature = feature();
+		assertTrue(new CertificateIsSufficient(feature).test(Optional.of(agreementNotAccepted())));
+	}
+
+	private String feature() {
+		return "feature-under-assessment-" + Long.toHexString(System.currentTimeMillis()); //$NON-NLS-1$
+	}
+
+	private ExaminationCertificate severe(String feature) {
+		return new TestCertificates().withSevereRestrictions(feature);
+	}
+
+	private ExaminationCertificate severe() {
+		return new TestCertificates().withSevereRestrictions();
+	}
+
+	private ExaminationCertificate agreementNotAccepted(String feature) {
+		return new TestCertificates().withAgreementRestrictions(feature);
+	}
+
+	private ExaminationCertificate agreementNotAccepted() {
+		return new TestCertificates().withAgreementRestrictions();
+	}
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/ExaminationExplainedTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/ExaminationExplainedTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,32 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.base.tests.restrictions;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
-import java.util.Collections;
-
-import org.eclipse.passage.lic.api.EvaluationType;
-import org.eclipse.passage.lic.api.LicensedProduct;
-import org.eclipse.passage.lic.api.diagnostic.TroubleCode;
 import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
-import org.eclipse.passage.lic.api.restrictions.RestrictionLevel;
-import org.eclipse.passage.lic.base.BaseLicensedProduct;
-import org.eclipse.passage.lic.base.conditions.BaseCondition;
-import org.eclipse.passage.lic.base.conditions.BaseEvaluationInstructions;
-import org.eclipse.passage.lic.base.conditions.BaseValidityPeriodClosed;
-import org.eclipse.passage.lic.base.conditions.BaseVersionMatch;
-import org.eclipse.passage.lic.base.conditions.MatchingRuleCompatible;
-import org.eclipse.passage.lic.base.conditions.UnknownConditionOrigin;
-import org.eclipse.passage.lic.base.conditions.evaluation.BasePermission;
-import org.eclipse.passage.lic.base.requirements.BaseFeature;
-import org.eclipse.passage.lic.base.requirements.BaseRequirement;
-import org.eclipse.passage.lic.base.restrictions.BaseExaminationCertificate;
-import org.eclipse.passage.lic.base.restrictions.BaseRestriction;
 import org.eclipse.passage.lic.base.restrictions.ExaminationExplained;
 import org.junit.Test;
 
@@ -46,7 +28,7 @@ public final class ExaminationExplainedTest {
 	}
 
 	@Test
-	public void explains() {
+	public void explainsSensibleCeritificate() {
 		String explanation = new ExaminationExplained(certificate()).get().trim();
 		assertFalse(explanation.isEmpty());
 		assertTrue(explanation.contains("woha!")); //$NON-NLS-1$
@@ -56,49 +38,7 @@ public final class ExaminationExplainedTest {
 	}
 
 	private ExaminationCertificate certificate() {
-		return new BaseExaminationCertificate(//
-				Collections.singletonMap(//
-						new BaseRequirement(//
-								new BaseFeature(//
-										"properly-licensed-feature", //$NON-NLS-1$
-										"1.2.3", //$NON-NLS-1$
-										"Feature to Succeed", //$NON-NLS-1$
-										"This test"), //$NON-NLS-1$
-								new RestrictionLevel.Of("oops"), //$NON-NLS-1$
-								"This test"), //$NON-NLS-1$
-						new BasePermission(//
-								product(), //
-								new BaseCondition(//
-										"condition-identifier", //$NON-NLS-1$
-										"properly-licensed-feature", //$NON-NLS-1$
-										new BaseVersionMatch("1.2.3", new MatchingRuleCompatible()), //$NON-NLS-1$
-										new BaseValidityPeriodClosed(//
-												ZonedDateTime.now().minusDays(11), //
-												ZonedDateTime.now().plusDays(11)),
-										new BaseEvaluationInstructions(//
-												new EvaluationType.Of("christmas"), //$NON-NLS-1$
-												"nose=red" //$NON-NLS-1$
-										)), //
-								ZonedDateTime.now(), //
-								ZonedDateTime.now().plusDays(2), //
-								new UnknownConditionOrigin())//
-				), //
-				Collections.singleton(//
-						new BaseRestriction(//
-								product(), //
-								new BaseRequirement(//
-										new BaseFeature(//
-												"failed-feature", //$NON-NLS-1$
-												"17.2.1", //$NON-NLS-1$
-												"Feature to fail", //$NON-NLS-1$
-												"This test"), //$NON-NLS-1$
-										new RestrictionLevel.Of("woha!"), //$NON-NLS-1$
-										"This test"), //$NON-NLS-1$
-								new TroubleCode.Of(777, "just do not like you")))); //$NON-NLS-1$
-	}
-
-	private LicensedProduct product() {
-		return new BaseLicensedProduct("Story", "2.12.75"); //$NON-NLS-1$//$NON-NLS-2$
+		return new TestCertificates().verbose();
 	}
 
 }

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/TestCertificates.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/TestCertificates.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.internal.base.tests.restrictions;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.passage.lic.api.EvaluationType;
+import org.eclipse.passage.lic.api.LicensedProduct;
+import org.eclipse.passage.lic.api.agreements.AgreementToAccept;
+import org.eclipse.passage.lic.api.diagnostic.TroubleCode;
+import org.eclipse.passage.lic.api.restrictions.ExaminationCertificate;
+import org.eclipse.passage.lic.api.restrictions.RestrictionLevel;
+import org.eclipse.passage.lic.api.tests.fakes.agreements.FakeAgreementState;
+import org.eclipse.passage.lic.api.tests.fakes.agreements.FakeResolvedAgreement;
+import org.eclipse.passage.lic.base.BaseLicensedProduct;
+import org.eclipse.passage.lic.base.agreements.BaseAgreementToAccept;
+import org.eclipse.passage.lic.base.agreements.UnacceptedAgreementRestriction;
+import org.eclipse.passage.lic.base.conditions.BaseCondition;
+import org.eclipse.passage.lic.base.conditions.BaseEvaluationInstructions;
+import org.eclipse.passage.lic.base.conditions.BaseValidityPeriodClosed;
+import org.eclipse.passage.lic.base.conditions.BaseVersionMatch;
+import org.eclipse.passage.lic.base.conditions.MatchingRuleCompatible;
+import org.eclipse.passage.lic.base.conditions.UnknownConditionOrigin;
+import org.eclipse.passage.lic.base.conditions.evaluation.BasePermission;
+import org.eclipse.passage.lic.base.diagnostic.code.LicenseDoesNotMatch;
+import org.eclipse.passage.lic.base.diagnostic.code.TentativeAccess;
+import org.eclipse.passage.lic.base.requirements.BaseFeature;
+import org.eclipse.passage.lic.base.requirements.BaseRequirement;
+import org.eclipse.passage.lic.base.restrictions.BaseExaminationCertificate;
+import org.eclipse.passage.lic.base.restrictions.BaseRestriction;
+
+@SuppressWarnings("restriction")
+final class TestCertificates {
+
+	ExaminationCertificate verbose() {
+		return new BaseExaminationCertificate(//
+				Collections.singletonMap(//
+						new BaseRequirement(//
+								new BaseFeature(//
+										"properly-licensed-feature", //$NON-NLS-1$
+										"1.2.3", //$NON-NLS-1$
+										"Feature to Succeed", //$NON-NLS-1$
+										"This test"), //$NON-NLS-1$
+								new RestrictionLevel.Of("oops"), //$NON-NLS-1$
+								"This test"), //$NON-NLS-1$
+						new BasePermission(//
+								product(), //
+								new BaseCondition(//
+										"condition-identifier", //$NON-NLS-1$
+										"properly-licensed-feature", //$NON-NLS-1$
+										new BaseVersionMatch("1.2.3", new MatchingRuleCompatible()), //$NON-NLS-1$
+										new BaseValidityPeriodClosed(//
+												ZonedDateTime.now().minusDays(11), //
+												ZonedDateTime.now().plusDays(11)),
+										new BaseEvaluationInstructions(//
+												new EvaluationType.Of("christmas"), //$NON-NLS-1$
+												"nose=red" //$NON-NLS-1$
+										)), //
+								ZonedDateTime.now(), //
+								ZonedDateTime.now().plusDays(2), //
+								new UnknownConditionOrigin())//
+				), //
+				Collections.singleton(//
+						new BaseRestriction(//
+								product(), //
+								new BaseRequirement(//
+										new BaseFeature(//
+												"failed-feature", //$NON-NLS-1$
+												"17.2.1", //$NON-NLS-1$
+												"Feature to fail", //$NON-NLS-1$
+												"This test"), //$NON-NLS-1$
+										new RestrictionLevel.Of("woha!"), //$NON-NLS-1$
+										"This test"), //$NON-NLS-1$
+								new TroubleCode.Of(777, "just do not like you"))) //$NON-NLS-1$
+		);
+	}
+
+	ExaminationCertificate onlyBearableRestrictions() {
+		return new BaseExaminationCertificate(//
+				Collections.emptyMap(), // no permissions
+				Collections.singleton(//
+						new BaseRestriction(//
+								product(), //
+								warningProtectedFeature(), //
+								new TentativeAccess()))//
+		);
+	}
+
+	ExaminationCertificate withSevereRestrictions() {
+		return withSevereRestrictions("very-much-protected-feature"); //$NON-NLS-1$
+	}
+
+	ExaminationCertificate withSevereRestrictions(String feature) {
+		return new BaseExaminationCertificate(//
+				Collections.emptyMap(), // no permissions
+				Collections.singleton(//
+						new BaseRestriction(//
+								product(), //
+								errorProtectedFeature(feature), //
+								new LicenseDoesNotMatch())//
+				));
+	}
+
+	ExaminationCertificate withAgreementRestrictions() {
+		return withAgreementRestrictions("not-very-much-protected-feature"); //$NON-NLS-1$
+	}
+
+	ExaminationCertificate withAgreementRestrictions(String feature) {
+		AgreementToAccept agreement = new BaseAgreementToAccept(//
+				warningProtectedFeature(feature), //
+				new FakeResolvedAgreement(), //
+				new FakeAgreementState(false));
+		return new BaseExaminationCertificate(//
+				Collections.emptyMap(), // no permissions
+				List.of(new UnacceptedAgreementRestriction(product(), agreement).get()), //
+				List.of(agreement)//
+		);
+	}
+
+	ExaminationCertificate agreementAccepted() {
+		AgreementToAccept agreement = new BaseAgreementToAccept(//
+				warningProtectedFeature(), //
+				new FakeResolvedAgreement(), //
+				new FakeAgreementState(true));
+		return new BaseExaminationCertificate(//
+				Collections.emptyMap(), // no permissions
+				Collections.emptyList(), // no restrictions
+				List.of(agreement)//
+		);
+	}
+
+	private LicensedProduct product() {
+		return new BaseLicensedProduct("Story", "2.12.75"); //$NON-NLS-1$//$NON-NLS-2$
+	}
+
+	private BaseRequirement warningProtectedFeature() {
+		return warningProtectedFeature("not-very-much-protected-feature"); //$NON-NLS-1$
+	}
+
+	private BaseRequirement warningProtectedFeature(String feature) {
+		return new BaseRequirement(//
+				new BaseFeature(//
+						feature, //
+						"0.0.1", //$NON-NLS-1$
+						"Feature for a user to try, but notably", //$NON-NLS-1$
+						"Does not need to be error-level protected"), //$NON-NLS-1$
+				new RestrictionLevel.Warning(), //
+				"Requirement is not mandatory to satisfy");//$NON-NLS-1$
+	}
+
+	private BaseRequirement errorProtectedFeature(String feature) {
+		return new BaseRequirement(//
+				new BaseFeature(//
+						feature, //
+						"12.1.0", //$NON-NLS-1$
+						"Mature an precious feature", //$NON-NLS-1$
+						"Does need to ve error-level protected"), //$NON-NLS-1$
+				new RestrictionLevel.Error(), //
+				"Requirement is mandatory to satisfy"); //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
- implement new predicate over ExaminationCertificate to ensure its a certificate sufficiently covers one particular feature
- test the implementation
- use the predicate in LicenseStatusDialog to define whether current state is OK or not - for one feature grant acquisition request


Closes #1272 