### PR TITLE
[#1650] Migrate test to JUnit6

### DIFF
--- a/tests/org.eclipse.passage.lic.equinox.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.equinox.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
 Fragment-Host: org.eclipse.passage.lic.equinox
-Import-Package: org.junit
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)",
+ org.junit.jupiter.api.function;version="[6.1.0,7.0.0)"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.passage.lic.base;bundle-version="0.0.0",
  org.eclipse.passage.lic.equinox.tests.data.requirements;bundle-version="0.0.0",

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleManifestTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,22 +9,24 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.passage.lic.api.LicensingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 public final class BundleManifestTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceIsMandatory() {
-		new BundleManifest(null);
+		assertThrows(NullPointerException.class, () -> new BundleManifest(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleNameTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleNameTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class BundleNameTest {
 
@@ -25,9 +27,9 @@ public final class BundleNameTest {
 				new BundleName(new DataBundle().bundle()).get());
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void prohibitNull() {
-		new BundleName(null);
+		assertThrows(NullPointerException.class, () -> new BundleName(null));
 	}
 
 }

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleVendorTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/BundleVendorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class BundleVendorTest {
 
@@ -25,9 +27,9 @@ public final class BundleVendorTest {
 				new BundleVendor(new DataBundle().bundle()).get());
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void prohibitNull() {
-		new BundleVendor(null);
+		assertThrows(NullPointerException.class, () -> new BundleVendor(null));
 	}
 
 }

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/CapabilityLicFeatureInfoTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/CapabilityLicFeatureInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.passage.lic.base.BaseNamedData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.wiring.BundleCapability;
 
 abstract class CapabilityLicFeatureInfoTest<T> {
@@ -43,9 +44,9 @@ abstract class CapabilityLicFeatureInfoTest<T> {
 		);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullInputMap() {
-		infoSupplier(null).get();
+		assertThrows(NullPointerException.class, () -> infoSupplier(null).get());
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/LicCapabilityAttributesFromDeclarationTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/LicCapabilityAttributesFromDeclarationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.passage.lic.api.LicensingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class LicCapabilityAttributesFromDeclarationTest {
 
@@ -61,9 +63,9 @@ public final class LicCapabilityAttributesFromDeclarationTest {
 		assertEquals("Honor Euler.txt::comp_lics/EULERS IDENTITY", e.get().get("agreements")); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceIsMandatory() {
-		new LicCapabilityAttributesFromDeclaration(null);
+		assertThrows(NullPointerException.class, () -> new LicCapabilityAttributesFromDeclaration(null));
 	}
 
 	private Collection<Map<String, Object>> packs(String source) {

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/LicensingFeatureCapabilitiesFromBundleTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/LicensingFeatureCapabilitiesFromBundleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,11 +9,12 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -22,7 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.wiring.BundleCapability;
 
 public final class LicensingFeatureCapabilitiesFromBundleTest {

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/ProvidedCapabilitiesFromManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/ProvidedCapabilitiesFromManifestTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,23 +9,25 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
 
 import org.eclipse.passage.lic.api.LicensingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ProvidedCapabilitiesFromManifestTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceIsMandatory() {
-		new ProvidedCapabilitiesFromManifest(null);
+		assertThrows(NullPointerException.class, () -> new ProvidedCapabilitiesFromManifest(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/RequirementsFromManifestTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/RequirementsFromManifestTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,13 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
- *     ArSysOp - further support
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,7 +27,7 @@ import org.eclipse.passage.lic.api.agreements.ResolvedAgreement;
 import org.eclipse.passage.lic.api.requirements.Requirement;
 import org.eclipse.passage.lic.base.diagnostic.NoErrors;
 import org.eclipse.passage.lic.base.diagnostic.NoSevereErrors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 
 @SuppressWarnings("restriction")
@@ -51,9 +52,9 @@ public class RequirementsFromManifestTest {
 		assertE(response.data().get());
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void sourceIsMandatory() {
-		new RequirementsFromManifest(null);
+		assertThrows(NullPointerException.class, () -> new RequirementsFromManifest(null));
 	}
 
 	private void assertE(Collection<Requirement> requirements) {

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/ResolvedRequirementsServiceTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/ResolvedRequirementsServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -26,7 +26,7 @@ import org.eclipse.passage.lic.api.ServiceInvocationResult;
 import org.eclipse.passage.lic.api.requirements.Requirement;
 import org.eclipse.passage.lic.api.tests.ResolvedRequirementsContractTest;
 import org.eclipse.passage.lic.base.requirements.RequirementsFeatureFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.InvalidSyntaxException;
 
 @SuppressWarnings("restriction")

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/WriteLicCapablitiesTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/equinox/requirements/WriteLicCapablitiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,17 +9,18 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.equinox.requirements;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.passage.lic.api.requirements.Requirement;
 import org.eclipse.passage.lic.base.NamedData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class WriteLicCapablitiesTest {
 	private final String expectation = "Provide-Capability: " //$NON-NLS-1$
@@ -36,7 +37,7 @@ public final class WriteLicCapablitiesTest {
 						data.e(), //
 						data.pi(), //
 						data.incomplete())))//
-								.write(target); //
+				.write(target); //
 		assertEquals(expectation, target.toString());
 
 	}

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/io/BundleKeyKeeperTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/io/BundleKeyKeeperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.equinox.io;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,7 +25,7 @@ import org.eclipse.passage.lic.api.LicensedProduct;
 import org.eclipse.passage.lic.api.LicensingException;
 import org.eclipse.passage.lic.base.BaseLicensedProduct;
 import org.eclipse.passage.lic.equinox.io.BundleKeyKeeper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -56,14 +58,14 @@ public final class BundleKeyKeeperTest {
 		fail("Public key for the foreign product is not supposed to fit"); //$NON-NLS-1$
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void productIsMandatory() {
-		new BundleKeyKeeper(null, bundle());
+		assertThrows(NullPointerException.class, () -> new BundleKeyKeeper(null, bundle()));
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void bundleIsMandatory() {
-		new BundleKeyKeeper(this::productWithKey, (Bundle) null);
+		assertThrows(NullPointerException.class, () -> new BundleKeyKeeper(this::productWithKey, (Bundle) null));
 	}
 
 	private Bundle bundle() {

--- a/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/tests/LicensedProductFromContextTest.java
+++ b/tests/org.eclipse.passage.lic.equinox.tests/src/org/eclipse/passage/lic/internal/equinox/tests/LicensedProductFromContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 ArSysOp
+ * Copyright (c) 2020, 2026 ArSysOp
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,11 +9,13 @@
  *
  * Contributors:
  *     ArSysOp - initial API and implementation
+ *     ArSysOp - further support and improvements
  *******************************************************************************/
 package org.eclipse.passage.lic.internal.equinox.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,14 +27,14 @@ import org.eclipse.passage.lic.base.ProductIdentifier;
 import org.eclipse.passage.lic.base.ProductVersion;
 import org.eclipse.passage.lic.base.version.DefaultVersion;
 import org.eclipse.passage.lic.equinox.LicensedProductFromContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 
 public final class LicensedProductFromContextTest {
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void nullCOntextIsProhibited() {
-		new LicensedProductFromContext(null);
+		assertThrows(NullPointerException.class, () -> new LicensedProductFromContext(null));
 	}
 
 	@Test


### PR DESCRIPTION
* migrate `org.eclipse.passage.lic.equinox.tests`