### PR TITLE
[#1430] Remove code unused by LIC and LCD

### DIFF
--- a/features/org.eclipse.passage.demo.feature/feature.xml
+++ b/features/org.eclipse.passage.demo.feature/feature.xml
@@ -35,13 +35,11 @@
       <import feature="org.eclipse.passage.lic.execute.feature"/>
    </requires>
 
-
    <plugin
          id="org.eclipse.passage.seal.demo"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-
 
 </feature>

--- a/features/org.eclipse.passage.lic.compile.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.compile.feature/feature.xml
@@ -40,10 +40,6 @@
          id="org.eclipse.passage.lic.emf.feature"
          version="0.0.0"/>
 
-   <includes
-         id="org.eclipse.passage.lic.e4.ui.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.passage.lic.compile.branding"
          download-size="0"

--- a/features/org.eclipse.passage.lic.licenses.feature/feature.xml
+++ b/features/org.eclipse.passage.lic.licenses.feature/feature.xml
@@ -33,9 +33,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.passage.lic.equinox.feature" version="0.0.0" match="equivalent"/>
       <import feature="org.eclipse.passage.lic.emf.feature" version="0.0.0" match="equivalent"/>
-      <import feature="org.eclipse.passage.lic.e4.ui.feature" version="0.0.0" match="equivalent"/>
    </requires>
 
    <plugin

--- a/sites/org.eclipse.passage.repository/category.xml
+++ b/sites/org.eclipse.passage.repository/category.xml
@@ -17,9 +17,6 @@
    <feature id="org.eclipse.passage.lic.execute.feature">
       <category name="org.eclipse.passage.lic.category"/>
    </feature>
-   <feature id="org.eclipse.passage.lic.bc.feature">
-      <category name="org.eclipse.passage.lic.category"/>
-   </feature>
    <feature id="org.eclipse.passage.lic.compile.feature.source">
       <category name="org.eclipse.passage.lic.category.source"/>
    </feature>
@@ -45,6 +42,9 @@
       <category name="org.eclipse.passage.lic.category"/>
    </feature>
    <feature id="org.eclipse.passage.lic.licenses.feature">
+      <category name="org.eclipse.passage.lic.category"/>
+   </feature>
+   <feature id="org.eclipse.passage.lic.e4.ui.feature">
       <category name="org.eclipse.passage.lic.category"/>
    </feature>
    <bundle id="bcpg"/>

--- a/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Automatic-Module-Name: org.eclipse.passage.lic.jface.tests
+Automatic-Module-Name: org.eclipse.passage.lic.emf.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.emf.tests
 Bundle-Version: 4.0.0.qualifier


### PR DESCRIPTION
 - exclude ui requirements from Passage Runtime component
 - publish `e4.ui` feature
- do not publish `lic.bc` feature separately - it is included in `lic.execute`