### PR TITLE
[#1361] support stable P2 repository structure for publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,10 @@
 		<module>./releng/org.eclipse.passage.lbc.aggregator</module>
 		<module>./releng/org.eclipse.passage.ldc.aggregator</module>
 		<module>./releng/org.eclipse.passage.demo.aggregator</module>
+		<!-- enable and fix after 3.0.0 RC2 -->
+		<!--
 		<module>sites/org.eclipse.passage.repository</module>
+		-->
 	</modules>
 
 </project>


### PR DESCRIPTION
Disable for the rest of 3.0.0, too late for the change of this scale