### PR TITLE
[#1650] Migrate test to JUnit6

### DIFF
--- a/releng/org.eclipse.passage.parent/pom.xml
+++ b/releng/org.eclipse.passage.parent/pom.xml
@@ -496,6 +496,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
+					<providerHint>junit6</providerHint>
 					<argLine>${surefire.testArgLine}
 						${surefire.platformSystemProperties}
 						${surefire.systemProperties}

--- a/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
+++ b/releng/org.eclipse.passage.target/org.eclipse.passage.target.target
@@ -37,6 +37,7 @@
 			<unit id="com.sun.jna" version="0.0.0"/>
 			<unit id="com.sun.jna.platform" version="0.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
+			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
 		</location>
 	</locations>

--- a/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.api.tests/META-INF/MANIFEST.MF
@@ -24,4 +24,6 @@ Export-Package: org.eclipse.passage.lic.api.tests;x-friends:="org.eclipse.passag
  org.eclipse.passage.lic.api.tests.registry;x-internal:=true,
  org.eclipse.passage.lic.api.tests.resrictions;x-internal:=true,
  org.eclipse.passage.lic.api.tests.version;x-internal:=true
-Import-Package: org.junit
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)",
+ org.junit.jupiter.api.function;version="[6.1.0,7.0.0)",
+ org.opentest4j;version="[1.3.0,2.0.0)"

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/FrameworkContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,11 +9,12 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - ongoing support
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
@@ -26,7 +27,7 @@ import org.eclipse.passage.lic.api.inspection.RuntimeEnvironmentRegistry;
 import org.eclipse.passage.lic.api.registry.Registry;
 import org.eclipse.passage.lic.api.registry.Service;
 import org.eclipse.passage.lic.api.registry.ServiceId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/IdentifierContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/IdentifierContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 ArSysOp
