### PR TITLE
[#1330] Misprints in licensing requirement level should be treated as fata

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/restrictions/CertificateIsSufficient.java
@@ -60,7 +60,7 @@ public final class CertificateIsSufficient implements Predicate<Optional<Examina
 	}
 
 	private boolean notBearable(Restriction restriction) {
-		return new RequirementDemandsExecutionStop().test(restriction.unsatisfiedRequirement());
+		return new RestrictionMustPauseExecution().test(restriction);
 	}
 
 	private boolean relatesToFeature(Restriction restriction) {

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsSufficientTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/CertificateIsSufficientTest.java
@@ -35,6 +35,12 @@ public final class CertificateIsSufficientTest {
 	}
 
 	@Test
+	public void assessedFeatureIsSoftlyRestricted() {
+		String feature = feature();
+		assertFalse(new CertificateIsSufficient(feature).test(Optional.of(warn(feature))));
+	}
+
+	@Test
 	public void notAssessedFeatureIsRestricted() {
 		String feature = feature();
 		assertTrue(new CertificateIsSufficient(feature).test(Optional.of(severe())));
@@ -59,6 +65,10 @@ public final class CertificateIsSufficientTest {
 
 	private ExaminationCertificate severe(String feature) {
 		return new TestCertificates().withSevereRestrictions(feature);
+	}
+
+	private ExaminationCertificate warn(String feature) {
+		return new TestCertificates().withWarningRestrictions(feature);
 	}
 
 	private ExaminationCertificate severe() {

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/TestCertificates.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/restrictions/TestCertificates.java
@@ -113,6 +113,17 @@ final class TestCertificates {
 				));
 	}
 
+	ExaminationCertificate withWarningRestrictions(String feature) {
+		return new BaseExaminationCertificate(//
+				Collections.emptyMap(), // no permissions
+				Collections.singleton(//
+						new BaseRestriction(//
+								product(), //
+								warningProtectedFeature(feature), //
+								new LicenseDoesNotMatch())//
+				));
+	}
+
 	ExaminationCertificate withAgreementRestrictions() {
 		return withAgreementRestrictions("not-very-much-protected-feature"); //$NON-NLS-1$
 	}
@@ -165,8 +176,8 @@ final class TestCertificates {
 				new BaseFeature(//
 						feature, //
 						"12.1.0", //$NON-NLS-1$
-						"Mature an precious feature", //$NON-NLS-1$
-						"Does need to ve error-level protected"), //$NON-NLS-1$
+						"Mature and precious feature", //$NON-NLS-1$
+						"Needs to be error-level protected"), //$NON-NLS-1$
 				new RestrictionLevel.Error(), //
 				"Requirement is mandatory to satisfy"); //$NON-NLS-1$
 	}


### PR DESCRIPTION
Warning-restrictions also treated as signs of insufficient coverage.

Closes #1330 