### PR TITLE
[#1453] Evolve raw string identifier to semantic entity

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/GrantIdentifier.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/GrantIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,34 +9,20 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support and improvements
  *******************************************************************************/
-package org.eclipse.passage.lic.api.acquire;
+package org.eclipse.passage.lic.api;
 
-import java.util.Date;
-
-import org.eclipse.passage.lic.api.FeatureIdentifier;
-import org.eclipse.passage.lic.api.GrantIdentifier;
+import org.eclipse.passage.lic.api.acquire.GrantAcquisition;
 
 /**
+ * Identifies a grant acquired to use a feature under license protection
  * 
- * @since 2.1
+ * @see GrantAcquisition#grant()
+ * 
+ * @since 4.0
  */
-public interface GrantAcquisition {
+public interface GrantIdentifier {
 
 	String identifier();
 
-	/**
-	 * @since 4.0
-	 */
-	GrantIdentifier grant();
-
-	/**
-	 * @since 4.0
-	 */
-	FeatureIdentifier feature();
-
-	String user();
-
-	Date created();
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseGrantIdentifier.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseGrantIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2024 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,34 +9,16 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support and improvements
  *******************************************************************************/
-package org.eclipse.passage.lic.api.acquire;
+package org.eclipse.passage.lic.base;
 
-import java.util.Date;
-
-import org.eclipse.passage.lic.api.FeatureIdentifier;
 import org.eclipse.passage.lic.api.GrantIdentifier;
 
 /**
+ * Base implementation for {@link GrantIdentifier}
  * 
- * @since 2.1
+ * @since 4.0
  */
-public interface GrantAcquisition {
+public record BaseGrantIdentifier(String identifier) implements GrantIdentifier {
 
-	String identifier();
-
-	/**
-	 * @since 4.0
-	 */
-	GrantIdentifier grant();
-
-	/**
-	 * @since 4.0
-	 */
-	FeatureIdentifier feature();
-
-	String user();
-
-	Date created();
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/acquire/BaseGrantAcquisition.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/acquire/BaseGrantAcquisition.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.Objects;
 
 import org.eclipse.passage.lic.api.FeatureIdentifier;
+import org.eclipse.passage.lic.api.GrantIdentifier;
 import org.eclipse.passage.lic.api.acquire.GrantAcquisition;
 
 /**
@@ -28,7 +29,7 @@ public final class BaseGrantAcquisition implements GrantAcquisition, Serializabl
 
 	private static final long serialVersionUID = 2755031536488685673L;
 	private final String id;
-	private final String grant;
+	private final GrantIdentifier grant;
 	private final FeatureIdentifier feature;
 	private final String user;
 	private final Date created;
@@ -36,7 +37,8 @@ public final class BaseGrantAcquisition implements GrantAcquisition, Serializabl
 	/**
 	 * @since 4.0
 	 */
-	public BaseGrantAcquisition(String id, String grant, FeatureIdentifier feature, String user, Date created) {
+	public BaseGrantAcquisition(String id, GrantIdentifier grant, FeatureIdentifier feature, String user,
+			Date created) {
 		this.id = Objects.requireNonNull(id);
 		this.grant = Objects.requireNonNull(grant);
 		this.feature = Objects.requireNonNull(feature);
@@ -50,7 +52,7 @@ public final class BaseGrantAcquisition implements GrantAcquisition, Serializabl
 	}
 
 	@Override
-	public String grant() {
+	public GrantIdentifier grant() {
 		return grant;
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/acquire/LocalLicenseAcquisitionService.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/acquire/LocalLicenseAcquisitionService.java
@@ -20,6 +20,7 @@ import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.api.acquire.GrantAcquisition;
 import org.eclipse.passage.lic.api.acquire.LicenseAcquisitionService;
+import org.eclipse.passage.lic.base.BaseGrantIdentifier;
 import org.eclipse.passage.lic.base.BaseServiceInvocationResult;
 
 // FIXME: just stub for now. Implement properly. #568791
@@ -34,7 +35,7 @@ public abstract class LocalLicenseAcquisitionService implements LicenseAcquisiti
 		return new BaseServiceInvocationResult<>(//
 				new BaseGrantAcquisition(//
 						"local", //$NON-NLS-1$
-						"temp", //$NON-NLS-1$
+						new BaseGrantIdentifier("temp"), //$NON-NLS-1$
 						feature, //
 						"user", //$NON-NLS-1$
 						new Date())//

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/TentativeFeatureAccess.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/internal/base/access/TentativeFeatureAccess.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import org.eclipse.passage.lic.api.FeatureIdentifier;
 import org.eclipse.passage.lic.api.acquire.GrantAcquisition;
 import org.eclipse.passage.lic.base.BaseFeatureIdentifier;
+import org.eclipse.passage.lic.base.BaseGrantIdentifier;
 import org.eclipse.passage.lic.base.acquire.BaseGrantAcquisition;
 
 final class TentativeFeatureAccess implements Supplier<GrantAcquisition>, Predicate<GrantAcquisition> {
@@ -40,7 +41,7 @@ final class TentativeFeatureAccess implements Supplier<GrantAcquisition>, Predic
 	public GrantAcquisition get() {
 		return new BaseGrantAcquisition(//
 				String.format("%s-id", tentative), //$NON-NLS-1$
-				String.format("%s-grant", tentative), //$NON-NLS-1$
+				new BaseGrantIdentifier(String.format("%s-grant", tentative)), //$NON-NLS-1$
 				feature, //
 				String.format("%s-user", tentative), //$NON-NLS-1$
 				new Date());
@@ -49,7 +50,7 @@ final class TentativeFeatureAccess implements Supplier<GrantAcquisition>, Predic
 	@Override
 	public boolean test(GrantAcquisition grant) {
 		return grant.identifier().startsWith(tentative) //
-				&& grant.grant().startsWith(tentative) //
+				&& grant.grant().identifier().startsWith(tentative) //
 				&& grant.user().startsWith(tentative);
 	}
 

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/EGrantAcquisition.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/EGrantAcquisition.java
@@ -30,7 +30,7 @@ public final class EGrantAcquisition implements Supplier<GrantAcqisition> {
 	public GrantAcqisition get() {
 		GrantAcqisition grant = LicensesFactory.eINSTANCE.createGrantAcqisition();
 		grant.setIdentifier(source.identifier());
-		grant.setGrant(source.grant());
+		grant.setGrant(source.grant().identifier());
 		grant.setFeature(source.feature().identifier());
 		grant.setUser(source.user());
 		grant.setCreated(source.created());

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PGrantAcquisition.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/convert/PGrantAcquisition.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.eclipse.passage.lic.base.BaseFeatureIdentifier;
+import org.eclipse.passage.lic.base.BaseGrantIdentifier;
 import org.eclipse.passage.lic.base.acquire.BaseGrantAcquisition;
 import org.eclipse.passage.lic.licenses.model.api.GrantAcqisition;
 
@@ -32,7 +33,7 @@ public final class PGrantAcquisition implements Supplier<org.eclipse.passage.lic
 	public org.eclipse.passage.lic.api.acquire.GrantAcquisition get() {
 		return new BaseGrantAcquisition(//
 				source.getIdentifier(), //
-				source.getGrant(), //
+				new BaseGrantIdentifier(source.getGrant()), //
 				new BaseFeatureIdentifier(source.getFeature()), //
 				source.getUser(), //
 				source.getCreated());


### PR DESCRIPTION
Rework `String` grant identifier to a dedicated type `GrantIdentifier`