+ * Copyright (c) 2025, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,24 +9,26 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - ongoing support
  *******************************************************************************/
 
 package org.eclipse.passage.lic.api.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.passage.lic.api.FeatureIdentifier;
 import org.eclipse.passage.lic.api.GrantIdentifier;
 import org.eclipse.passage.lic.api.UserIdentifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class IdentifierContractTest<T> {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void doesNotTolerateNullInput() {
-		identifierForInput(null);
+		assertThrows(NullPointerException.class, () -> identifierForInput(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ReadOnlyCollectionTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/ReadOnlyCollectionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,18 +9,19 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - ongoing support
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/EvaluationTypeContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/EvaluationTypeContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,19 +9,21 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.passage.lic.api.EvaluationType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class EvaluationTypeContractTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void nullIdentifierIsProhibited() {
-		forIdentifier(null);
+		assertThrows(NullPointerException.class, () -> forIdentifier(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/MatchingRuleContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/MatchingRuleContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.passage.lic.api.conditions.MatchingRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class MatchingRuleContractTest {
 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodClosedContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodClosedContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,15 +9,17 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.ZonedDateTime;
 
 import org.eclipse.passage.lic.api.conditions.ValidityPeriodClosed;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -35,17 +37,17 @@ public abstract class ValidityPeriodClosedContractTest extends ValidityPeriodOpe
 	 * Attempt to construct a period on reversed dates must fail, type of failure is
 	 * on an implementor.
 	 */
-	@Test(expected = Exception.class)
+	@Test
 	public final void doNotReverseIncorectBounds() {
-		forTwoDates(movedNow(10), movedNow(-10));
+		assertThrows(Exception.class, () -> forTwoDates(movedNow(10), movedNow(-10)));
 	}
 
 	/**
 	 * Implementation must rise NPE if there is no data for ending date definition.
 	 */
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void doNotInventTo() {
-		forTwoDates(ZonedDateTime.now(), null);
+		assertThrows(NullPointerException.class, () -> forTwoDates(ZonedDateTime.now(), null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,16 +9,17 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.ZonedDateTime;
 
 import org.eclipse.passage.lic.api.conditions.ValidityPeriod;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class ValidityPeriodContractTest<V extends ValidityPeriod> {
 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodOpenContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/ValidityPeriodOpenContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,16 +9,18 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.ZonedDateTime;
 import java.util.function.Function;
 
 import org.eclipse.passage.lic.api.conditions.ValidityPeriodOpen;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -37,9 +39,9 @@ public abstract class ValidityPeriodOpenContractTest<V extends ValidityPeriodOpe
 	 * Implementation must rise NPE if there is no data for starting date
 	 * definition.
 	 */
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void doNotInventFrom() {
-		atLeastMonthLongFrom(null);
+		assertThrows(NullPointerException.class, () -> atLeastMonthLongFrom(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/EmissionTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/EmissionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,11 +9,13 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions.evaluation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 
@@ -21,23 +23,24 @@ import org.eclipse.passage.lic.api.conditions.evaluation.Emission;
 import org.eclipse.passage.lic.api.conditions.evaluation.Permission;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.FakeConditionPack;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermission;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class EmissionTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void conditionPackIsMandatory() {
-		new Emission(null);
+		assertThrows(NullPointerException.class, () -> new Emission(null));
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void doesNotTolerateNullPermission() {
-		new Emission(new FakeConditionPack(), (Permission) null);
+		assertThrows(RuntimeException.class, () -> new Emission(new FakeConditionPack(), (Permission) null));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void doesNotTolerateNullPermissions() {
-		new Emission(new FakeConditionPack(), (Collection<Permission>) null);
+		assertThrows(NullPointerException.class,
+				() -> new Emission(new FakeConditionPack(), (Collection<Permission>) null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionEvaluationServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionEvaluationServiceContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,10 +9,12 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions.evaluation;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.passage.lic.api.conditions.evaluation.ExpressionEvaluationException;
 import org.eclipse.passage.lic.api.conditions.evaluation.ExpressionEvaluationService;
@@ -20,24 +22,25 @@ import org.eclipse.passage.lic.api.conditions.evaluation.ExpressionTokenAssessme
 import org.eclipse.passage.lic.api.conditions.evaluation.ParsedExpression;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeExpressionTokenAssessmentService;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakeParsedExpression;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class ExpressionEvaluationServiceContractTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void prohibitsNullExpression() {
-		prohibitsNullArgument(null, new FakeExpressionTokenAssessmentService());
+		assertThrows(NullPointerException.class,
+				() -> prohibitsNullArgument(null, new FakeExpressionTokenAssessmentService()));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void prohibitsNullAssessor() {
-		prohibitsNullArgument(new FakeParsedExpression(), null);
+		assertThrows(NullPointerException.class, () -> prohibitsNullArgument(new FakeParsedExpression(), null));
 	}
 
-	@Test(expected = ExpressionEvaluationException.class)
+	@Test
 	public final void canOnlyEvaluateExpressionOfSameProtocl() throws ExpressionEvaluationException {
-		evaluator().evaluate(new FakeParsedExpression("fake"), //$NON-NLS-1$
-				new FakeExpressionTokenAssessmentService());
+		assertThrows(ExpressionEvaluationException.class, () -> evaluator().evaluate(new FakeParsedExpression("fake"), //$NON-NLS-1$
+				new FakeExpressionTokenAssessmentService()));
 	}
 
 	private void prohibitsNullArgument(ParsedExpression expression, ExpressionTokenAssessmentService assessor) {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionParsingServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/evaluation/ExpressionParsingServiceContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,28 +9,30 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions.evaluation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.passage.lic.api.conditions.evaluation.ExpressionParsingException;
 import org.eclipse.passage.lic.api.conditions.evaluation.ExpressionParsingService;
 import org.eclipse.passage.lic.api.conditions.evaluation.ParsedExpression;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class ExpressionParsingServiceContractTest {
 
-	@Test(expected = ExpressionParsingException.class)
+	@Test
 	public final void blankExpressionCausesFailure() throws ExpressionParsingException {
-		parser().parsed("\t"); //$NON-NLS-1$
+		assertThrows(ExpressionParsingException.class, () -> parser().parsed("\t")); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void prohibitsNullExpression() throws ExpressionParsingException {
-		parser().parsed(null);
+		assertThrows(NullPointerException.class, () -> parser().parsed(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ConditionTransportContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ConditionTransportContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions.mining;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,7 +28,7 @@ import java.util.stream.Collectors;
 import org.eclipse.passage.lic.api.conditions.Condition;
 import org.eclipse.passage.lic.api.conditions.ValidityPeriodClosed;
 import org.eclipse.passage.lic.api.conditions.mining.ConditionTransport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class ConditionTransportContractTest {
 
@@ -39,7 +41,7 @@ public abstract class ConditionTransportContractTest {
 	public final void readYourOwnWritings() throws IOException {
 		// given
 		Collection<Condition> sedentaries = conditions();
-		assumeTrue("Too few: supply at least two test conditions for transportation", sedentaries.size() > 1); //$NON-NLS-1$
+		assumeTrue(sedentaries.size() > 1, "Too few: supply at least two test conditions for transportation"); //$NON-NLS-1$
 		ConditionTransport transport = transport();
 		// when
 		Collection<Condition> nomads = read(transport, serialized(sedentaries));
@@ -47,14 +49,14 @@ public abstract class ConditionTransportContractTest {
 		assertEquals(new HashSet<>(textual(sedentaries)), new HashSet<>(textual(nomads)));
 	}
 
-	@Test(expected = IOException.class)
-	public final void failOnNotSufficientData() throws IOException {
-		read(transport(), serializedInvalid()); // $NON-NLS-1$
+	@Test
+	public final void failOnNotSufficientData() {
+		assertThrows(IOException.class, () -> read(transport(), serializedInvalid()));
 	}
 
-	@Test(expected = IOException.class)
-	public final void failOnEmptySource() throws IOException {
-		read(transport(), ""); //$NON-NLS-1$
+	@Test
+	public final void failOnEmptySource() {
+		assertThrows(IOException.class, () -> read(transport(), "")); //$NON-NLS-1$
 	}
 
 	private Collection<Condition> read(ConditionTransport transport, String source) throws IOException {

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ContentTypeTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/conditions/mining/ContentTypeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,19 +9,22 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.conditions.mining;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.passage.lic.api.conditions.mining.ContentType;
 import org.eclipse.passage.lic.api.registry.ServiceId;
 import org.eclipse.passage.lic.api.tests.registry.ServiceIdContractTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ContentTypeTest extends ServiceIdContractTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void typeIsMandatory() {
-		new ContentType.Of(null);
+		assertThrows(NullPointerException.class, () -> new ContentType.Of(null));
 	}
 
 	@Override

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/inspection/RuntimeEnvironmentContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,15 +9,16 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.inspection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -30,7 +31,8 @@ import org.eclipse.passage.lic.api.EvaluationType;
 import org.eclipse.passage.lic.api.LicensingException;
 import org.eclipse.passage.lic.api.inspection.EnvironmentProperty;
 import org.eclipse.passage.lic.api.inspection.RuntimeEnvironment;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 public abstract class RuntimeEnvironmentContractTest {
 	@Test
@@ -43,12 +45,16 @@ public abstract class RuntimeEnvironmentContractTest {
 		try {
 			assertFalse(environment().isAssuptionTrue(property(), invalidPropertyValue()));
 		} catch (LicensingException e) {
-			assumeNoException(e); // skip the test in the case of environment denial
+			Assumptions.abort("environment denial"); //$NON-NLS-1$
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void doesNotInspectNullProperty() {
+		assertThrows(NullPointerException.class, () -> withNullProperty());
+	}
+
+	private void withNullProperty() {
 		try {
 			environment().isAssuptionTrue(null, "none"); //$NON-NLS-1$
 		} catch (LicensingException e) {
@@ -56,8 +62,12 @@ public abstract class RuntimeEnvironmentContractTest {
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void doesNotInspectForNullValue() {
+		assertThrows(NullPointerException.class, () -> withNullValue());
+	}
+
+	private void withNullValue() {
 		try {
 			environment().isAssuptionTrue(property(), null); // $NON-NLS-1$
 		} catch (LicensingException e) {
@@ -70,7 +80,7 @@ public abstract class RuntimeEnvironmentContractTest {
 		try {
 			assertTrue(environment().isAssuptionTrue(property(), "*"));//$NON-NLS-1$
 		} catch (LicensingException e) {
-			assumeNoException(e); // skip the test in the case of environment denial
+			Assumptions.abort("environment denial"); //$NON-NLS-1$
 		}
 	}
 
@@ -81,7 +91,7 @@ public abstract class RuntimeEnvironmentContractTest {
 			assertNotNull(state);
 			assertFalse(state.trim().isEmpty());
 		} catch (LicensingException e) {
-			assumeNoException(e); // skip the test in the case of environment denial
+			Assumptions.abort("environment denial"); //$NON-NLS-1$
 		}
 	}
 
@@ -105,7 +115,7 @@ public abstract class RuntimeEnvironmentContractTest {
 			readySteadyGo.countDown(); // and now trigger'em all to ddos the env
 			done.await(); // and just wait until each of'em finish
 		} catch (InterruptedException e) {
-			assumeNoException(e); // skip the test then: further checks will fail
+			Assumptions.abort("further checks will fail"); //$NON-NLS-1$
 		}
 
 		// then: all of'em succeed

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/ServiceIdContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/ServiceIdContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,13 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.registry;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.passage.lic.api.registry.ServiceId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class ServiceIdContractTest {
 

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/StringServiceIdTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/registry/StringServiceIdTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,18 +9,21 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.registry;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.passage.lic.api.registry.ServiceId;
 import org.eclipse.passage.lic.api.registry.StringServiceId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class StringServiceIdTest extends ServiceIdContractTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void idIsMandatory() {
-		new StringServiceId(null);
+		assertThrows(NullPointerException.class, () -> new StringServiceId(null));
 	}
 
 	@Override

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/resrictions/PermissionsExaminationServiceContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/resrictions/PermissionsExaminationServiceContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,8 +9,11 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.resrictions;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.function.Supplier;
@@ -20,24 +23,26 @@ import org.eclipse.passage.lic.api.restrictions.PermissionsExaminationService;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.FakeLicensedProduct;
 import org.eclipse.passage.lic.api.tests.fakes.conditions.evaluation.FakePermission;
 import org.eclipse.passage.lic.api.tests.fakes.requirements.FakeRequirement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class PermissionsExaminationServiceContractTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void prohibitsNullRequirements() {
-		examiner(FakeLicensedProduct::new).examine(null, Collections.singleton(new FakePermission()));
+		assertThrows(NullPointerException.class,
+				() -> examiner(FakeLicensedProduct::new).examine(null, Collections.singleton(new FakePermission())));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void prohibitsNullPermissions() {
-		examiner(FakeLicensedProduct::new).examine(Collections.singleton(new FakeRequirement()), null);
+		assertThrows(NullPointerException.class,
+				() -> examiner(FakeLicensedProduct::new).examine(Collections.singleton(new FakeRequirement()), null));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void prohibitsNullProduct() {
-		examiner(null).examine(Collections.singleton(new FakeRequirement()),
-				Collections.singleton(new FakePermission()));
+		assertThrows(NullPointerException.class, () -> examiner(null)
+				.examine(Collections.singleton(new FakeRequirement()), Collections.singleton(new FakePermission())));
 	}
 
 	protected abstract PermissionsExaminationService examiner(Supplier<LicensedProduct> product);

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/version/SemanticVersionContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/version/SemanticVersionContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,20 +9,26 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.version;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.passage.lic.api.version.SemanticVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class SemanticVersionContractTest {
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void notExistingQualifierRetrievalMustFail() {
+		assertThrows(RuntimeException.class, () -> mustFail());
+	}
+
+	private void mustFail() {
 		SemanticVersion version = withoutQualifier();
 		assumeFalse(version.hasQualifier());
 		version.qualifier();

--- a/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/version/VersionContractTest.java
+++ b/tests/org.eclipse.passage.lic.api.tests/src/org/eclipse/passage/lic/api/tests/version/VersionContractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.api.tests.version;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.passage.lic.api.version.Version;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class VersionContractTest {
 

--- a/tests/org.eclipse.passage.lic.bc.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.bc.tests/META-INF/MANIFEST.MF
@@ -3,8 +3,10 @@ Automatic-Module-Name: org.eclipse.passage.lic.bc.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.bc.tests
 Bundle-Version: 4.7.0.qualifier
-Import-Package: org.junit,
- org.junit.rules
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)",
+ org.junit.jupiter.api.function;version="[6.1.0,7.0.0)",
+ org.junit.jupiter.api.io;version="[6.1.0,7.0.0)",
+ org.opentest4j;version="[1.3.0,2.0.0)"
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/BcStreamCodecTest.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/BcStreamCodecTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,15 +9,16 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.bc.tests;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,14 +31,13 @@ import org.eclipse.passage.lic.api.io.StreamCodec;
 import org.eclipse.passage.lic.base.BaseLicensedProduct;
 import org.eclipse.passage.lic.base.io.PassageFileExtension;
 import org.eclipse.passage.lic.bc.BcStreamCodec;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("restriction")
 abstract class BcStreamCodecTest {
 
-	@Rule
-	public final TemporaryFolder root = new TemporaryFolder();
+	@TempDir
+	public File root;
 
 	protected final void assertFileExists(Path file) {
 		assertTrue(Files.exists(file));

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/KeyPairGenerationTest.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/KeyPairGenerationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,13 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.bc.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -32,7 +33,7 @@ import org.eclipse.passage.lic.api.io.StreamCodec.Smart;
 import org.eclipse.passage.lic.base.io.FileContent;
 import org.eclipse.passage.lic.base.io.PassageFileExtension;
 import org.eclipse.passage.lic.bc.BcStreamCodec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public final class KeyPairGenerationTest extends BcStreamCodecTest {
@@ -108,40 +109,40 @@ public final class KeyPairGenerationTest extends BcStreamCodecTest {
 
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void publicKeyPathIsMandatory() throws LicensingException, IOException {
-		codec().createKeyPair(//
+		assertThrows(NullPointerException.class, () -> codec().createKeyPair(//
 				null, //
 				new TmpFile(root).keyFile(new PassageFileExtension.PrivateKey()), //
 				"u", //$NON-NLS-1$
-				"p"); //$NON-NLS-1$
+				"p")); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void privateKeyPathIsMandatory() throws LicensingException, IOException {
-		codec().createKeyPair(//
+		assertThrows(NullPointerException.class, () -> codec().createKeyPair(//
 				new TmpFile(root).keyFile(new PassageFileExtension.PublicKey()), //
 				null, //
 				"u", //$NON-NLS-1$
-				"p"); //$NON-NLS-1$
+				"p")); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void usernameIsMandatory() throws LicensingException, IOException {
-		codec().createKeyPair(//
+		assertThrows(NullPointerException.class, () -> codec().createKeyPair(//
 				new TmpFile(root).keyFile(new PassageFileExtension.PublicKey()), //
 				new TmpFile(root).keyFile(new PassageFileExtension.PrivateKey()), //
 				null, //
-				"p"); //$NON-NLS-1$
+				"p")); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void passwordIsMandatory() throws LicensingException, IOException {
-		codec().createKeyPair(//
+		assertThrows(NullPointerException.class, () -> codec().createKeyPair(//
 				new TmpFile(root).keyFile(new PassageFileExtension.PublicKey()), //
 				new TmpFile(root).keyFile(new PassageFileExtension.PrivateKey()), //
 				"u", //$NON-NLS-1$
-				null);
+				null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamDecodingTest.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamDecodingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.bc.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -34,7 +35,7 @@ import org.eclipse.passage.lic.base.io.BaseDigestExpectation;
 import org.eclipse.passage.lic.base.io.FileContent;
 import org.eclipse.passage.lic.bc.BcDigest;
 import org.eclipse.passage.lic.bc.BcStreamCodec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public final class StreamDecodingTest extends BcStreamCodecTest {
@@ -107,29 +108,45 @@ public final class StreamDecodingTest extends BcStreamCodecTest {
 		return encoded;
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void sourceIsMandatory() throws IOException {
+	@Test
+	public void sourceIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerSource());
+	}
+
+	private void innerSource() throws IOException {
 		try (OutputStream output = anOutput(); InputStream key = anInput()) {
 			decodeNull(null, output, key, new DigestExpectation.None());
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void targetIsMandatory() throws IOException {
+	@Test
+	public void targetIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerTarget());
+	}
+
+	private void innerTarget() throws IOException {
 		try (InputStream input = anInput(); InputStream key = anInput()) {
 			decodeNull(input, null, key, new DigestExpectation.None());
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void keyIsMandatory() throws IOException {
+	@Test
+	public void keyIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerKey());
+	}
+
+	private void innerKey() throws IOException {
 		try (InputStream input = anInput(); OutputStream output = anOutput()) {
 			decodeNull(input, output, null, new DigestExpectation.None());
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void digestIsMandatory() throws IOException {
+		assertThrows(NullPointerException.class, () -> innerDigest());
+	}
+
+	private void innerDigest() throws IOException {
 		try (InputStream input = anInput(); OutputStream output = anOutput(); InputStream key = anInput()) {
 			decodeNull(input, output, key, null);
 		}

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamEncodingTest.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/StreamEncodingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.bc.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -32,7 +33,7 @@ import org.eclipse.passage.lic.api.io.StreamCodec;
 import org.eclipse.passage.lic.base.io.FileContent;
 import org.eclipse.passage.lic.base.io.PassageFileExtension;
 import org.eclipse.passage.lic.bc.BcStreamCodec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public final class StreamEncodingTest extends BcStreamCodecTest {
@@ -80,41 +81,61 @@ public final class StreamEncodingTest extends BcStreamCodecTest {
 			assertTrue(e.getMessage().contains("key")); //$NON-NLS-1$
 			return;
 		} catch (Exception e) {
-			return; // can also legitimately fail due BC intolerance for incorrect input 
+			return; // can also legitimately fail due BC intolerance for incorrect input
 		}
 		fail("Enconding is not supposed to encrypt anything with a random sequence of chars as a key"); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void sourceIsMandatory() throws IOException {
+	@Test
+	public void sourceIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerSource());
+	}
+
+	private void innerSource() throws IOException {
 		try (OutputStream destination = anOutput(); InputStream key = anInput()) {
 			encodeNull(null, destination, key);
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void destinationIsMandatory() throws IOException {
+	@Test
+	public void destinationIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerDestination());
+	}
+
+	private void innerDestination() throws IOException {
 		try (InputStream input = anInput(); InputStream key = anInput()) {
 			encodeNull(input, null, key);
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void keyIsMandatory() throws IOException {
+	@Test
+	public void keyIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerKey());
+	}
+
+	private void innerKey() throws IOException {
 		try (InputStream input = anInput(); OutputStream destination = anOutput()) {
 			encodeNull(input, destination, null);
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void ownerIsMandatory() throws IOException {
+	@Test
+	public void ownerIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerOwner());
+	}
+
+	private void innerOwner() throws IOException {
 		try (InputStream input = anInput(); OutputStream destination = anOutput(); InputStream key = anInput()) {
 			encodeNull(input, destination, key, null, "pass"); //$NON-NLS-1$
 		}
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void passwordIsMandatory() throws IOException {
+	@Test
+	public void passwordIsMandatory() {
+		assertThrows(NullPointerException.class, () -> innerPassword());
+	}
+
+	private void innerPassword() throws IOException {
 		try (InputStream input = anInput(); OutputStream destination = anOutput(); InputStream key = anInput()) {
 			encodeNull(input, destination, key, "owner", null); //$NON-NLS-1$
 		}

--- a/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/TmpFile.java
+++ b/tests/org.eclipse.passage.lic.bc.tests/src/org/eclipse/passage/lic/internal/bc/tests/TmpFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,22 +9,24 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.bc.tests;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.IntStream;
 
 import org.eclipse.passage.lic.base.io.PassageFileExtension;
-import org.junit.rules.TemporaryFolder;
 
 final class TmpFile {
 
-	private final TemporaryFolder folder;
+	private final File folder;
 
-	TmpFile(TemporaryFolder folder) {
+	TmpFile(File folder) {
 		this.folder = folder;
 	}
 
@@ -39,14 +41,14 @@ final class TmpFile {
 	 * Physically creates an empty file with an arbitrary extension
 	 */
 	Path file(String extension) throws IOException {
-		return folder.newFile(Long.toHexString(System.nanoTime()) + extension).toPath();
+		return Files.createFile(new File(folder, Long.toHexString(System.nanoTime()) + extension).toPath());
 	}
 
 	/**
 	 * Creates a reference for not yet existing file
 	 */
 	Path keyPath(PassageFileExtension extension) throws IOException {
-		return folder.getRoot().toPath().resolve(Long.toHexString(System.nanoTime()) + extension.get());
+		return folder.toPath().resolve(Long.toHexString(System.nanoTime()) + extension.get());
 	}
 
 	Path fileWithContent() throws IOException {

--- a/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.emf.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,6 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Fragment-Host: org.eclipse.passage.lic.emf
-Import-Package: org.junit
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)",
+ org.junit.jupiter.api.function;version="[6.1.0,7.0.0)"
 Export-Package: org.eclipse.passage.lic.emf.meta;x-internal:=true

--- a/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/SimpleQualifiedNamesTest.java
+++ b/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/SimpleQualifiedNamesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,16 +9,17 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.emf;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class SimpleQualifiedNamesTest {
 

--- a/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/meta/ComposedClassMetadataTest.java
+++ b/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/meta/ComposedClassMetadataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,18 +9,20 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.emf.meta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcoreFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ComposedClassMetadataTest {
 
@@ -30,14 +32,14 @@ public final class ComposedClassMetadataTest {
 	private final EntityMetadata metadata = new PlainEntityMetadata(type, id, name);
 	private final ClassMetadata searcher = c -> Optional.of(metadata);
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullConsider() {
-		new ComposedClassMetadata().consider(null);
+		assertThrows(NullPointerException.class, () -> new ComposedClassMetadata().consider(null));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullForget() {
-		new ComposedClassMetadata().forget(null);
+		assertThrows(NullPointerException.class, () -> new ComposedClassMetadata().forget(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/meta/PlainEntityMetadataTest.java
+++ b/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/meta/PlainEntityMetadataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,15 +9,17 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.emf.meta;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcoreFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class PlainEntityMetadataTest {
 
@@ -25,19 +27,19 @@ public final class PlainEntityMetadataTest {
 	private final EStructuralFeature id = EcoreFactory.eINSTANCE.createEAttribute();
 	private final EStructuralFeature name = EcoreFactory.eINSTANCE.createEReference();
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullType() {
-		new PlainEntityMetadata(null, id, name);
+		assertThrows(NullPointerException.class, () -> new PlainEntityMetadata(null, id, name));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullId() {
-		new PlainEntityMetadata(type, null, name);
+		assertThrows(NullPointerException.class, () -> new PlainEntityMetadata(type, null, name));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullName() {
-		new PlainEntityMetadata(type, id, null);
+		assertThrows(NullPointerException.class, () -> new PlainEntityMetadata(type, id, null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/resource/ExtractEObjectTest.java
+++ b/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/resource/ExtractEObjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,17 +9,18 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.emf.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ExtractEObjectTest {
 

--- a/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/resource/ExtractResourceTest.java
+++ b/tests/org.eclipse.passage.lic.emf.tests/src/org/eclipse/passage/lic/emf/resource/ExtractResourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 ArSysOp
+ * Copyright (c) 2021, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,17 +9,18 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.emf.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ExtractResourceTest {
 

--- a/tests/org.eclipse.passage.lic.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.jface.tests/META-INF/MANIFEST.MF
@@ -9,4 +9,4 @@ Bundle-Copyright: %Bundle-Copyright
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.equinox.preferences;bundle-version="0.0.0"
 Fragment-Host: org.eclipse.passage.lic.jface
-Import-Package: org.junit
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)"

--- a/tests/org.eclipse.passage.lic.jface.tests/src/org/eclipse/passage/lic/jface/tests/LicensingColorTest.java
+++ b/tests/org.eclipse.passage.lic.jface.tests/src/org/eclipse/passage/lic/jface/tests/LicensingColorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 ArSysOp
+ * Copyright (c) 2019, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.jface.tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.passage.lic.jface.resource.LicensingColors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LicensingColorTest {
 

--- a/tests/org.eclipse.passage.lic.jface.tests/src/org/eclipse/passage/lic/jface/tests/ProductContactsTest.java
+++ b/tests/org.eclipse.passage.lic.jface.tests/src/org/eclipse/passage/lic/jface/tests/ProductContactsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,14 +9,15 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.jface.tests;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.passage.lic.internal.jface.dialogs.licensing.ProductContacts;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductContactsTest {
 


### PR DESCRIPTION
* migrate `org.eclipse.passage.lic.api.tests`