### PR TITLE
[#1290] Resolve API breakage after making RequestParameters#encode final

### DIFF
--- a/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/remote/impl/RequestParameters.java
+++ b/bundles/org.eclipse.passage.lic.hc/src/org/eclipse/passage/lic/hc/remote/impl/RequestParameters.java
@@ -80,7 +80,7 @@ public abstract class RequestParameters implements QueryParameters {
 				new ServerAuthenticationExpression(encode(access.getServer().getAuthentication().getExpression())));
 	}
 
-	protected final String encode(String value) throws LicensingException {
+	protected String encode(String value) throws LicensingException {
 		try {
 			return URLEncoder.encode(value, "UTF-8"); //$NON-NLS-1$
 		} catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Make it non-final again. See #1289 for further steps

Fixes #1290 