### PR TITLE
[#1482] From-The-Box Support for optional license storage

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/LenientLocalConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/LenientLocalConditions.java
@@ -36,7 +36,7 @@ public abstract class LenientLocalConditions extends BaseLocalConditions {
 	}
 
 	@Override
-	protected Collection<Path> licenses(LicensedProduct product) throws LicensingException {
+	protected final Collection<Path> licenses(LicensedProduct product) throws LicensingException {
 		return new LenientFileCollection(base(product), scope).get();
 	}
 

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/LocalConditions.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/conditions/mining/LocalConditions.java
@@ -44,7 +44,7 @@ public abstract class LocalConditions extends BaseLocalConditions {
 	}
 
 	@Override
-	protected Collection<Path> licenses(LicensedProduct product) throws LicensingException {
+	protected final Collection<Path> licenses(LicensedProduct product) throws LicensingException {
 		return new FileCollection(base(product), scope).get();
 	}
 


### PR DESCRIPTION
fix an interface error made during #1482 implementation: if a method have not empty implementation, it cannot be overridden