### PR TITLE
[#1459] Add contract test for FeatureIdentifier

### DIFF
--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseFeatureIdentifier.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseFeatureIdentifier.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.base;
 
+import java.util.Objects;
+
 import org.eclipse.passage.lic.api.FeatureIdentifier;
 
 /**
@@ -19,6 +21,35 @@ import org.eclipse.passage.lic.api.FeatureIdentifier;
  * 
  * @since 4.0
  */
-public record BaseFeatureIdentifier(String identifier) implements FeatureIdentifier {
+public final class BaseFeatureIdentifier implements FeatureIdentifier {
+
+	private final String identifier;
+
+	public BaseFeatureIdentifier(String identifier) {
+		this.identifier = Objects.requireNonNull(identifier);
+	}
+
+	@Override
+	public String identifier() {
+		return identifier;
+	}
+
+	@Override
+	public int hashCode() {
+		return identifier.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof FeatureIdentifier id)) {
+			return false;
+		}
+		return id.identifier().equals(identifier);
+	}
+
+	@Override
+	public String toString() {
+		return identifier;
+	}
 
 }

--- a/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseFeatureIdentifier.java
+++ b/bundles/org.eclipse.passage.lic.base/src/org/eclipse/passage/lic/base/BaseFeatureIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 ArSysOp
+ * Copyright (c) 2024, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation; further evolution
  *******************************************************************************/
 package org.eclipse.passage.lic.base;
 

--- a/tests/org.eclipse.passage.lic.api.tests/OSGI-INF/l10n/bundle.properties
+++ b/tests/org.eclipse.passage.lic.api.tests/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 ArSysOp and others
+# Copyright (c) 2018, 2025 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 
 Bundle-Name = Passage LIC API Tests
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018, 2024 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2025 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FeatureIdentifierContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FeatureIdentifierContractTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.passage.lic.api.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.passage.lic.api.FeatureIdentifier;
+import org.junit.Test;
+
+public abstract class FeatureIdentifierContractTest {
+
+	@Test(expected = NullPointerException.class)
+	public void doesNotTolerateNullInput() {
+		featureIdentifier(null);
+	}
+
+	@Test
+	public void canBeMapKey() {
+		String input = "same-input"; //$NON-NLS-1$
+		FeatureIdentifier left = featureIdentifier(input);
+		FeatureIdentifier right = featureIdentifier(input);
+		assertEquals(left.hashCode(), right.hashCode());
+		assertTrue(left.equals(right));
+	}
+
+	protected abstract FeatureIdentifier featureIdentifier(String input);
+
+}

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/BaseFeatureIdentifierTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/BaseFeatureIdentifierTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2024 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+
 package org.eclipse.passage.lic.internal.base.tests;
 
 import org.eclipse.passage.lic.api.FeatureIdentifier;

--- a/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/BaseFeatureIdentifierTest.java
+++ b/tests/org.eclipse.passage.lic.base.tests/src/org/eclipse/passage/lic/internal/base/tests/BaseFeatureIdentifierTest.java
@@ -1,0 +1,15 @@
+package org.eclipse.passage.lic.internal.base.tests;
+
+import org.eclipse.passage.lic.api.FeatureIdentifier;
+import org.eclipse.passage.lic.api.tests.FeatureIdentifierContractTest;
+import org.eclipse.passage.lic.base.BaseFeatureIdentifier;
+
+@SuppressWarnings("restriction")
+public final class BaseFeatureIdentifierTest extends FeatureIdentifierContractTest {
+
+	@Override
+	protected FeatureIdentifier featureIdentifier(String input) {
+		return new BaseFeatureIdentifier(input);
+	}
+
+}


### PR DESCRIPTION
Contract test proved itself helpful again: record syntax cannot lay demands on constructor arguments. 