### PR TITLE
[#1471] lic.bc.tests.StreamEncodingTest fails stochastically

### DIFF
--- a/bundles/org.eclipse.passage.lic.bc/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.eclipse.passage.lic.bc/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 ArSysOp and others
+# Copyright (c) 2018, 2025 ArSysOp and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 
 Bundle-Name = Passage LIC BC
 Bundle-Vendor = Eclipse Passage
-Bundle-Copyright = Copyright (c) 2018, 2024 ArSysOp and others.\n\
+Bundle-Copyright = Copyright (c) 2018, 2025 ArSysOp and others.\n\
 \n\
 This program and the accompanying materials are made\n\
 available under the terms of the Eclipse Public License 2.0\n\

--- a/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/bc/BcStreamCodec.java
+++ b/bundles/org.eclipse.passage.lic.bc/src/org/eclipse/passage/lic/bc/BcStreamCodec.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2025 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     ArSysOp - initial API and implementation
+ *     ArSysOp - initial API and implementation; further evolution
  *******************************************************************************/
 package org.eclipse.passage.lic.bc;
 

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamEncodingTest.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamEncodingTest.java
@@ -79,8 +79,10 @@ public final class StreamEncodingTest extends BcStreamCodecTest {
 		} catch (LicensingException e) {
 			assertTrue(e.getMessage().contains("key")); //$NON-NLS-1$
 			return;
+		} catch (Exception e) {
+			return; // can also legitimately fail due BC intolerance for incorrect input 
 		}
-		fail("Enconding is not supposed to encrypt anything with  a random sequence of chars as a key"); //$NON-NLS-1$
+		fail("Enconding is not supposed to encrypt anything with a random sequence of chars as a key"); //$NON-NLS-1$
 	}
 
 	@Test(expected = NullPointerException.class)


### PR DESCRIPTION
This test is supposed to fail stochastically due to its purpose and random nature of error-generating input. 

The reason of test malfunction is the inaccuracy of failure handling: not only LicensingExcetion must be expected, but also any type of runtime exception caused by BS's intolerance to incorrect input;