### PR TITLE
Fix broken OSGi Declarative Service definition files of different Registry implementations

### DIFF
--- a/bundles/org.eclipse.passage.loc.licenses.core/OSGI-INF/org.eclipse.passage.loc.internal.licenses.core.LicenseDomainRegistry.xml
+++ b/bundles/org.eclipse.passage.loc.licenses.core/OSGI-INF/org.eclipse.passage.loc.internal.licenses.core.LicenseDomainRegistry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.passage.loc.internal.licenses.core.LicenseDomainRegistry">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="deactivate" name="org.eclipse.passage.loc.internal.licenses.core.LicenseDomainRegistry">
    <property name="org.eclipse.passage.lic.emf.edit.domain.name" value="licenses"/>
    <property name="org.eclipse.passage.lic.emf.edit.file.extension" value="licenses_xmi"/>
    <service>

--- a/bundles/org.eclipse.passage.loc.products.core/OSGI-INF/org.eclipse.passage.loc.internal.products.core.ProductDomainRegistry.xml
+++ b/bundles/org.eclipse.passage.loc.products.core/OSGI-INF/org.eclipse.passage.loc.internal.products.core.ProductDomainRegistry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.passage.loc.internal.products.core.ProductDomainRegistry">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="deactivate" name="org.eclipse.passage.loc.internal.products.core.ProductDomainRegistry">
    <property name="org.eclipse.passage.lic.emf.edit.domain.name" value="products"/>
    <property name="org.eclipse.passage.lic.emf.edit.file.extension" value="products_xmi"/>
    <service>

--- a/bundles/org.eclipse.passage.loc.products.core/OSGI-INF/org.eclipse.passage.loc.internal.products.core.ProductOperatorServiceImpl.xml
+++ b/bundles/org.eclipse.passage.loc.products.core/OSGI-INF/org.eclipse.passage.loc.internal.products.core.ProductOperatorServiceImpl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.passage.loc.internal.products.core.ProductOperatorServiceImpl">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.passage.loc.internal.products.core.ProductOperatorServiceImpl">
    <service>
       <provide interface="org.eclipse.passage.loc.internal.equinox.OperatorProductService"/>
    </service>


### PR DESCRIPTION
In the current master build starting an Eclipse application that contains the bundle `org.eclipse.passage.loc.licenses.core` or `org.eclipse.passage.loc.products.core` fails with the error below and the `LicenseDomainRegistry`, `ProductDomainRegistry` and `ProductOperatorServiceImpl` cannot be obtained as OSGi service because their DS component description files need to reference `scr-v1.3.0` instead of only `1.1.0`.
```
org.osgi.service.component.ComponentException: Component org.eclipse.passage.loc.internal.licenses.core.LicenseDomainRegistry validation failed: Field reference requires DS >= 1.3
	at org.apache.felix.scr.impl.metadata.ComponentMetadata.validationFailure(ComponentMetadata.java:1101)
	at org.apache.felix.scr.impl.metadata.ReferenceMetadata.validate(ReferenceMetadata.java:729)
	at org.apache.felix.scr.impl.metadata.ComponentMetadata.validate(ComponentMetadata.java:994)
	at org.apache.felix.scr.impl.BundleComponentActivator.validateAndRegister(BundleComponentActivator.java:445)
	at org.apache.felix.scr.impl.BundleComponentActivator.loadDescriptor(BundleComponentActivator.java:407)
	at org.apache.felix.scr.impl.BundleComponentActivator.initialize(BundleComponentActivator.java:283)
	at org.apache.felix.scr.impl.BundleComponentActivator.<init>(BundleComponentActivator.java:218)
	at org.apache.felix.scr.impl.Activator.loadComponents(Activator.java:612)
	at org.apache.felix.scr.impl.Activator.access$200(Activator.java:75)
	at org.apache.felix.scr.impl.Activator$ScrExtension.start(Activator.java:480)
	at org.apache.felix.scr.impl.AbstractExtender.createExtension(AbstractExtender.java:196)
	at org.apache.felix.scr.impl.AbstractExtender.modifiedBundle(AbstractExtender.java:169)
	at org.apache.felix.scr.impl.AbstractExtender.addingBundle(AbstractExtender.java:139)
	at org.apache.felix.scr.impl.AbstractExtender.addingBundle(AbstractExtender.java:49)
	at org.osgi.util.tracker.BundleTracker$Tracked.customizerAdding(BundleTracker.java:477)
...
```
Fixes https://github.com/eclipse-passage/passage/issues/1364.