### PR TITLE
[#1507] Legacy license migration is not thread safe

### DIFF
--- a/bundles/org.eclipse.passage.lic.emf/build.properties
+++ b/bundles/org.eclipse.passage.lic.emf/build.properties
@@ -16,7 +16,6 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               templates/,\
                about.html,\
                about.ini,\
                about.mappings,\

--- a/bundles/org.eclipse.passage.lic.emf/build.properties
+++ b/bundles/org.eclipse.passage.lic.emf/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2021 ArSysOp and others
+# Copyright (c) 2018, 2025 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
-#     ArSysOp - initial API and implementation
+#     ArSysOp - initial API and implementation, further support
 ###############################################################################
 
 source.. = src/

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/migration/DelegateClassifiers.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/emf/migration/DelegateClassifiers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,12 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
 package org.eclipse.passage.lic.emf.migration;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.emf.ecore.EClass;
@@ -34,17 +32,16 @@ public final class DelegateClassifiers {
 	}
 
 	public void delegate(EClassRoutes routes) {
-		DelegatingEPackage delegating = new DelegateEPackage().apply(uri);
-		DelegatingEFactory factory = delegating.getDelegatingEFactory();
-		Map<EClass, EClass> delegated = new HashMap<>();
-		Map<String, EClass> defined = routes.defined();
-		for (Entry<String, EClass> entry : defined.entrySet()) {
-			EClass to = entry.getValue();
-			EClass from = EcoreUtil.copy(to);
-			from.setName(entry.getKey());
-			delegated.put(from, to);
-			delegating.getEClassifiers().add(from);
-			factory.delegateEClass(to.getEPackage().getEFactoryInstance(), from, to);
+		synchronized (DelegateClassifiers.class) {
+			DelegatingEPackage delegating = new DelegateEPackage().apply(uri);
+			DelegatingEFactory factory = delegating.getDelegatingEFactory();
+			for (Entry<String, EClass> entry : routes.defined().entrySet()) {
+				EClass to = entry.getValue();
+				EClass from = EcoreUtil.copy(to);
+				from.setName(entry.getKey());
+				delegating.getEClassifiers().add(from);
+				factory.delegateEClass(to.getEPackage().getEFactoryInstance(), from, to);
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/EObjectFromBytes.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/EObjectFromBytes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,7 @@ import java.util.Objects;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 
-public class EObjectFromBytes<T extends EObject> extends EObjectFromStream<T> {
+public final class EObjectFromBytes<T extends EObject> extends EObjectFromStream<T> {
 
 	private final byte[] content;
 

--- a/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/EObjectFromFile.java
+++ b/bundles/org.eclipse.passage.lic.emf/src/org/eclipse/passage/lic/internal/emf/EObjectFromFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,7 @@ import java.util.Objects;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 
-public class EObjectFromFile<T extends EObject> extends EObjectFromStream<T> {
+public final class EObjectFromFile<T extends EObject> extends EObjectFromStream<T> {
 
 	private final File file;
 

--- a/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/migration/LicensesResourceHandler.java
+++ b/bundles/org.eclipse.passage.lic.licenses.model/src/org/eclipse/passage/lic/internal/licenses/model/migration/LicensesResourceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation, further support
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.licenses.model.migration;
 
@@ -26,10 +26,10 @@ import org.eclipse.passage.lic.internal.licenses.model.AssignGrantIdentifiers;
 import org.eclipse.passage.lic.licenses.model.api.PersonalLicensePack;
 import org.eclipse.passage.lic.licenses.model.meta.LicensesPackage;
 
-public class LicensesResourceHandler extends MigratingResourceHandler {
+public final class LicensesResourceHandler extends MigratingResourceHandler {
 
 	@Override
-	protected final void complete(XMLResource resource) {
+	protected void complete(XMLResource resource) {
 		resource.getContents().stream()//
 				.filter(PersonalLicensePack.class::isInstance)//
 				.map(PersonalLicensePack.class::cast)//
@@ -37,7 +37,7 @@ public class LicensesResourceHandler extends MigratingResourceHandler {
 	}
 
 	@Override
-	protected final void register() {
+	protected void register() {
 		migrate033();
 		migrate040();
 		migrate050();
@@ -49,7 +49,7 @@ public class LicensesResourceHandler extends MigratingResourceHandler {
 	}
 
 	@Override
-	protected final MigrationRoutes attributes() {
+	protected MigrationRoutes attributes() {
 		MigrationRoutes routes = new SimpleMigrationRoutes();
 		LicensesPackage licenses = LicensesPackage.eINSTANCE;
 
@@ -144,20 +144,17 @@ public class LicensesResourceHandler extends MigratingResourceHandler {
 
 	private void migrate200() {
 		String uri = "http://www.eclipse.org/passage/lic/licenses/2.0.0"; //$NON-NLS-1$
-		LicensesPackage delegate = LicensesPackage.eINSTANCE;
-		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> delegate);
+		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> LicensesPackage.eINSTANCE);
 	}
 
 	private void migrate300() {
 		String uri = "http://www.eclipse.org/passage/lic/licenses/3.0.0"; //$NON-NLS-1$
-		LicensesPackage delegate = LicensesPackage.eINSTANCE;
-		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> delegate);
+		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> LicensesPackage.eINSTANCE);
 	}
 
 	private void migrate400() {
 		String uri = "http://www.eclipse.org/passage/lic/licenses/4.0.0"; //$NON-NLS-1$
-		LicensesPackage delegate = LicensesPackage.eINSTANCE;
-		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> delegate);
+		EPackage.Registry.INSTANCE.computeIfAbsent(uri, ns -> LicensesPackage.eINSTANCE);
 	}
 
 }


### PR DESCRIPTION
Synch is applied to the complete procedure of taking decision whether legacy nsuri is covered or not, following by classifiers migration. 