### PR TITLE
[#1430] Remove code unused by LIC and LCD

### DIFF
--- a/sites/org.eclipse.passage.repository/category.xml
+++ b/sites/org.eclipse.passage.repository/category.xml
@@ -44,6 +44,9 @@
    <feature id="org.eclipse.passage.lic.api.tests.feature">
       <category name="org.eclipse.passage.lic.category"/>
    </feature>
+   <feature id="org.eclipse.passage.lic.licenses.feature">
+      <category name="org.eclipse.passage.lic.category"/>
+   </feature>
    <bundle id="bcpg"/>
    <bundle id="bcpg.source"/>
    <bundle id="bcpkix"/>


### PR DESCRIPTION
publish `licenses` feature