### PR TITLE
[Setup] Fix broken Oomph Setup for Passage

### DIFF
--- a/releng/org.eclipse.passage.releng/passage.setup
+++ b/releng/org.eclipse.passage.releng/passage.setup
@@ -75,8 +75,6 @@
       xsi:type="setup.p2:P2Task"
       label="Passage">
     <requirement
-        name="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group"/>
-    <requirement
         name="org.eclipse.emf.sdk.feature.group"/>
     <requirement
         name="org.eclipse.sirius.specifier.feature.group"/>
@@ -88,7 +86,7 @@
     <setupTask
         xsi:type="jdt:JRETask"
         version="JavaSE-21"
-        location="${jre.location-17}"
+        location="${jre.location-21}"
         name="JRE for JavaSE-21">
       <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
     </setupTask>


### PR DESCRIPTION
- Remove requirement of the installation on EMFForms, which is not available anymore (from SimRel) and because the LOC has been removed, it's also not necessary anymore.
- Fix JRE Task to use the jre.location for Java-21

Part of
- https://github.com/eclipse-passage/passage/issues/1241
