### PR TITLE
[#1372] Delete marker interface Gear

### DIFF
--- a/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/GearAware.java
+++ b/bundles/org.eclipse.passage.lic.equinox/src/org/eclipse/passage/lic/equinox/GearAware.java
@@ -61,6 +61,9 @@ public abstract class GearAware<G, S extends Supplier<G>> {
 	@FunctionalInterface
 	public interface Unsafe<G, T> {
 
+		/**
+		 * @since 3.0
+		 */
 		Optional<T> apply(G gear) throws Exception;
 
 	}


### PR DESCRIPTION
Missed since 3.0 annotation for `GearAware.Unsafe#apply`

Closes #1372