### PR TITLE
[#1650] Migrate test to JUnit6

### DIFF
--- a/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.passage.lic.oshi.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.passage.lic.oshi.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.passage.lic.oshi.tests
 Bundle-Version: 4.7.0.qualifier
-Import-Package: org.junit
+Import-Package: org.junit.jupiter.api;version="[6.1.0,7.0.0)"
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright


### PR DESCRIPTION
* migrate `org.eclipse.passage.lic.oshi.tests`