### PR TITLE
[#1430] Remove code unused by LIC and LCD

### DIFF
--- a/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/evaluation/ExpressionProtocol.java
+++ b/bundles/org.eclipse.passage.lic.api/src/org/eclipse/passage/lic/api/conditions/evaluation/ExpressionProtocol.java
@@ -58,14 +58,6 @@ public abstract class ExpressionProtocol implements ServiceId {
 
 	}
 
-	public static final class Munich extends ExpressionProtocol {
-
-		public Munich() {
-			super("munich"); //$NON-NLS-1$
-		}
-
-	}
-
 	public static final class Default extends ExpressionProtocol {
 
 		public Default() {


### PR DESCRIPTION
expression protocol Munich is not used