### PR TITLE
[#1370] Operator distributive configuration issue makes it fail on startup

### DIFF
--- a/bundles/org.eclipse.passage.loc.operator.seal/build.properties
+++ b/bundles/org.eclipse.passage.loc.operator.seal/build.properties
@@ -16,4 +16,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               about.html
+               about.html,\
+               config/


### PR DESCRIPTION
Include missing resource into binary distribution